### PR TITLE
add --part-suffix option

### DIFF
--- a/test/test_filedownloader.py
+++ b/test/test_filedownloader.py
@@ -1,0 +1,59 @@
+import unittest
+
+from test.helper import FakeYDL
+
+from youtube_dl import FileDownloader
+
+
+class BaseTestFileDownloader(unittest.TestCase):
+    params = {}
+
+    def setUp(self):
+        self.downloader = FileDownloader(FakeYDL(), self.params)
+
+
+class TestPartFileDefaults(BaseTestFileDownloader):
+    params = {}
+
+    def test_temp_name_missing_file(self):
+        # file is missing: should add the default suffix
+        fn = self.downloader.temp_name('some file.ext')
+        self.assertEqual(fn, 'some file.ext.part')
+
+    def test_undo_temp_name_no_suffix(self):
+        # file doesn't end with the suffix: should be untouched
+        fn = self.downloader.undo_temp_name('some file.ext')
+        self.assertEqual(fn, 'some file.ext')
+
+    def test_undo_temp_name_with_suffix(self):
+        # file ends with the suffix: should be removed
+        fn = self.downloader.undo_temp_name('some file.ext.part')
+        self.assertEqual(fn, 'some file.ext')
+
+
+class TestPartFileCustomSuffix(BaseTestFileDownloader):
+    params = {'partsuffix': '.othersuffix'}
+
+    def test_temp_name_missing_file(self):
+        # file is missing: should add the custom suffix
+        fn = self.downloader.temp_name('some file.ext')
+        self.assertEqual(fn, 'some file.ext.othersuffix')
+
+    def test_undo_temp_name_no_suffix(self):
+        # file doesn't end with the suffix: should be untouched
+        fn = self.downloader.undo_temp_name('some file.ext')
+        self.assertEqual(fn, 'some file.ext')
+
+    def test_undo_temp_name_default_suffix(self):
+        # file ends with the default suffix: should be untouched
+        fn = self.downloader.undo_temp_name('some file.ext.part')
+        self.assertEqual(fn, 'some file.ext.part')
+
+    def test_undo_temp_name_custom_suffix(self):
+        # file ends with the custom suffix: should be removed
+        fn = self.downloader.undo_temp_name('some file.ext.othersuffix')
+        self.assertEqual(fn, 'some file.ext')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -308,6 +308,7 @@ def _real_main(argv=None):
         'logtostderr': opts.outtmpl == '-',
         'consoletitle': opts.consoletitle,
         'nopart': opts.nopart,
+        'partsuffix': opts.partsuffix,
         'updatetime': opts.updatetime,
         'writedescription': opts.writedescription,
         'writeannotations': opts.writeannotations,

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -13,6 +13,9 @@ from ..utils import (
     timeconvert,
 )
 
+# default value for 'partsuffix' option
+DEFAULT_PART_SUFFIX = '.part'
+
 
 class FileDownloader(object):
     """File Downloader class.
@@ -37,6 +40,7 @@ class FileDownloader(object):
     logtostderr:        Log messages to stderr instead of stdout.
     consoletitle:       Display progress in console window's titlebar.
     nopart:             Do not use temporary .part files.
+    partsuffix:         Suffix for .part files.
     updatetime:         Use the Last-modified header to set output file timestamps.
     test:               Download only first bytes to test the downloader.
     min_filesize:       Skip files smaller than this size
@@ -173,11 +177,12 @@ class FileDownloader(object):
         if self.params.get('nopart', False) or filename == '-' or \
                 (os.path.exists(encodeFilename(filename)) and not os.path.isfile(encodeFilename(filename))):
             return filename
-        return filename + '.part'
+        return filename + self.params.get('partsuffix', DEFAULT_PART_SUFFIX)
 
     def undo_temp_name(self, filename):
-        if filename.endswith('.part'):
-            return filename[:-len('.part')]
+        suffix = self.params.get('partsuffix', DEFAULT_PART_SUFFIX)
+        if filename.endswith(suffix):
+            return filename[:-len(suffix)]
         return filename
 
     def try_rename(self, old_filename, new_filename):

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -623,6 +623,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='nopart', default=False,
         help='Do not use .part files - write directly into output file')
     filesystem.add_option(
+        '--part-suffix',
+        action='store', dest='partsuffix', default='.part', metavar='SUFFIX',
+        help='Suffix to use for .part files (default is "%default")')
+    filesystem.add_option(
         '--no-mtime',
         action='store_false', dest='updatetime', default=True,
         help='Do not use the Last-modified header to set the file modification time')


### PR DESCRIPTION
I want to be able to change '.part' to something else in temporary files so that I can distinguish them.  My file manager uses shared-mime-info to associate MIME types with applications, and shared-mime-info mostly uses filenames.  Lots of applications create '.part' files, but youtube-dl specifically creates '.part' files which are videos, and I only want to associate those ones with my video player.

I wasn't sure if I was supposed to update README.md - I tried, but 'make README.md' seems to think it's already up-to-date.
