### PR TITLE
Use `{title}` style for --output templates rather than `%(title)s`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,26 @@ which means you can modify it, redistribute it or use it however you like.
 ## Filesystem Options:
     -a, --batch-file FILE            File containing URLs to download ('-' for stdin)
     --id                             Use only video ID in file name
-    -o, --output TEMPLATE            Output filename template. Use %(title)s to get the title, %(uploader)s for the uploader name, %(uploader_id)s for the uploader
-                                     nickname if different, %(autonumber)s to get an automatically incremented number, %(ext)s for the filename extension, %(format)s for
-                                     the format description (like "22 - 1280x720" or "HD"), %(format_id)s for the unique id of the format (like YouTube's itags: "137"),
-                                     %(upload_date)s for the upload date (YYYYMMDD), %(extractor)s for the provider (youtube, metacafe, etc), %(id)s for the video id,
-                                     %(playlist_title)s, %(playlist_id)s, or %(playlist)s (=title if present, ID otherwise) for the playlist the video is in,
-                                     %(playlist_index)s for the position in the playlist. %(height)s and %(width)s for the width and height of the video format.
-                                     %(resolution)s for a textual description of the resolution of the video format. %% for a literal percent. Use - to output to stdout.
-                                     Can also be used to download to a different directory, for example with -o '/my/downloads/%(uploader)s/%(title)s-%(id)s.%(ext)s' .
-    --autonumber-size NUMBER         Specify the number of digits in %(autonumber)s when it is present in output filename template or --auto-number option is given
+    -o, --output TEMPLATE            Output filename template. Use 
+                                     {title} to get the title, 
+                                     {uploader} for the uploader name, {uploader_id} for the uploader nickname if different, 
+                                     {autonumber} to get an automatically incremented number, 
+                                     {ext} for the filename extension, 
+                                     {format} for the format description (like "22 - 1280x720" or "HD"), 
+                                     {format_id} for the unique id of the format (like YouTube's itags: "137"), 
+                                     {upload_date} for the upload date (YYYYMMDD), 
+                                     {extractor} for the provider (youtube, metacafe, etc), 
+                                     {id} for the video id, 
+                                     {playlist_title}, {playlist_id}, or {playlist} (=title if present, ID otherwise) for the playlist the video is in, 
+                                     {playlist_index} for the position in the playlist, 
+                                     {height} and {width} for the width and height of the video format, 
+                                     {resolution} for a textual description of the resolution of the video format, 
+                                     {{ }} %% for literal braces and percent. 
+                                     Use - to output to stdout. 
+                                     Can also be used to download to a different directory, for example with -o '/my/downloads/{uploader}/{title}-{id}.{ext}' .
+    --autonumber-size NUMBER         Specify the number of digits in {autonumber} when it is present in output filename template or --auto-number option is given
     --restrict-filenames             Restrict filenames to only ASCII characters, and avoid "&" and spaces in filenames
-    -A, --auto-number                [deprecated; use  -o "%(autonumber)s-%(title)s.%(ext)s" ] Number downloaded files starting from 00000
+    -A, --auto-number                [deprecated; use  -o '{autonumber}-{title}.{ext}' ] Number downloaded files starting from 00000
     -t, --title                      [deprecated] Use title in file name (default)
     -l, --literal                    [deprecated] Alias of --title
     -w, --no-overwrites              Do not overwrite files
@@ -221,7 +230,7 @@ which means you can modify it, redistribute it or use it however you like.
     --embed-subs                     Embed subtitles in the video (only for mkv and mp4 videos)
     --embed-thumbnail                Embed thumbnail in the audio as cover art
     --add-metadata                   Write metadata to the video file
-    --metadata-from-title FORMAT     Parse additional metadata like song title / artist from the video title. The format syntax is the same as --output, the parsed
+    --metadata-from-title FORMAT     Parse additional metadata like song title / artist from the video title. The format syntax is the same as --output but using `%(NAME)s` instead of `{NAME}`, the parsed
                                      parameters replace existing values. Additional templates: %(album)s, %(artist)s. Example: --metadata-from-title "%(artist)s -
                                      %(title)s" matches a title like "Coldplay - Paradise"
     --xattrs                         Write metadata to the video file's xattrs (using dublin core and xdg standards)
@@ -260,27 +269,31 @@ On Windows you may also need to setup `%HOME%` environment variable manually.
 
 # OUTPUT TEMPLATE
 
-The `-o` option allows users to indicate a template for the output file names. The basic usage is not to set any template arguments when downloading a single file, like in `youtube-dl -o funny_video.flv "http://some/video"`. However, it may contain special sequences that will be replaced when downloading each video. The special sequences have the format `%(NAME)s`. To clarify, that is a percent symbol followed by a name in parenthesis, followed by a lowercase S. Allowed names are:
+The `-o` option allows users to indicate a template for the output file names. The basic usage is not to set any template arguments when downloading a single file, like in `youtube-dl -o funny_video.flv "http://some/video"`. However, it may contain special sequences that will be replaced when downloading each video. The special sequences have the format `{NAME}`. To clarify, that is a name enclosed in braces. Allowed names are:
 
- - `id`: The sequence will be replaced by the video identifier.
- - `url`: The sequence will be replaced by the video URL.
- - `uploader`: The sequence will be replaced by the nickname of the person who uploaded the video.
- - `upload_date`: The sequence will be replaced by the upload date in YYYYMMDD format.
- - `title`: The sequence will be replaced by the video title.
- - `ext`: The sequence will be replaced by the appropriate extension (like flv or mp4).
- - `epoch`: The sequence will be replaced by the Unix epoch when creating the file.
- - `autonumber`: The sequence will be replaced by a five-digit number that will be increased with each download, starting at zero.
- - `playlist`: The name or the id of the playlist that contains the video.
- - `playlist_index`: The index of the video in the playlist, a five-digit number.
+ - `{title}`: the video title.
+ - `{uploader}`, `{uploader_id}`: the uploader name / nickname.
+ - `{autonumber}`: an automatically incremented number.
+ - `{ext}`: the filename extension.
+ - `{format}`: the format description (like "22 - 1280x720" or "HD").
+ - `{format_id}`: the unique id of the format (like YouTube's itags: "137").
+ - `{upload_date}`: the upload date, in YYYYMMDD format.
+ - `{extractor}`: the provider (youtube, metacafe, etc).
+ - `{id}`: the video identifier.
+ - `{playlist_title}`, `{playlist_id}`, `{playlist}` (=title if present, ID otherwise): the playlist the video is in.
+ - `{playlist_index}`: the position in the playlist, padded with zeros.
+ - `{height}`, `{width}`: the width and height of the video format.
+ - `{resolution}`: a textual description of the resolution of the video format.
+ - `{{`, `}}`, `%%`: literal braces and percent. 
 
-The current default template is `%(title)s-%(id)s.%(ext)s`.
+The current default template is `{title}-{id}.{ext}`.
 
 In some cases, you don't want special characters such as 中, spaces, or &, such as when transferring the downloaded filename to a Windows system or the filename through an 8bit-unsafe channel. In these cases, add the `--restrict-filenames` flag to get a shorter title:
 
 ```bash
-$ youtube-dl --get-filename -o "%(title)s.%(ext)s" BaW_jenozKc
+$ youtube-dl --get-filename -o "{title}.{ext}" 'http://youtube.com/watch?v=BaW_jenozKc'
 youtube-dl test video ''_ä↭𝕐.mp4    # All kinds of weird characters
-$ youtube-dl --get-filename -o "%(title)s.%(ext)s" BaW_jenozKc --restrict-filenames
+$ youtube-dl --get-filename -o "{title}.{ext}" 'http://youtube.com/watch?v=BaW_jenozKc' --restrict-filenames
 youtube-dl_test_video_.mp4          # A simple file name
 ```
 
@@ -430,7 +443,7 @@ From then on, after restarting your shell, you will be able to access both youtu
 
 ### How do I put downloads into a specific folder?
 
-Use the `-o` to specify an [output template](#output-template), for example `-o "/home/user/videos/%(title)s-%(id)s.%(ext)s"`. If you want this for all of your downloads, put the option into your [configuration file](#configuration).
+Use the `-o` to specify an [output template](#output-template), for example `-o "/home/user/videos/{title}-{id}.{ext}"`. If you want this for all of your downloads, put the option into your [configuration file](#configuration).
 
 ### How do I download a video starting with a `-` ?
 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -110,7 +110,7 @@ class _NA_formatter(object):
     to prevent stuff such as {upload_date:%Y} from yielding errors"""
     def __format__(self, fmt):
         return 'NA'
-    def __str__(self, fmt):
+    def __str__(self):
         return 'NA'  # just in case; can probably be removed
 
 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -566,9 +566,11 @@ class YoutubeDL(object):
                                  if v is not None)
             template_dict = collections.defaultdict(lambda: 'NA', template_dict)
 
-            outtmpl = sanitize_path(self.params.get('outtmpl', DEFAULT_OUTTMPL))
+            outtmpl = self.params.get('outtmpl', DEFAULT_OUTTMPL)
             tmpl = compat_expanduser(outtmpl)
-            filename = tmpl % template_dict
+            # Backwards compatibility fix (deprecated): %(foo)s -> {foo}, %% -> %
+            tmpl = re.sub(r'(?<!%)((?:%)*)\1%\(([^)]*)\)s', r'\1{\2}', tmpl).replace('%%','%')
+            filename = sanitize_path(tmpl.format(**template_dict))
             # Temporary fix for #4787
             # 'Treat' all problem characters by passing filename through preferredencoding
             # to workaround encoding issues with subprocess on python2 @ Windows

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -546,8 +546,7 @@ class YoutubeDL(object):
             autonumber_size = self.params.get('autonumber_size')
             if autonumber_size is None:
                 autonumber_size = 5
-            autonumber_templ = '%0' + str(autonumber_size) + 'd'
-            template_dict['autonumber'] = autonumber_templ % self._num_downloads
+            template_dict['autonumber'] = '%0*d' % (autonumber_size, self._num_downloads)
             if template_dict.get('playlist_index') is not None:
                 template_dict['playlist_index'] = '%0*d' % (len(str(template_dict['n_entries'])), template_dict['playlist_index'])
             if template_dict.get('resolution') is None:
@@ -568,10 +567,7 @@ class YoutubeDL(object):
             template_dict = collections.defaultdict(lambda: 'NA', template_dict)
 
             outtmpl = self.params.get('outtmpl', DEFAULT_OUTTMPL)
-            tmpl = compat_expanduser(outtmpl)
-            # Backwards compatibility fix (deprecated): %(foo)s -> {foo}, %% -> %
-            tmpl = re.sub(r'(?<!%)((?:%)*)\1%\(([^)]*)\)s', r'\1{\2}', tmpl).replace('%%','%')
-            filename = sanitize_path(string.Formatter().vformat(tmpl, None, template_dict))
+            filename = sanitize_path(string.Formatter().vformat(outtmpl, None, template_dict))
             # Temporary fix for #4787
             # 'Treat' all problem characters by passing filename through preferredencoding
             # to workaround encoding issues with subprocess on python2 @ Windows

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 import shutil
+import string
 import subprocess
 import socket
 import sys
@@ -570,7 +571,7 @@ class YoutubeDL(object):
             tmpl = compat_expanduser(outtmpl)
             # Backwards compatibility fix (deprecated): %(foo)s -> {foo}, %% -> %
             tmpl = re.sub(r'(?<!%)((?:%)*)\1%\(([^)]*)\)s', r'\1{\2}', tmpl).replace('%%','%')
-            filename = sanitize_path(tmpl.format(**template_dict))
+            filename = sanitize_path(string.Formatter().vformat(tmpl, None, template_dict))
             # Temporary fix for #4787
             # 'Treat' all problem characters by passing filename through preferredencoding
             # to workaround encoding issues with subprocess on python2 @ Windows

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -596,7 +596,7 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '--autonumber-size',
         dest='autonumber_size', metavar='NUMBER',
-        help='Specify the number of digits in %(autonumber)s when it is present in output filename template or --auto-number option is given')
+        help='Specify the number of digits in {autonumber} when it is present in output filename template or --auto-number option is given')
     filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
@@ -604,7 +604,7 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '-A', '--auto-number',
         action='store_true', dest='autonumber', default=False,
-        help='[deprecated; use  -o "%(autonumber)s-%(title)s.%(ext)s" ] Number downloaded files starting from 00000')
+        help='[deprecated; use  -o "{autonumber}-{title}.{ext}" ] Number downloaded files starting from 00000')
     filesystem.add_option(
         '-t', '--title',
         action='store_true', dest='usetitle', default=False,
@@ -722,7 +722,8 @@ def parseOpts(overrideArguments=None):
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',
         help='Parse additional metadata like song title / artist from the video title. '
-             'The format syntax is the same as --output, '
+             'The format syntax is the same as --output '
+             'but using "%(NAME)s" instead of "{NAME}"; '
              'the parsed parameters replace existing values. '
              'Additional templates: %(album)s, %(artist)s. '
              'Example: --metadata-from-title "%(artist)s - %(title)s" matches a title like '

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -575,22 +575,24 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '-o', '--output',
         dest='outtmpl', metavar='TEMPLATE',
-        help=('Output filename template. Use %(title)s to get the title, '
-              '%(uploader)s for the uploader name, %(uploader_id)s for the uploader nickname if different, '
-              '%(autonumber)s to get an automatically incremented number, '
-              '%(ext)s for the filename extension, '
-              '%(format)s for the format description (like "22 - 1280x720" or "HD"), '
-              '%(format_id)s for the unique id of the format (like YouTube\'s itags: "137"), '
-              '%(upload_date)s for the upload date (YYYYMMDD), '
-              '%(extractor)s for the provider (youtube, metacafe, etc), '
-              '%(id)s for the video id, '
-              '%(playlist_title)s, %(playlist_id)s, or %(playlist)s (=title if present, ID otherwise) for the playlist the video is in, '
-              '%(playlist_index)s for the position in the playlist. '
-              '%(height)s and %(width)s for the width and height of the video format. '
-              '%(resolution)s for a textual description of the resolution of the video format. '
-              '%% for a literal percent. '
+        help=('Output filename template. Use {title} to get the title, '
+              '{uploader} for the uploader name, {uploader_id} for the uploader nickname if different, '
+              '{autonumber} to get an automatically incremented number, '
+              '{ext} for the filename extension, '
+              '{format} for the format description (like "22 - 1280x720" or "HD"), '
+              '{format_id} for the unique id of the format (like YouTube\'s itags: "137"), '
+              '{upload_date} for the upload date (YYYYMMDD), '
+              '{extractor} for the provider (youtube, metacafe, etc), '
+              '{id} for the video id, '
+              '{playlist_title}, {playlist_id}, or {playlist} (=title if present, ID otherwise) for the playlist the video is in, '
+              '{playlist_index} for the position in the playlist, '
+              '{height} and {width} for the width and height of the video format, '
+              '{resolution} for a textual description of the resolution of the video format, '
+              '{{ }} %% for literal braces and percent. '
+              'The legacy form %(title)s is also supported with the same meaning as {title}, '
+              'but this may change in a future. '
               'Use - to output to stdout. Can also be used to download to a different directory, '
-              'for example with -o \'/my/downloads/%(uploader)s/%(title)s-%(id)s.%(ext)s\' .'))
+              'for example with -o \'/my/downloads/{uploader}/{title}-{id}.{ext}\' .'))
     filesystem.add_option(
         '--autonumber-size',
         dest='autonumber_size', metavar='NUMBER',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -276,7 +276,7 @@ def parseOpts(overrideArguments=None):
             'For example, to only match videos that have been liked more than '
             '100 times and disliked less than 50 times (or the dislike '
             'functionality is not available at the given service), but who '
-            'also have a description, use  --match-filter '
+            'also have a description, use --match-filter '
             '"like_count > 100 & dislike_count <? 50 & description" .'
         ))
     selection.add_option(
@@ -581,7 +581,7 @@ def parseOpts(overrideArguments=None):
               '{ext} for the filename extension, '
               '{format} for the format description (like "22 - 1280x720" or "HD"), '
               '{format_id} for the unique id of the format (like YouTube\'s itags: "137"), '
-              '{upload_date} for the upload date (YYYYMMDD), '
+              '{upload_date} for the upload date (YYYY-mm-dd), '
               '{extractor} for the provider (youtube, metacafe, etc), '
               '{id} for the video id, '
               '{playlist_title}, {playlist_id}, or {playlist} (=title if present, ID otherwise) for the playlist the video is in, '
@@ -589,6 +589,7 @@ def parseOpts(overrideArguments=None):
               '{height} and {width} for the width and height of the video format, '
               '{resolution} for a textual description of the resolution of the video format, '
               '{{ }} %% for literal braces and percent. '
+              'Format specifiers such as {autonumber:03} or {upload_date:%d-%m-%Y} are allowed. '
               'The legacy form %(title)s is also supported with the same meaning as {title}, '
               'but this may change in a future. '
               'Use - to output to stdout. Can also be used to download to a different directory, '
@@ -596,7 +597,8 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '--autonumber-size',
         dest='autonumber_size', metavar='NUMBER',
-        help='Specify the number of digits in {autonumber} when it is present in output filename template or --auto-number option is given')
+        help=('[deprecated; use {autonumber:0N} where N is the number of digits] '
+              'Specify the number of digits in {autonumber} when it is present in output filename template or --auto-number option is given'))
     filesystem.add_option(
         '--restrict-filenames',
         action='store_true', dest='restrictfilenames', default=False,
@@ -604,7 +606,7 @@ def parseOpts(overrideArguments=None):
     filesystem.add_option(
         '-A', '--auto-number',
         action='store_true', dest='autonumber', default=False,
-        help='[deprecated; use  -o "{autonumber}-{title}.{ext}" ] Number downloaded files starting from 00000')
+        help='[deprecated; use -o \'{autonumber}-{title}.{ext}\' ] Number downloaded files starting from 00000')
     filesystem.add_option(
         '-t', '--title',
         action='store_true', dest='usetitle', default=False,

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -1657,7 +1657,7 @@ def qualities(quality_ids):
     return q
 
 
-DEFAULT_OUTTMPL = '%(title)s-%(id)s.%(ext)s'
+DEFAULT_OUTTMPL = '{title}-{id}.{ext}'
 
 
 def limit_length(s, length):


### PR DESCRIPTION
Currently youtube-dl uses Python's native string interpolation for automated output file naming.  For example, `%(title)s` will be replaced with the video's title.  However, this syntax is ugly and counter-intuitive, specially for people who are not familiar with Python but still want to use this program.

This patch replaces the `%` interpolation with str.format() formatting, so that instead of `%(title)s` the user can just write `{title}`, which in my opinion looks quite better.  Plus it seems to be the preferred formatting method nowadays and it has more options.

Backwards compatibility is provided by replacing all `%(whatever)s` in the template string with `{whatever}` using a regex, and `%%` with `%`; however this is a temporary (and ugly) workaround that can probably be removed in a future when users have gotten used to the new format.

This change requires Python 2.6 or greater to work, since `str.format()` is new in version 2.6 (if that version can be considered "new" at all nowadays).

PS: I moved the call to `sanitize_path()` AFTER formatting the file name; it makes little sense to sanitize a format string rather than an actual file name/path.
