### PR TITLE
Add a postprocessor to concatenate files in a playlist

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -128,6 +128,7 @@ class YoutubeDL(object):
     listsubtitles:     Lists all available subtitles for the video
     subtitlesformat:   Subtitle format [srt/sbv/vtt] (default=srt)
     subtitleslangs:    List of languages of the subtitles to download
+    concat:            Join videos in a playlist end-to-end
     keepvideo:         Keep the video file after post-processing
     daterange:         A DateRange object, download only if the upload_date is in the range.
     skip_download:     Skip the actual download of the video file

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -97,6 +97,7 @@ from .postprocessor import (
     FFmpegExtractAudioPP,
     FFmpegEmbedSubtitlePP,
     XAttrMetadataPP,
+    FFmpegConcatPP,
 )
 
 
@@ -495,6 +496,8 @@ def parseOpts(overrideArguments=None):
             help='"best", "aac", "vorbis", "mp3", "m4a", "opus", or "wav"; best by default')
     postproc.add_option('--audio-quality', metavar='QUALITY', dest='audioquality', default='5',
             help='ffmpeg/avconv audio quality specification, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default 5)')
+    postproc.add_option('--join', action='store_true', dest='concat', default=False,
+            help='when downloading a playlist of multiple videos, try to join them together end-to-end (EXPERIMENTAL)')
     postproc.add_option('--recode-video', metavar='FORMAT', dest='recodevideo', default=None,
             help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm)')
     postproc.add_option('-k', '--keep-video', action='store_true', dest='keepvideo', default=False,
@@ -790,6 +793,7 @@ def _real_main(argv=None):
         'default_search': opts.default_search,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,
         'encoding': opts.encoding,
+        'concat': opts.concat,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -1,6 +1,7 @@
 
 from .ffmpeg import (
     FFmpegMergerPP,
+    FFmpegConcatPP,
     FFmpegMetadataPP,
     FFmpegVideoConvertor,
     FFmpegExtractAudioPP,
@@ -10,6 +11,7 @@ from .xattrpp import XAttrMetadataPP
 
 __all__ = [
     'FFmpegMergerPP',
+    'FFmpegConcatPP',
     'FFmpegMetadataPP',
     'FFmpegVideoConvertor',
     'FFmpegExtractAudioPP',

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -506,6 +506,7 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         #No method using solely the command line is listed. And I'm like "really?".
         with open(filename + '.list.txt', 'wb') as f:
             for file in info['__files_to_append']:
+                file = file.replace("'", "\\'")
                 f.write("file '" + file + "'\n")
         self.run_ffmpeg_multiple_files([filename + '.list.txt'], filename, args, preopts=concatargs)
         os.unlink(filename + '.list.txt')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -497,9 +497,9 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         self._downloader.to_screen(u'[ffmpeg] Appending files into "%s"' % filename)
         #According to the ffmpeg docs this is literally how you're supposed to concat files.
         #No method using solely the command line is listed. And I'm like "really?".
-        with open(u'youtube-dl_ffmpeg_append_list.txt', 'wb') as f:
+        with open(filename + '.list.txt', 'wb') as f:
             for file in info['__files_to_append']:
                 f.write("file '" + file + "'\n")
-        self.run_ffmpeg_multiple_files([u'youtube-dl_ffmpeg_append_list.txt'], filename, args, preopts=concatargs)
-        os.unlink('youtube-dl_ffmpeg_append_list.txt')
+        self.run_ffmpeg_multiple_files([filename + '.list.txt'], filename, args, preopts=concatargs)
+        os.unlink(filename + '.list.txt')
         return True, info

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -488,13 +488,17 @@ class FFmpegMergerPP(FFmpegPostProcessor):
         return True, info
 
 class FFmpegConcatPP(FFmpegPostProcessor):
+    #Concat support requires that the IE return '_type' = 'playlist'
+    #Otherwise it silently fail
     def run(self, info):
-        filename = info['filepath']
+        filename = info['title'] + u'.mp4' #What could possibly go wrong?
         concatargs = ['-f', 'concat']
         args = ['-c', 'copy']
         self._downloader.to_screen(u'[ffmpeg] Appending files into "%s"' % filename)
+        #According to the ffmpeg docs this is literally how you're supposed to concat files.
+        #No method using solely the command line is listed. And I'm like "really?".
         with open(u'youtube-dl_ffmpeg_append_list.txt', 'wb') as f:
-            for file in info['__files_to_merge']:
+            for file in info['__files_to_append']:
                 f.write("file '" + file + "'\n")
         self.run_ffmpeg_multiple_files([u'youtube-dl_ffmpeg_append_list.txt'], filename, args, preopts=concatargs)
         os.unlink('youtube-dl_ffmpeg_append_list.txt')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -491,7 +491,14 @@ class FFmpegConcatPP(FFmpegPostProcessor):
     #Concat support requires that the IE return '_type' = 'playlist'
     #Otherwise it silently fail
     def run(self, info):
-        filename = info['title'] + u'.mp4' #What could possibly go wrong?
+        #Determine appropriate output extension
+        extlist = []
+        for input_filename in info['__files_to_append']:
+            extlist.append(os.path.splitext(input_filename)[-1])
+        if len(set(extlist)) != 1:
+            self._downloader.report_warning('Not all files are in the same format! Joining the files may fail.')
+        
+        filename = info['title'] + extlist[0]
         concatargs = ['-f', 'concat']
         args = ['-c', 'copy']
         self._downloader.to_screen(u'[ffmpeg] Appending files into "%s"' % filename)


### PR DESCRIPTION
It may not be pretty, but it friggin' works. I did some initial testing with The Daily Show, but I have no idea how it handles other sites. Of particular concern is non-MP4 formats. Currently, the output file is always an MP4 container (this should be fixed), since I have concerns about it breaking with obscure containers. I've tested AVI, FLV, MP4, and MKV (they work), but there are dozens of others I haven't tested. For the time being, MP4 seems a reasonable default, since just about everything can play it.

This patch changes a few interfaces, most notably adding a return value to the process_info() function in YoutubeDL.py. Also, a 'saved-filename' key is added to the dictionary returned by process_video_result(). Also, run_ffmpeg_multiple_files() now accepts an optional list argument called preopts, for arguments that need to go before the input files. (Oh, ffmpeg. You so silly.)

The command line option is `--join`. Also, joining silently fails if the IE doesn't return "playlist" as the `_type`. Also, I have no idea what happens if you specify multiple URLs that are each a playlist. Or if you specify some that are and some that aren't. Or if the items in the playlist have different formats. Or something else I forgot in the time it took me to write out those other three.

I can't think of anything else to add to this wall of text, and getting acquainted with the youtube-dl internals has left my brain a pile of mush, so beware of mistakes both large and small. Now if you'll excuse me, I've got about a month's worth of Daily Show to catch up on.
