### PR TITLE
Added flag to merge videos from a playlist into one continuous file

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -646,7 +646,7 @@ class YoutubeDL(object):
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
 
-            if self.params['concat']:
+            if self.params.get('concat', False):
                 concat = FFmpegConcatPP(self)
                 if concat._get_executable():
                     postprocessors = [concat]

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -646,29 +646,27 @@ class YoutubeDL(object):
                 playlist_results.append(entry_result)
             ie_result['entries'] = playlist_results
 
-            if download and not(self.params.get('simulate', False)) and \
-                    self.params.get('concat', False):
-                downloaded = []
+            if self.params['concat']:
                 concat = FFmpegConcatPP(self)
-                if not concat._get_executable():
+                if concat._get_executable():
+                    postprocessors = [concat]
+                else:
                     postprocessors = []
                     self.report_warning('You have requested multiple '
                         'formats but ffmpeg or avconv are not installed.'
                         ' The formats won\'t be merged')
-                else:
-                    postprocessors = [concat]
-                for f in ie_result['entries']:
+
+                downloaded = []
+                for video in playlist_results:
                     new_info = dict(ie_result)
-                    new_info.update(f)
-                    if 'ext' in new_info: ie_result['ext'] = new_info['ext']
-                    if 'id' in new_info: ie_result['id'] = new_info['id']
+                    new_info.update(video)
+                    ie_result['ext'] = video['ext']
                     fname = self.prepare_filename(new_info)
                     downloaded.append(fname)
-                
                 filename = self.prepare_filename(ie_result)
-
                 ie_result['__postprocessors'] = postprocessors
                 ie_result['__files_to_merge'] = downloaded
+
                 self.post_process(filename, ie_result)
 
             return ie_result

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -520,7 +520,6 @@ def parseOpts(overrideArguments=None):
         help='Prefer ffmpeg over avconv for running the postprocessors')
 
 
-
     parser.add_option_group(general)
     parser.add_option_group(selection)
     parser.add_option_group(downloader)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -500,6 +500,8 @@ def parseOpts(overrideArguments=None):
             help='ffmpeg/avconv audio quality specification, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default 5)')
     postproc.add_option('--recode-video', metavar='FORMAT', dest='recodevideo', default=None,
             help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm)')
+    postproc.add_option('--concat', action='store_true', dest='concat',
+            help='Attempt to concatenate multiple videos into one file')
     postproc.add_option('-k', '--keep-video', action='store_true', dest='keepvideo', default=False,
             help='keeps the video file on disk after the post-processing; the video is erased by default')
     postproc.add_option('--no-post-overwrites', action='store_true', dest='nopostoverwrites', default=False,
@@ -516,6 +518,7 @@ def parseOpts(overrideArguments=None):
         help='Prefer avconv over ffmpeg for running the postprocessors (default)')
     postproc.add_option('--prefer-ffmpeg', action='store_true', dest='prefer_ffmpeg',
         help='Prefer ffmpeg over avconv for running the postprocessors')
+
 
 
     parser.add_option_group(general)
@@ -791,6 +794,7 @@ def _real_main(argv=None):
         'bidi_workaround': opts.bidi_workaround,
         'debug_printtraffic': opts.debug_printtraffic,
         'prefer_ffmpeg': opts.prefer_ffmpeg,
+        'concat': opts.concat,
         'include_ads': opts.include_ads,
         'default_search': opts.default_search,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -1,6 +1,7 @@
 
 from .atomicparsley import AtomicParsleyPP
 from .ffmpeg import (
+    FFmpegConcatPP,
     FFmpegAudioFixPP,
     FFmpegMergerPP,
     FFmpegMetadataPP,
@@ -12,6 +13,7 @@ from .xattrpp import XAttrMetadataPP
 
 __all__ = [
     'AtomicParsleyPP',
+    'FFmpegConcatPP',
     'FFmpegAudioFixPP',
     'FFmpegMergerPP',
     'FFmpegMetadataPP',

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -60,7 +60,7 @@ class FFmpegPostProcessor(PostProcessor):
             self._downloader.to_screen(u'[debug] ffmpeg command line: %s' % shell_quote(cmd))
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         if via_stdin:
-            stdout, stderr = p.communicate(input=bytes(stdin_cmd, 'utf-8'))
+            stdout, stderr = p.communicate(input=stdin_cmd.encode('utf-8'))
         else:
             stdout, stderr = p.communicate()
         if p.returncode != 0:

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -507,7 +507,7 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         files_cmd = u''
         for path in files:
             encoded_path = encodeFilename(path, True)
-            files_cmd += u'file \'%s\'\n' % path
+            files_cmd += u'file \'%s\'\n' % encoded_path
         stdout, stderr = p.communicate(input=bytes(files_cmd, 'utf-8'))
         if p.returncode != 0:
             stderr = stderr.decode('utf-8', 'replace')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -508,7 +508,7 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         for path in files:
             encoded_path = encodeFilename(path, True)
             files_cmd += u'file \'%s\'\n' % path
-        stdout, stderr = p.communicate(input=files_cmd)
+        stdout, stderr = p.communicate(input=bytes(files_cmd, 'utf-8'))
         if p.returncode != 0:
             stderr = stderr.decode('utf-8', 'replace')
             msg = stderr.strip().split('\n')[-1]

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -517,6 +517,8 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         for path in files:
             os.remove(encodeFilename(path))
 
+        return True, info
+
 class FFmpegAudioFixPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -501,8 +501,10 @@ class FFmpegConcatPP(FFmpegPostProcessor):
         args = ['-f', 'concat', '-i', '-', '-c', 'copy']
         self._downloader.to_screen(u'[ffmpeg] Concatenating files into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], filename, args, via_stdin=True)
-        for path in info['__files_to_merge']:
-            os.remove(encodeFilename(path))
+        if self._downloader.params.get('keepvideo', False) is False:
+            for path in info['__files_to_merge']:
+                self._downloader.to_screen('Deleting original file %s (pass -k to keep)' % filename)
+                os.remove(encodeFilename(path))
         return True, info
 
 class FFmpegAudioFixPP(FFmpegPostProcessor):


### PR DESCRIPTION
#### Example Use-Case

```
youtube-dl http://thecolbertreport.cc.com/full-episodes/wllm5p/april-30--2014---audra-mcdonald
```

Usually, this produces four videos, one for each segment of the show. However...

```
youtube-dl --concat http://thecolbertreport.cc.com/full-episodes/wllm5p/april-30--2014---audra-mcdonald
```

Will produce one continuous video for the show.
