### PR TITLE
Customizable sort formats

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -904,7 +904,7 @@ class InfoExtractor(object):
                         default_criteria_order.remove(field)
 
             default_key_dict = dict(default_key)
-            return [default_key_dict[field] for field in criteria_order]
+            return [default_key_dict[criterion] for criterion in criteria_order]
 
         formats.sort(key=_formats_key)
 

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -882,7 +882,7 @@ class InfoExtractor(object):
                     not criteria_exclusion):
                 return [value for _, value in default_key]
 
-            default_criteria_order = list(list(zip(*default_key))[0])
+            default_criteria_order = [name for name, _ in default_key]
             criteria_order = []
             if criteria_preference:
                 for field in criteria_preference:

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -770,7 +770,7 @@ class InfoExtractor(object):
         Sort formats.
 
         Sorting behavior can be customized by specifying absolute or relative criteria
-        order and criteria exclusion. Criteria is either a field from formats dictionary
+        order and criteria exclusion. Criterion is either a field from formats dictionary
         or a synthetic expression calculated based on some data from formats dictionary.
         Currently following criteria are supported for sorting customization:
 

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -859,7 +859,7 @@ class InfoExtractor(object):
             def field_criterion(name, default=-1):
                 return name, f.get(name) if f.get(name) is not None else default
 
-            default_key = (
+            default_criteria_values = (
                 synthetic_criterion('preference', preference),
                 field_criterion('language_preference'),
                 field_criterion('quality'),
@@ -880,9 +880,9 @@ class InfoExtractor(object):
 
             if (not criteria_preference and not criteria_relative_preference and
                     not criteria_exclusion):
-                return [value for _, value in default_key]
+                return [value for _, value in default_criteria_values]
 
-            default_criteria_order = [name for name, _ in default_key]
+            default_criteria_order = [name for name, _ in default_criteria_values]
             criteria_order = []
             if criteria_preference:
                 for field in criteria_preference:
@@ -903,8 +903,8 @@ class InfoExtractor(object):
                             criteria_order.append(field)
                         default_criteria_order.remove(field)
 
-            default_key_dict = dict(default_key)
-            return [default_key_dict[criterion] for criterion in criteria_order]
+            default_criteria_dict = dict(default_criteria_values)
+            return [default_criteria_dict[criterion] for criterion in criteria_order]
 
         formats.sort(key=_formats_key)
 

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -880,7 +880,7 @@ class InfoExtractor(object):
 
             if (not criteria_preference and not criteria_relative_preference and
                     not criteria_exclusion):
-                return default_key
+                return [value for _, value in default_key]
 
             default_criteria_order = list(list(zip(*default_key))[0])
             criteria_order = []

--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -441,7 +441,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
                 m3u8_url, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False))
         # Bitrates are completely broken. Single m3u8 may contain entries in kbps and bps
         # at the same time without actual units specified. This lead to wrong sorting.
-        self._sort_formats(formats, field_preference=('preference', 'height', 'width', 'fps', 'format_id'))
+        self._sort_formats(formats, criteria_preference=('preference', 'height', 'width', 'fps', 'format_id'))
 
         subtitles = {}
         text_tracks = config['request'].get('text_tracks')

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1551,7 +1551,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     if f.get('vcodec') != 'none':
                         f['stretched_ratio'] = ratio
 
-        self._sort_formats(formats)
+        self._sort_formats(
+            formats,
+            criteria_relative_preference=('height', 'width', 'ext_preference', 'tbr'))
 
         return {
             'id': video_id,


### PR DESCRIPTION
This PR proposes experimental `_sort_formats` behavior extension by introducing the notion of criterion.

The main problem with sorting now is that it's impossible to tweak the default sorting behavior without copy pasting sorting key routine or providing `field_preference` that is also flawed since it does not support calculated conditions. Thus the aim of this improvement is to be able to easily customize the default sorting behavior with minimal overhead and maximum convenience.

For this to happen the notion of _criterion_ is introduced. _Criterion_ is a either a field from formats dictionary or a synthetic expression calculated based on some data from formats dictionary. _Criterion_ is referenced as a plain string denoting it's name, _criteria_ is either a list or a tuple of criterions.

Currently following criteria are supported for sorting customization:

**Field criteria**:
- `format_id`
- `width`
- `height`
- `tbr`
- `abr`
- `vbr`
- `fps`
- `filesize`
- `filesize_approx`
- `language_preference`
- `quality`
- `source_preference`

**Synthetic criteria:**

| Synthetic criterion | Explanation |
| --- | --- |
| `preference` | Calculated based on `preference` field with some corrections |
| `proto_preference` | Calculated based on `protocol` field and prioritizes direct HTTP(s) URLs |
| `ext_preference` | Video extension preference, calculated based on `ext` field and value of `prefer_free_formats` setting |
| `audio_ext_preference` | Audio extension preference, calculated based on `ext` field and value of `prefer_free_formats` setting |

With this approach sorting can be customized in several ways.

**Way 1: Hardcode criteria preference**
Use only specified criterions when sorting formats removing any other default criteria from consideration. This is achieved by passing criteria to `criteria_preference` in order of preference.

**Example:** Override default criteria with set of only 5 criteria in exactly this preference:

``` python
# Bitrates are completely broken. Single m3u8 may contain entries in kbps and bps
# at the same time without actual units specified. This lead to wrong sorting.
self._sort_formats(formats, criteria_preference=('preference', 'height', 'width', 'fps', 'format_id'))
```

**Way 2: Tweak relative criteria preference**
Tweak criteria relative preference between several criteria keeping all other default criteria inplace. This is achieved by passing relative critea list to `criteria_relative_preference`.

**Example:** Prefer `width` over `height`, all other default criteria stay as before

``` python
self._sort_formats(formats, criteria_relative_preference=('width', 'height'))
```

**Way 3: Exclude criteria from consideration**
Remove criteria from consideration completely. This is achieved by passing criteria list to exclude to `criteria_exclusion`.

**Example:** Remove `tbr` from consideration, all other default criteria stay as before:

``` python
self._sort_formats(formats, criteria_exclusion=('tbr',))
```

Way 2 and Way 3 may be combined.

This solves #6018, #8001.
