### PR TITLE
libfdkaac transcode support

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -162,7 +162,7 @@ def _real_main(argv=None):
     if opts.playlistend not in (-1, None) and opts.playlistend < opts.playliststart:
         raise ValueError('Playlist end must be greater than playlist start')
     if opts.extractaudio:
-        if opts.audioformat not in ['best', 'aac', 'mp3', 'm4a', 'opus', 'vorbis', 'wav']:
+        if opts.audioformat not in ['best', 'aac', 'libfdkaac', 'libfdkaac-he', 'libfdkaac-hev2', 'mp3', 'm4a', 'opus', 'vorbis', 'wav']:
             parser.error('invalid audio format specified')
     if opts.audioquality:
         opts.audioquality = opts.audioquality.strip('k').strip('K')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -23,7 +23,7 @@ from ..utils import (
     subtitles_filename,
 )
 
-FFMPEG_CBR_SAMPLERATE_TABLE = {
+LIBFDKAAC_CBR_SAMPLERATE_TABLE = {
     "libfdkaac": [
         [16, 23, 11025],
         [24, 31, 16000],
@@ -45,7 +45,7 @@ FFMPEG_CBR_SAMPLERATE_TABLE = {
     ]
 }
 
-FFMPEG_VBR_SAMPLERATE_TABLE = {
+LIBFDKAAC_VBR_SAMPLERATE_TABLE = {
     "libfdkaac": [
         [1, 32000], #40kbps
         [2, 32000], #64kbps
@@ -248,7 +248,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             raise AudioConversionError(err.msg)
 
     def get_fdkaac_cbr_samplerate(self, codec, bitrate):
-        table = FFMPEG_CBR_SAMPLERATE_TABLE[codec];
+        table = LIBFDKAAC_CBR_SAMPLERATE_TABLE[codec];
         int_bitrate = int(bitrate)
         for configuration in table:
             min_rate, max_rate, sample_rate = configuration[0], configuration[1], configuration[2]
@@ -257,7 +257,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
         raise PostProcessingError('WARNING: Can''t find fdkaac samplerate configuration for bitrate.')
 
     def get_fdkaac_vbr_samplerate(self, codec, vbr_value):
-        table = FFMPEG_VBR_SAMPLERATE_TABLE[codec];
+        table = LIBFDKAAC_VBR_SAMPLERATE_TABLE[codec];
         int_vbr_level = int(vbr_value)
         for configuration in table:
             vbr_level, sample_rate = configuration[0], configuration[1]

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -237,7 +237,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                         more_opts += ['-b:a', self._preferredquality + 'k']
         else:
             # We convert the audio (lossy)
-            acodec = {'mp3': 'libmp3lame', 'aac': 'aac', 'm4a': 'aac', 'opus': 'opus', 'vorbis': 'libvorbis', 'wav': None}[self._preferredcodec]
+            acodec = {'mp3': 'libmp3lame', 'aac': 'aac', 'm4a': 'aac', 'opus': 'opus', 'vorbis': 'libvorbis', 'wav': None, 'libfdkaac': None, 'libfdkaac-he': None, 'libfdkaac-hev2': None}[self._preferredcodec]
             extension = self._preferredcodec
             more_opts = []
             if self._preferredquality is not None:
@@ -255,6 +255,21 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             if self._preferredcodec == 'wav':
                 extension = 'wav'
                 more_opts += ['-f', 'wav']
+            if self._preferredcodec == 'libfdkaac' or self._preferredcodec == 'libfdkaac-he' or self._preferredcodec == 'libfdkaac-hev2':
+                more_opts = []
+                acodec = 'libfdk_aac'
+                prefix, sep, ext = path.rpartition('.')
+                if (ext == 'm4a'):
+                    extension = 'libfdkaac.m4a'
+                if self._preferredquality is not None:
+                    if int(self._preferredquality) < 6:
+                        more_opts += ['-vbr', self._preferredquality]
+                    else:
+                        more_opts += ['-b:a', self._preferredquality + 'k']
+                if self._preferredcodec == 'libfdkaac-he':
+                    more_opts += ['-profile:a', 'aac_he']
+                elif self._preferredcodec == 'libfdkaac-hev2':
+                    more_opts += ['-profile:a', 'aac_he_v2']
 
         prefix, sep, ext = path.rpartition('.')  # not os.path.splitext, since the latter does not work on unicode in all setups
         new_path = prefix + sep + extension


### PR DESCRIPTION
Hi,

There's a better AAC encoder available now for a while in ffmpeg, the FDKAAC encoder which is opensourced part of the Android code, and it's part of the Fraunhofer AAC encoder family. I've added all profiles (LC, HE-V1, HE-V2), also it's possible to use the VBR modes if the quality value is lower than 6. See: https://trac.ffmpeg.org/wiki/Encode/AAC#fdk_aac

I'm not fluent in Python so feel free to modify it for your needs. Since it's possible to transcode from m4a to m4a, I've added a little workaround which sets the target extension to libfdkaac.m4a if the source file was m4a so the rest of the code keep working without overwriting the original file.
