### PR TITLE
Add support for merged videos to formats

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1052,6 +1052,13 @@ class YoutubeDL(object):
                 os.remove(encodeFilename(filename))
             except (IOError, OSError):
                 self.report_warning('Unable to remove downloaded video file')
+        if '__files_to_merge' in ie_info and not self.params.get('keepvideo', False):
+            for fname in ie_info['__files_to_merge']:
+                try:
+                    self.to_screen('Deleting original file %s (pass -k to keep)' % fname)
+                    os.remove(encodeFilename(fname))
+                except (IOError, OSError):
+                    self.report_warning('Unable to remove downloaded video file')
 
     def _make_archive_id(self, info_dict):
         # Future-proof against any change in case

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -231,6 +231,8 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
         # RTMP (unnamed)
         '_rtmp': {'protocol': 'rtmp'},
     }
+    _merged_formats = [x+'+'+y for x in ['133','134','135','136','137','138','160','264'] for y in ['139','140','141']] + \
+                      [x+'+'+y for x in ['167','168','169','170','218','219','242','243','244','245','246','247','248'] for y in ['171','172']]
 
     IE_NAME = u'youtube'
     _TESTS = [
@@ -1351,6 +1353,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor, SubtitlesInfoExtractor):
             except (ExtractorError, KeyError) as e:
                 self.report_warning(u'Skipping DASH manifest: %s' % e, video_id)
 
+        self._add_merged_formats(formats,self._merged_formats)
         self._sort_formats(formats)
 
         return {

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1451,3 +1451,43 @@ except AttributeError:
         if ret:
             raise subprocess.CalledProcessError(ret, p.args, output=output)
         return output
+
+def select_format(format_spec, available_formats):
+    if format_spec == 'best' or format_spec is None:
+        return available_formats[-1]
+    elif format_spec == 'worst':
+        return available_formats[0]
+    elif format_spec == 'bestaudio':
+        audio_formats = [
+            f for f in available_formats
+            if f.get('vcodec') == 'none']
+        if audio_formats:
+            return audio_formats[-1]
+    elif format_spec == 'worstaudio':
+        audio_formats = [
+            f for f in available_formats
+            if f.get('vcodec') == 'none']
+        if audio_formats:
+            return audio_formats[0]
+    elif format_spec == 'bestvideo':
+        video_formats = [
+            f for f in available_formats
+            if f.get('acodec') == 'none']
+        if video_formats:
+            return video_formats[-1]
+    elif format_spec == 'worstvideo':
+        video_formats = [
+            f for f in available_formats
+            if f.get('acodec') == 'none']
+        if video_formats:
+            return video_formats[0]
+    else:
+        extensions = ['mp4', 'flv', 'webm', '3gp']
+        if format_spec in extensions:
+            filter_f = lambda f: f['ext'] == format_spec
+        else:
+            filter_f = lambda f: f['format_id'] == format_spec
+        matches = list(filter(filter_f, available_formats))
+        if matches:
+            return matches[-1]
+    return None


### PR DESCRIPTION
I've added the new optional key "sub_formats" to formats. It's an array which contains the format used for video and the format used for audio.
The method `_sort_formats` in `extractor/common.py` assigns merged formats a preference of -1000 if ffmpeg/avconv is not available.
I've also added the method `_add_merged_formats` to `extractor/common.py` which automatically generates merged formats and makes it very easy for IEs to support merged formats. (E.g. in YoutubeIE: 68c925b)
The source files of merged videos get deleted after merging. (3ab9e41)
I've moved the method `select_format` from `YoutubeDL.py` to `utils.py` that's the biggest change in terms of lines (+40-40).

```
$ youtube-dl-git -F "http://www.youtube.com/watch?v=QAUzWtLMnU0"
...
[info] Available formats for QAUzWtLMnU0:
format code extension resolution  note 
171         webm      audio only  DASH audio , audio@ 48k (worst)
140         m4a       audio only  DASH audio , audio@128k
160         mp4       144p        DASH video , video only
242         webm      240p        DASH video , video only
133         mp4       240p        DASH video , video only
243         webm      360p        DASH video , video only
134         mp4       360p        DASH video , video only
244         webm      480p        DASH video , video only
135         mp4       480p        DASH video , video only
247         webm      720p        DASH video , video only
136         mp4       720p        DASH video , video only
248         webm      1080p       DASH video , video only
137         mp4       1080p       DASH video , video only
160+140     mp4       144p        audio@128k
17          3gp       176x144     
242+171     webm      240p        audio@ 48k
133+140     mp4       240p        audio@128k
36          3gp       320x240     
5           flv       400x240     
243+171     webm      360p        audio@ 48k
134+140     mp4       360p        audio@128k
43          webm      640x360     
18          mp4       640x360     
244+171     webm      480p        audio@ 48k
135+140     mp4       480p        audio@128k
247+171     webm      720p        audio@ 48k
136+140     mp4       720p        audio@128k
22          mp4       1280x720    
248+171     webm      1080p       audio@ 48k
137+140     mp4       1080p       audio@128k (best)
```
