### PR TITLE
Fix broken ttml to srt conversion (extra linefeeds and missing words) 

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1850,12 +1850,10 @@ def dfxp2srt(dfxp_data):
         'ttaf1': 'http://www.w3.org/2006/10/ttaf1',
     })
 
-
     def text_or_empty(v):
         """ return string that contains something other than whitespace, or '' """
         str = str_or_none(v, '')
-        return '' if not re.search(r'[^\s]',str,re.DOTALL) else str
-
+        return '' if not re.search(r'[^\s]', str, re.DOTALL) else str
 
     def parse_node(node):
         str_or_empty = functools.partial(str_or_none, default='')
@@ -1872,7 +1870,7 @@ def dfxp2srt(dfxp_data):
 
         return out
 
-    dfxp = xml.etree.ElementTree.fromstring(dfxp_data.replace('\n','').encode('utf-8'))
+    dfxp = xml.etree.ElementTree.fromstring(dfxp_data.replace('\n', '').encode('utf-8'))
     out = []
     paras = dfxp.findall(_x('.//ttml:p')) or dfxp.findall(_x('.//ttaf1:p')) or dfxp.findall('.//p')
 

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1865,7 +1865,7 @@ def dfxp2srt(dfxp_data):
 
         return out
 
-    dfxp = xml.etree.ElementTree.fromstring(dfxp_data.encode('utf-8'))
+    dfxp = xml.etree.ElementTree.fromstring(dfxp_data.replace('\n','').encode('utf-8'))
     out = []
     paras = dfxp.findall(_x('.//ttml:p')) or dfxp.findall(_x('.//ttaf1:p')) or dfxp.findall('.//p')
 

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1850,6 +1850,12 @@ def dfxp2srt(dfxp_data):
         'ttaf1': 'http://www.w3.org/2006/10/ttaf1',
     })
 
+
+    def text_or_empty(v):
+        str = str_or_none(v, '')
+        return '' if not re.search(r'[^\s]',str,re.DOTALL) else str
+
+
     def parse_node(node):
         str_or_empty = functools.partial(str_or_none, default='')
 
@@ -1859,7 +1865,7 @@ def dfxp2srt(dfxp_data):
             if child.tag in (_x('ttml:br'), _x('ttaf1:br'), 'br'):
                 out += '\n' + str_or_empty(child.tail)
             elif child.tag in (_x('ttml:span'), _x('ttaf1:span'), 'span'):
-                out += str_or_empty(parse_node(child))
+                out += str_or_empty(parse_node(child)) + text_or_empty(child.tail)
             else:
                 out += str_or_empty(xml.etree.ElementTree.tostring(child))
 

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1852,6 +1852,7 @@ def dfxp2srt(dfxp_data):
 
 
     def text_or_empty(v):
+        """ return string that contains something other than whitespace, or '' """
         str = str_or_none(v, '')
         return '' if not re.search(r'[^\s]',str,re.DOTALL) else str
 


### PR DESCRIPTION
- Issue 1: dfxp2srt will lose text nodes that follow span blocks (example from  http://www.pbs.org/wgbh/pages/frontline/escaping-isis/)
  
  (p begin="00:00:16.733" end="00:00:22.633" region="bottom" style="default")
   &gt;&gt; (span tts:fontStyle="italic")Tonight on(/span) Frontline, (span tts:fontStyle="italic")they(br/)
   live under the veil in fear.(/span)
  (/p)

' Frontline, ' is missing entirely, as the parser doesn't insert node.tail. The first line from the above, after conversion to .srt:

```
>> Tonight onthey
```

After patch:

```
>> Tonight on Frontline, they
```

The patch specifically excludes whitespace-only text nodes;

Without exclusion (spaces converted to _ for clarification)

```
_____live_under_the_veil_in_fear.___
```

With exclusion:

```
_____live_under_the_veil_in_fear.
```
- Issue 2: Linefeeds in the xml are present in the resulting .srt, in addition to '<br>' and '<p>'. This does not follow xml or dfxp spec (http://www.w3.org/TR/ttaf1-dfxp/), and can result in a broken .srt with double linefeeds. This will not display correctly in mx player on android; it will display the timestamp headers, then stop displaying text entirely. (example from http://video.pbs.org/video/2365487526)/
  
  1
  00:00:15,766 --> 00:00:17,733
  
  ```
  >> NARRATOR:
  
  Tonight on Frontline...
  ```
  
  2
  00:00:17,765 --> 00:00:20,899
  
  ```
  >> Salmonella sickens
  
  and kills more of us
  ```
  
  3

By stripping out '\n' from the xml before conversion, a usable .srt is generated:

```
1
00:00:15,766 --> 00:00:17,733
    >> NARRATOR:
    Tonight on Frontline...   

2
00:00:17,765 --> 00:00:20,899
    >> Salmonella sickens
    and kills more of us   

3
```
