### PR TITLE
[youtube_dl] Added cancelable metadata / playlist downlod progress hook

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -640,9 +640,10 @@ class YoutubeDL(object):
                     'extractor_key': ie_result['extractor_key'],
                 }
                 playlistProgress = {
-                    'current': i,
+                    'current': i-1,
                     'total':   n_entries,
                     'playlist': ie_result['webpage_url'],
+                    'currentData': playlist_results[-1] if len(playlist_results) > 0 else None,
                     'next': entry
                 }
                 skipNext = False
@@ -664,6 +665,21 @@ class YoutubeDL(object):
                                                       download=download,
                                                       extra_info=extra)
                 playlist_results.append(entry_result)
+
+
+            playlistProgress = {
+                'current': n_entries,
+                'total':   n_entries,
+                'playlist': ie_result['webpage_url'],
+                'currentData': playlist_results[-1] if len(playlist_results) > 0 else None,
+                'next': None
+            }
+
+            for ph in self._metadata_hooks:
+                ph(playlistProgress)
+
+
+
             ie_result['entries'] = playlist_results
             return ie_result
         elif result_type == 'compat_list':

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -114,6 +114,7 @@ class YoutubeDL(object):
     nooverwrites:      Prevent overwriting files.
     playliststart:     Playlist item to start at.
     playlistend:       Playlist item to end at.
+    playlistonly:      Stops after getting the playlist entries
     matchtitle:        Download only matching titles.
     rejecttitle:       Reject downloads for matching titles.
     logger:            Log messages to a logging.Logger instance.
@@ -661,11 +662,13 @@ class YoutubeDL(object):
                     self.to_screen('[download] ' + reason)
                     continue
 
-                entry_result = self.process_ie_result(entry,
+                if not self.params.get('playlistonly', False):
+                    entry_result = self.process_ie_result(entry,
                                                       download=download,
                                                       extra_info=extra)
-                playlist_results.append(entry_result)
-
+                    playlist_results.append(entry_result)
+                else:
+                    playlist_results.append(entry)
 
             playlistProgress = {
                 'current': n_entries,
@@ -678,10 +681,9 @@ class YoutubeDL(object):
             for ph in self._metadata_hooks:
                 ph(playlistProgress)
 
-
-
             ie_result['entries'] = playlist_results
             return ie_result
+
         elif result_type == 'compat_list':
             def _fixup(r):
                 self.add_extra_info(r,


### PR DESCRIPTION
I added cancelable hooks to playlist metadata downloads.

Here an example showing how to skip downloads after the 3rd entry of a playlist:

``` python
import youtube_dl

url = 'http://www.youtube.com/watch?v=QonQ_8qnAbY&list=PLC3CC1956BA739976&index=8'

ydl = youtube_dl.YoutubeDL({
    'ignoreerrors': True,
    'quiet': True,
    'socket_timeout': 10
})

ydl.add_default_info_extractors()

# dummy hook
def hook(status):
    if status['current'] > 3:
        print "Skipping..."
        return False # returning False from any of the added hooks makes the next request skipped
    else:
        print(status)

# Adding the hook
ydl.add_metadata_hook(hook)

result = ydl.extract_info(url, download = False)
```
