### PR TITLE
Add support for Steam broadcasts with parallel dash downloads

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -71,7 +71,6 @@ from .utils import (
     write_json_file,
     write_string,
     YoutubeDLHandler,
-    prepend_extension,
     replace_extension,
     args_to_str,
     age_restricted,
@@ -1377,7 +1376,6 @@ class YoutubeDL(object):
                     return fd.download(name, info)
 
                 if info_dict.get('requested_formats') is not None:
-                    downloaded = []
                     success = True
                     merger = FFmpegMergerPP(self)
                     if not merger.available:
@@ -1420,16 +1418,8 @@ class YoutubeDL(object):
                             '[download] %s has already been downloaded and '
                             'merged' % filename)
                     else:
-                        for f in requested_formats:
-                            new_info = dict(info_dict)
-                            new_info.update(f)
-                            fname = self.prepare_filename(new_info)
-                            fname = prepend_extension(fname, 'f%s' % f['format_id'], new_info['ext'])
-                            downloaded.append(fname)
-                            partial_success = dl(fname, new_info)
-                            success = success and partial_success
+                        success = dl(filename, info_dict)
                         info_dict['__postprocessors'] = postprocessors
-                        info_dict['__files_to_merge'] = downloaded
                 else:
                     # Just a single file
                     success = dl(filename, info_dict)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -372,6 +372,7 @@ def _real_main(argv=None):
         'external_downloader_args': external_downloader_args,
         'postprocessor_args': postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
+        'parallel_dash_downloads': opts.parallel_dash_downloads,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/youtube_dl/downloader/__init__.py
+++ b/youtube_dl/downloader/__init__.py
@@ -9,6 +9,7 @@ from .http import HttpFD
 from .rtsp import RtspFD
 from .rtmp import RtmpFD
 from .dash import DashSegmentsFD
+from .merge import MergeFD
 
 from ..utils import (
     determine_protocol,
@@ -27,6 +28,9 @@ PROTOCOL_MAP = {
 
 def get_suitable_downloader(info_dict, params={}):
     """Get the downloader class that can handle the info dict."""
+    if info_dict.get('requested_formats') is not None:
+        return MergeFD
+
     protocol = determine_protocol(info_dict)
     info_dict['protocol'] = protocol
 

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -137,7 +137,8 @@ class FileDownloader(object):
         return int(round(number * multiplier))
 
     def to_screen(self, *args, **kargs):
-        self.ydl.to_screen(*args, **kargs)
+        if not self.params.get('quiet'):
+            self.ydl.to_screen(*args, **kargs)
 
     def to_stderr(self, message):
         self.ydl.to_screen(message)

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -14,6 +14,10 @@ from ..utils import (
 )
 
 
+class StopDownload(Exception):
+    pass
+
+
 class FileDownloader(object):
     """File Downloader class.
 
@@ -232,6 +236,9 @@ class FileDownloader(object):
         self.to_console_title('youtube-dl ' + msg)
 
     def report_progress(self, s):
+        if s.get('_skip_report_progress'):
+            return
+
         if s['status'] == 'finished':
             if self.params.get('noprogress', False):
                 self.to_screen('[download] Download completed')

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -347,7 +347,16 @@ class FileDownloader(object):
             self.to_screen('[download] Sleeping %s seconds...' % sleep_interval)
             time.sleep(sleep_interval)
 
-        return self.real_download(filename, info_dict)
+        try:
+            return self.real_download(filename, info_dict)
+        except (KeyboardInterrupt, StopDownload):
+            if info_dict.get('is_live'):
+                self.to_screen('[download] Stopping recording of livestream: {0}'.format(filename))
+                tmpfilename = self.temp_name(filename)
+                if os.path.exists(encodeFilename(tmpfilename)):
+                    self.try_rename(tmpfilename, filename)
+                return True
+            raise
 
     def real_download(self, filename, info_dict):
         """Real download process. Redefine in subclasses."""

--- a/youtube_dl/downloader/dash.py
+++ b/youtube_dl/downloader/dash.py
@@ -1,9 +1,19 @@
 from __future__ import unicode_literals
 
+import itertools
 import re
+import time
+import xml.etree.ElementTree as etree
 
 from .common import FileDownloader
-from ..compat import compat_urllib_request
+from ..compat import (
+    compat_str,
+    compat_urllib_request,
+)
+from ..utils import (
+    parse_iso8601,
+    xpath_with_ns,
+)
 
 
 class DashSegmentsFD(FileDownloader):
@@ -13,9 +23,6 @@ class DashSegmentsFD(FileDownloader):
     def real_download(self, filename, info_dict):
         self.report_destination(filename)
         tmpfilename = self.temp_name(filename)
-        base_url = info_dict['url']
-        segment_urls = info_dict['segment_urls']
-
         is_test = self.params.get('test', False)
         remaining_bytes = self._TEST_FILE_SIZE if is_test else None
         byte_counter = 0
@@ -34,21 +41,63 @@ class DashSegmentsFD(FileDownloader):
             outf.write(data)
             return len(data)
 
-        def combine_url(base_url, target_url):
-            if re.match(r'^https?://', target_url):
-                return target_url
-            return '%s/%s' % (base_url, target_url)
+        if not info_dict.get('is_live'):
+            base_url = info_dict['url']
+            segment_urls = info_dict['segment_urls']
+
+            def combine_url(base_url, target_url):
+                if re.match(r'^https?://', target_url):
+                    return target_url
+                return '%s/%s' % (base_url, target_url)
+
+            init_url = combine_url(base_url, info_dict['initialization_url'])
+            segment_urls = [combine_url(base_url, segment_url) for segment_url in segment_urls]
+
+        else:
+            manifest_url = info_dict['url']
+            manifest_xml = self.ydl.urlopen(manifest_url).read()
+            manifest = etree.fromstring(manifest_xml)
+            _x = lambda p: xpath_with_ns(p, {'ns': 'urn:mpeg:DASH:schema:MPD:2011'})
+            ad = [e for e in manifest.findall(_x('ns:Period/ns:AdaptationSet')) if e.attrib['id'] == info_dict['mpd_set_id']][0]
+            segment_template = ad.find(_x('ns:SegmentTemplate'))
+
+            def subs_url_template(url_template, repr_id, number=None):
+                result = url_template.replace('$RepresentationID$', repr_id)
+                if number is not None:
+                    result = result.replace('$Number$', compat_str(number))
+                return result
+
+            start_time = parse_iso8601(manifest.attrib['availabilityStartTime'])
+            segment_duration = (int(segment_template.attrib['duration']) / int(segment_template.attrib['timescale']))  # in seconds
+            first_segment = int((int(time.time()) - start_time) / segment_duration)
+            init_url = subs_url_template(segment_template.attrib['initialization'], '1')
+
+            def build_live_segment_urls():
+                for nr in itertools.count(first_segment):
+                    # We have to avoid requesting a segment before its start time
+                    expected_time = start_time + nr * segment_duration
+                    wait_time = expected_time - time.time()
+                    if wait_time > 0:
+                        time.sleep(wait_time)
+                    yield subs_url_template(segment_template.attrib['media'], '1', nr)
+            segment_urls = build_live_segment_urls()
 
         with open(tmpfilename, 'wb') as outf:
             append_url_to_file(
-                outf, combine_url(base_url, info_dict['initialization_url']),
+                outf, init_url,
                 'initialization segment')
             for i, segment_url in enumerate(segment_urls):
+                note = 'segment %d' % (i + 1)
+                if not info_dict.get('is_live'):
+                    note += ' / %d' % len(segment_urls)
                 segment_len = append_url_to_file(
-                    outf, combine_url(base_url, segment_url),
-                    'segment %d / %d' % (i + 1, len(segment_urls)),
-                    remaining_bytes)
+                    outf, segment_url, note, remaining_bytes)
                 byte_counter += segment_len
+                self._hook_progress({
+                    'status': 'downloading',
+                    'downloaded_bytes': byte_counter,
+                    'filename': filename,
+                })
                 if remaining_bytes is not None:
                     remaining_bytes -= segment_len
                     if remaining_bytes <= 0:

--- a/youtube_dl/downloader/merge.py
+++ b/youtube_dl/downloader/merge.py
@@ -1,0 +1,37 @@
+from __future__ import unicode_literals
+
+from .common import FileDownloader
+import youtube_dl
+from ..utils import prepend_extension
+
+
+class MergeFD(FileDownloader):
+    def real_download(self, filename, info_dict):
+        infos = []
+        for f in info_dict['requested_formats']:
+            new_info = dict(info_dict)
+            del new_info['requested_formats']
+            new_info.update(f)
+            fname = self.ydl.prepare_filename(new_info)
+            fname = prepend_extension(fname, 'f%s' % f['format_id'], new_info['ext'])
+            infos.append((fname, new_info))
+        success = True
+        for fname, info in infos:
+            params = dict(self.params)
+            params.update({
+                'quiet': True,
+                'noprogress': True,
+            })
+            fd = youtube_dl.downloader.get_suitable_downloader(info, self.params)(self.ydl, params)
+
+            def hook(status):
+                self._hook_progress(status)
+
+            fd.add_progress_hook(hook)
+            self.report_destination(fname)
+            partial_success = fd.download(fname, info)
+            success = success and partial_success
+
+        info_dict['__files_to_merge'] = [fname for fname, _ in infos]
+
+        return True

--- a/youtube_dl/downloader/merge.py
+++ b/youtube_dl/downloader/merge.py
@@ -1,20 +1,19 @@
-from __future__ import unicode_literals
+from __future__ import unicode_literals, division
 
-from .common import FileDownloader
+import threading
+
+from .common import FileDownloader, StopDownload
 import youtube_dl
 from ..utils import prepend_extension
 
 
+def _join_threads(threads, timeout=None):
+    for t in threads:
+        t.join(timeout=timeout)
+
+
 class MergeFD(FileDownloader):
-    def real_download(self, filename, info_dict):
-        infos = []
-        for f in info_dict['requested_formats']:
-            new_info = dict(info_dict)
-            del new_info['requested_formats']
-            new_info.update(f)
-            fname = self.ydl.prepare_filename(new_info)
-            fname = prepend_extension(fname, 'f%s' % f['format_id'], new_info['ext'])
-            infos.append((fname, new_info))
+    def _normal_download(self, filename, infos):
         success = True
         for fname, info in infos:
             params = dict(self.params)
@@ -31,7 +30,97 @@ class MergeFD(FileDownloader):
             self.report_destination(fname)
             partial_success = fd.download(fname, info)
             success = success and partial_success
+        return success
 
-        info_dict['__files_to_merge'] = [fname for fname, _ in infos]
+    def _parallel_download(self, filename, infos):
+        self.report_warning('Downloading DASH formats in parallel is an experimental feature, some things may not work as expected')
+        threads = []
+        statuses = []
+        downloaders = []
+        lock = threading.Lock()
+        stop_event = threading.Event()
+        for fname, info in infos:
+            params = dict(self.params)
+            params.update({
+                'quiet': True,
+                'noprogress': True,
+            })
+            FD = youtube_dl.downloader.get_suitable_downloader(info, self.params)
+            fd = FD(self.ydl, params)
+            downloaders.append(fd)
 
+            status = {}
+            statuses.append(status)
+
+            def hook(s, status=status):
+                with lock:
+                    status.update(s)
+                    s['_skip_report_progress'] = True
+                    self._hook_progress(s)
+
+                    global_status = {'filename': filename}
+                    if any(s.get('status') == 'downloading' for s in statuses):
+                        global_status['status'] = 'downloading'
+                    elif all(s.get('status') == 'finished' for s in statuses):
+                        global_status['status'] = 'finished'
+                    else:
+                        global_status['status'] = None
+                    for s in statuses:
+                        for key in ['total_bytes', 'downloaded_bytes', 'eta', 'elapsed', 'speed']:
+                            if s.get(key) is not None:
+                                global_status.setdefault(key, 0)
+                                global_status[key] += s[key]
+                    # Don't call _hook_progress because it's not a real file
+                    self.report_progress(global_status)
+                if stop_event.is_set():
+                    raise StopDownload()
+
+            fd.add_progress_hook(hook)
+            self.report_destination(fname)
+
+            def dl(fd, *args):
+                fd._error = None
+                try:
+                    return fd.download(*args)
+                except StopDownload:
+                    pass
+                except Exception as err:
+                    fd._error = err
+
+            thread = threading.Thread(target=dl, args=(fd, fname, info))
+            threads.append(thread)
+        try:
+            for t in threads:
+                t.start()
+            while True:
+                # the timeout seems to be required so that the main thread can
+                # catch the exceptions in python 2.x
+                _join_threads(threads, timeout=1)
+                if not any(t.is_alive() for t in threads):
+                    break
+        except BaseException:
+            stop_event.set()
+            _join_threads(threads)
+            raise
+
+        for fd in downloaders:
+            if fd._error is not None:
+                raise fd._error
         return True
+
+    def real_download(self, filename, info_dict):
+        infos = []
+        for f in info_dict['requested_formats']:
+            new_info = dict(info_dict)
+            del new_info['requested_formats']
+            new_info.update(f)
+            fname = self.ydl.prepare_filename(new_info)
+            fname = prepend_extension(fname, 'f%s' % f['format_id'], new_info['ext'])
+            infos.append((fname, new_info))
+
+        info_dict['__files_to_merge'] = [name for name, _ in infos]
+
+        if self.params.get('parallel_dash_downloads', False):
+            return self._parallel_download(filename, infos)
+        else:
+            return self._normal_download(filename, infos)

--- a/youtube_dl/extractor/__init__.py
+++ b/youtube_dl/extractor/__init__.py
@@ -561,7 +561,10 @@ from .srf import SrfIE
 from .srmediathek import SRMediathekIE
 from .ssa import SSAIE
 from .stanfordoc import StanfordOpenClassroomIE
-from .steam import SteamIE
+from .steam import (
+    SteamIE,
+    SteamBroadcastsIE,
+)
 from .streamcloud import StreamcloudIE
 from .streamcz import StreamCZIE
 from .streetvoice import StreetVoiceIE

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -424,6 +424,10 @@ def parseOpts(overrideArguments=None):
         '--external-downloader-args',
         dest='external_downloader_args', metavar='ARGS',
         help='Give these arguments to the external downloader')
+    downloader.add_option(
+        '--parallel-dash-downloads',
+        action='store_true', dest='parallel_dash_downloads', default=False,
+        help='(Experimental) download dash formats in parallel')
 
     workarounds = optparse.OptionGroup(parser, 'Workarounds')
     workarounds.add_option(


### PR DESCRIPTION
This is for issue #6012. Since the Steam live broadcasts are splitted in video and audio files (similar to YouTube DASH formats) I have added support for downloading them in parallel (I've never used the `threading` module for a real use case, so any feedback is appreciated). Additionally if a download of a livestream is cancelled (withc `Ctr-c`) the download success, allowing postprocessors to be run (merging in that case).

Question: should the parallel download be automatically used for livestreams?
