### PR TITLE
Stop libav compatibility links from being considered as genuine.

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -85,11 +85,16 @@ class FFmpegPostProcessor(PostProcessor):
                 self._paths = dict(
                     (p, os.path.join(location, p)) for p in programs)
                 self._versions = dict(
-                    (p, get_exe_version(self._paths[p], args=['-version']))
+                    (p, get_exe_version(self._paths[p], args=['-version'],
+                                        version_re=r'%s\s+version\s+([-0-9._a-zA-Z]+)' % p,
+                                        unrecognized=False))
                     for p in programs)
         if self._versions is None:
             self._versions = dict(
-                (p, get_exe_version(p, args=['-version'])) for p in programs)
+                (p, get_exe_version(p, args=['-version'],
+                                    version_re=r'%s\s+version\s+([-0-9._a-zA-Z]+)' % p,
+                                    unrecognized=False))
+                for p in programs)
             self._paths = dict((p, p) for p in programs)
 
         if prefer_ffmpeg:


### PR DESCRIPTION
Debian has abandoned libav for ffmpeg, but provides compatibility links to ffmpeg equivalents for programs that still require libav tools. youtube-dl doesn't differentiate between the two, so incorrectly complains about avconv being outdated and refuses to do any muxing. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=798936.

This fix prevents registration of version numbers for compatibility links, so that youtube-dl is forced to deal with only tools that are actually installed.
