### PR TITLE
Detect path of youtube_dl module, fixes python ImportError when symlinked

### DIFF
--- a/bin/youtube-dl.detect-path.py
+++ b/bin/youtube-dl.detect-path.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8, tab-width: 4 -*-
+
+from __future__ import unicode_literals
+# ^-- not used, but expected by ../test/test_unicode_literals.py
+
+import os.path
+import sys
+
+wrapper_path = os.path.realpath(__file__)
+sys.path.append(os.path.dirname(os.path.dirname(wrapper_path)))
+execfile(wrapper_path.rsplit('.', 2)[0])


### PR DESCRIPTION
Thanks for this project! Once I fixed the library path detection, it worked perfectly.

Preview before/after:

``` bash
$ git clone $REPO_URL . &>/dev/null && \
  ln -s $PWD/bin/youtube-dl ~/bin/ytdl-rg3

$ git checkout --quiet master && git log -n 1 --oneline
7023251 [comedycentral] Support /shows URLs (fixes #8405)

$ ytdl-rg3 --dump-user-agent
Traceback (most recent call last):
  File "/…/bin/ytdl-rg3", line 3, in <module>
    import youtube_dl
ImportError: No module named youtube_dl

$ git checkout --quiet fix-detect-libdir && git log -n 1 --oneline
6fca247 bin/youtube-dl: fix path detection

$ ytdl-rg3 --dump-user-agent
Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20150101 Firefox/44.0 (Chrome)
```
