### PR TITLE
--fallback-generic: try to download with generic on failure

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -297,6 +297,7 @@ def _real_main(argv=None):
         'restrictfilenames': opts.restrictfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,
+        'fallback_generic': opts.fallback_generic,
         'ratelimit': opts.ratelimit,
         'nooverwrites': opts.nooverwrites,
         'retries': opts_retries,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -155,6 +155,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='force_generic_extractor', default=False,
         help='Force extraction to use the generic extractor')
     general.add_option(
+        '--fallback-generic',
+        action='store_true', dest='fallback_generic', default=False,
+        help='Try the generic extractor if a site-specific extractor fails')
+    general.add_option(
         '--default-search',
         dest='default_search', metavar='PREFIX',
         help='Use this prefix for unqualified URLs. For example "gvsearch2:" downloads two videos from google videos for youtube-dl "large apple". Use the value "auto" to let youtube-dl guess ("auto_warning" to emit a warning when guessing). "error" just throws an error. The default value "fixup_error" repairs broken URLs, but emits an error if this is not possible instead of searching.')


### PR DESCRIPTION
- does not retry if generic fails, or if a url from generic fails
  (to prevent silly generic->embed->fail->generic->embed->fail->shenanigans)
- 'failed' extra_info propagates to playlist entries, to prevent
  the above as well
- extra_info re-initialized for every argument in .download()
  (it seems to persist to the next argument)
- 'arg_url' extra_info added, to store the requested url:
  
  youtube-dl http://www.telegraph.co.uk/news/newstopics/howaboutthat/11750410/Clever-dog-uses-boat-to-fetch-ball-without-getting-wet.html \
  --custom-meta 'description=\n arg_url=%(arg_url)s\n webpage_url=%(webpage_url)s'
  
  arg_url=http://www.telegraph.co.uk/news/newstopics/howaboutthat/11750410/Clever-dog-uses-boat-to-fetch-ball-without-getting-wet.html
  webpage_url=http://player.ooyala.com/player.js?embedCode=VpMjlidjp_25xhKrv4mmLPgL4hRArBZG
