### PR TITLE
--custom-meta option to write specific information to tags

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -367,6 +367,7 @@ def _real_main(argv=None):
         'hls_prefer_native': opts.hls_prefer_native,
         'external_downloader_args': external_downloader_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
+        'addmetadata': opts.addmetadata,
         'custommeta': opts.custommeta,
     }
 

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -367,6 +367,7 @@ def _real_main(argv=None):
         'hls_prefer_native': opts.hls_prefer_native,
         'external_downloader_args': external_downloader_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
+        'custommeta': opts.custommeta,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -214,7 +214,7 @@ def _real_main(argv=None):
             'key': 'MetadataFromTitle',
             'titleformat': opts.metafromtitle
         })
-    if opts.addmetadata:
+    if opts.addmetadata or opts.custommeta:
         postprocessors.append({'key': 'FFmpegMetadata'})
     if opts.extractaudio:
         postprocessors.append({

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -708,6 +708,16 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
+        '--custom-meta',
+        action='append', dest='custommeta', default=[],
+        help='Write specific information to a metadata tag.'
+             'Syntax: "tagname=string to add with %(format)s" '
+             'The formatting syntax is the same as output. '
+             'Example: --custom-meta "comment=%(webpage_url)s\\n%(description)s" will '
+             'add a line with the url, then the description in the "comment" tag. '
+             'Tags are format-specific, common ones include: artist, comment, title, copyright, uploader. '
+             'This can be invoked multiple times for different tags.')
+    postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',
         help='Parse additional metadata like song title / artist from the video title. '

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -708,15 +708,16 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
-        '--custom-meta',
+        '--custom-metadata',
         action='append', dest='custommeta', default=[], metavar='TAG=FORMAT',
         help='Write specific information to a metadata tag.'
              'Syntax: "tagname=string to add with %(format)s" '
              'The formatting syntax is the same as output. '
-             'Example: --custom-meta "comment=%(webpage_url)s\\n%(description)s" will '
+             'Example: --custom-metadata "comment=%(webpage_url)s\\n%(description)s" will '
              'add a line with the url, then the description in the "comment" tag. '
              'Tags are format-specific, common ones include: artist, comment, title, copyright, uploader. '
-             'This can be invoked multiple times for different tags.')
+             'This can be invoked multiple times for different tags. '
+             '--add-metadata is activated with this option.')
     postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -709,7 +709,7 @@ def parseOpts(overrideArguments=None):
         help='Write metadata to the video file')
     postproc.add_option(
         '--custom-meta',
-        action='append', dest='custommeta', default=[],
+        action='append', dest='custommeta', default=[], metavar='TAG=FORMAT',
         help='Write specific information to a metadata tag.'
              'Syntax: "tagname=string to add with %(format)s" '
              'The formatting syntax is the same as output. '

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -4,7 +4,7 @@ import io
 import os
 import subprocess
 import time
-
+import collections
 
 from .common import AudioConversionError, PostProcessor
 
@@ -368,8 +368,8 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             metadata['album'] = info['album']
 
         for m in self._downloader.params.get('custommeta'):
-            key,val = m.split('=',1)
-            metadata[key] = val.replace('\\n', '\n') % info
+            key, val = m.split('=', 1)
+            metadata[key] = val.replace('\\n', '\n') % collections.defaultdict(lambda: 'NA', info)
 
         if not metadata:
             self._downloader.to_screen('[ffmpeg] There isn\'t any metadata to add')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -369,7 +369,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
 
         for m in self._downloader.params.get('custommeta'):
             key, val = m.split('=', 1)
-            metadata[key] = val.replace('\\n', '\n') % collections.defaultdict(lambda: 'NA', info)
+            metadata[key] = val.replace('\\n', '\n') % collections.defaultdict(lambda: '', info)
 
         if not metadata:
             self._downloader.to_screen('[ffmpeg] There isn\'t any metadata to add')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -367,6 +367,10 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         if info.get('album') is not None:
             metadata['album'] = info['album']
 
+        for m in self._downloader.params.get('custommeta'):
+            key,val = m.split('=',1)
+            metadata[key] = val.replace('\\n', '\n') % info
+
         if not metadata:
             self._downloader.to_screen('[ffmpeg] There isn\'t any metadata to add')
             return [], info

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -349,23 +349,24 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
 class FFmpegMetadataPP(FFmpegPostProcessor):
     def run(self, info):
         metadata = {}
-        if info.get('title') is not None:
-            metadata['title'] = info['title']
-        if info.get('upload_date') is not None:
-            metadata['date'] = info['upload_date']
-        if info.get('artist') is not None:
-            metadata['artist'] = info['artist']
-        elif info.get('uploader') is not None:
-            metadata['artist'] = info['uploader']
-        elif info.get('uploader_id') is not None:
-            metadata['artist'] = info['uploader_id']
-        if info.get('description') is not None:
-            metadata['description'] = info['description']
-            metadata['comment'] = info['description']
-        if info.get('webpage_url') is not None:
-            metadata['purl'] = info['webpage_url']
-        if info.get('album') is not None:
-            metadata['album'] = info['album']
+        if self._downloader.params.get('addmetadata'):
+            if info.get('title') is not None:
+                metadata['title'] = info['title']
+            if info.get('upload_date') is not None:
+                metadata['date'] = info['upload_date']
+            if info.get('artist') is not None:
+                metadata['artist'] = info['artist']
+            elif info.get('uploader') is not None:
+                metadata['artist'] = info['uploader']
+            elif info.get('uploader_id') is not None:
+                metadata['artist'] = info['uploader_id']
+            if info.get('description') is not None:
+                metadata['description'] = info['description']
+                metadata['comment'] = info['description']
+            if info.get('webpage_url') is not None:
+                metadata['purl'] = info['webpage_url']
+            if info.get('album') is not None:
+                metadata['album'] = info['album']
 
         for m in self._downloader.params.get('custommeta'):
             key, val = m.split('=', 1)


### PR DESCRIPTION
This is added after the defaults provided by --add-metadata

Syntax: --custom-meta "TAGNAME=string with optional %(format)s"
Example: --custom-meta "comment=%(webpage_url)s\n%(description)s"

This can be invoked multiple times for different tags.

Example 2:
 youtube-dl --add-metadata -f 18 --meta 'artist=%(uploader_id)s' --meta 'comment=url: %(webpage_url)s\nviews: %(view_count)s / Rating: %(average_rating)s\n\n%(description)s' https://www.youtube.com/watch?v=WzhW20hLp6M
(snip)
[ffmpeg] Adding metadata to 'Breaking Bad Remix (Seasons 3-5)-WzhW20hLp6M.mp4'
 mp4info Breaking\ Bad\ Remix\ (Seasons\ 3-5)-WzhW20hLp6M.mp4
(snip)
 Artist: uploader: placeboing
 Comments: url: https://www.youtube.com/watch?v=WzhW20hLp6M
views: 5601679 / Rating: 4.97684526443

Music and remixing by me.
Seasons 1 and 2 remix: http://www.youtube.com/watch?v=WsqdmqRgrIc
MP3 download: https://www.dropbox.com/s/39luqbbi5cu36du/Chris%20Lohr%20-%20Breaking%20Bad%20Remix%20seasons%203-5.mp3
