### PR TITLE
Add support for website specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,24 @@ Note that options in configuration file are just the same options aka switches u
 
 You can use `--ignore-config` if you want to disable the configuration file for a particular youtube-dl run.
 
+### Per extractor configuration
+
+In addition to globally setting options, you can also set different options for each extractor.
+A different set of files is used: `~/.config/youtube-dl/config.ini` and `/etc/youtube-dl.ini` on Unix, `%APPDATA%\youtube-dl\config.ini` or `C:\Users\<user name>\youtube-dl.ini` on Windows.
+The files are stored in the [INI format](https://en.wikipedia.org/wiki/INI_file), each argument must be written in its own line using its full name without the leading `--`.
+To start a section with the options for an specific extractor you can write a line in the form `[<name>]`, where `<name>` is the name printed before the info message while downloading (like `youtube`, `youtube:playlist`, `vimeo` ...).
+
+For example, with the following configuration file youtube-dl will always extract the audio, as an mp3 file for YouTube videos and if the are inside a playlist they will be saved in a different folder:
+```
+extract-audio=
+
+[youtube]
+audio-format=mp3
+
+[youtube:playlist]
+output=%(playlist)s/%(title)s.%(ext)s
+```
+
 ### Authentication with `.netrc` file
 
 You may also want to configure automatic credentials storage for extractors that support authentication (by providing login and password with `--username` and `--password`) in order not to pass credentials as command line arguments on every youtube-dl execution and prevent tracking plain text passwords in the shell command history. You can achieve this using a [`.netrc` file](http://stackoverflow.com/tags/.netrc/info) on per extractor basis. For that you will need to create a`.netrc` file in your `$HOME` and restrict permissions to read/write by you only:

--- a/README.md
+++ b/README.md
@@ -431,12 +431,12 @@ You can use `--ignore-config` if you want to disable the configuration file for 
 
 In addition to globally setting options, you can also set different options for each extractor.
 A different set of files is used: `~/.config/youtube-dl/config.ini` and `/etc/youtube-dl.ini` on Unix, `%APPDATA%\youtube-dl\config.ini` or `C:\Users\<user name>\youtube-dl.ini` on Windows.
-The files are stored in the [INI format](https://en.wikipedia.org/wiki/INI_file), each argument must be written in its own line using its full name without the leading `--`.
+The files are stored in the [INI format](https://en.wikipedia.org/wiki/INI_file), each argument must be written in its own line using its full name without the leading `--` or the short version without the leading `-`.
 To start a section with the options for an specific extractor you can write a line in the form `[<name>]`, where `<name>` is the name printed before the info message while downloading (like `youtube`, `youtube:playlist`, `vimeo` ...).
 
 For example, with the following configuration file youtube-dl will always extract the audio, as an mp3 file for YouTube videos and if the are inside a playlist they will be saved in a different folder:
 ```
-extract-audio=
+x=
 
 [youtube]
 audio-format=mp3

--- a/devscripts/bash-completion.py
+++ b/devscripts/bash-completion.py
@@ -6,7 +6,7 @@ from os.path import dirname as dirn
 import sys
 
 sys.path.insert(0, dirn(dirn((os.path.abspath(__file__)))))
-import youtube_dl
+from youtube_dl.options import build_option_parser
 
 BASH_COMPLETION_FILE = "youtube-dl.bash-completion"
 BASH_COMPLETION_TEMPLATE = "devscripts/bash-completion.in"
@@ -25,5 +25,5 @@ def build_completion(opt_parser):
         filled_template = template.replace("{{flags}}", " ".join(opts_flag))
         f.write(filled_template)
 
-parser = youtube_dl.parseOpts()[0]
+parser = build_option_parser()
 build_completion(parser)

--- a/devscripts/fish-completion.py
+++ b/devscripts/fish-completion.py
@@ -7,7 +7,7 @@ from os.path import dirname as dirn
 import sys
 
 sys.path.insert(0, dirn(dirn((os.path.abspath(__file__)))))
-import youtube_dl
+from youtube_dl.options import build_option_parser
 from youtube_dl.utils import shell_quote
 
 FISH_COMPLETION_FILE = 'youtube-dl.fish'
@@ -44,5 +44,5 @@ def build_completion(opt_parser):
     with open(FISH_COMPLETION_FILE, 'w') as f:
         f.write(filled_template)
 
-parser = youtube_dl.parseOpts()[0]
+parser = build_option_parser()
 build_completion(parser)

--- a/devscripts/zsh-completion.py
+++ b/devscripts/zsh-completion.py
@@ -6,7 +6,7 @@ from os.path import dirname as dirn
 import sys
 
 sys.path.insert(0, dirn(dirn((os.path.abspath(__file__)))))
-import youtube_dl
+from youtube_dl.options import build_option_parser
 
 ZSH_COMPLETION_FILE = "youtube-dl.zsh"
 ZSH_COMPLETION_TEMPLATE = "devscripts/zsh-completion.in"
@@ -44,5 +44,5 @@ def build_completion(opt_parser):
     with open(ZSH_COMPLETION_FILE, "w") as f:
         f.write(template)
 
-parser = youtube_dl.parseOpts()[0]
+parser = build_option_parser()
 build_completion(parser)

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -710,6 +710,7 @@ class TestYoutubeDL(unittest.TestCase):
         ydl = YoutubeDL(params, auto_init=False)
         ydl.downloads = []
         real_process_info = ydl.process_info
+
         def process_info(info_dict, params):
             r = real_process_info(info_dict, params)
             ydl.downloads.append(info_dict)
@@ -728,7 +729,6 @@ class TestYoutubeDL(unittest.TestCase):
                     'url': 'http://example.com',
                 }
 
-
         ie = ExampleIE()
         ydl.add_info_extractor(ie)
         pars = ie.params
@@ -739,6 +739,23 @@ class TestYoutubeDL(unittest.TestCase):
 
         ydl.extract_info('example')
         self.assertEqual(ydl.downloads[-1]['_filename'], 'foo.mp4')
+
+        class ExamplePlaylistIE(InfoExtractor):
+            IE_NAME = 'example.com:playlist'
+            _VALID_URL = r'example:playlist'
+
+            def _real_extract(self, url):
+                return {
+                    '_type': 'playlist',
+                    'title': 'example playlist',
+                    'entries': [self.url_result('example')],
+                }
+        playlist_params = {'outtmpl': '%(playlist)s/%(title)s.%(ext)s'}
+        ydl.params = Params(
+            {'skip_download': True}, {'example.com:playlist': playlist_params})
+        ydl.add_info_extractor(ExamplePlaylistIE())
+        ydl.extract_info('example:playlist')
+        self.assertEqual(ydl.downloads[-1]['_filename'], 'example playlist/example.mp4')
 
 
 if __name__ == '__main__':

--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -17,6 +17,7 @@ from youtube_dl.extractor import YoutubeIE
 from youtube_dl.extractor.common import InfoExtractor
 from youtube_dl.postprocessor.common import PostProcessor
 from youtube_dl.utils import ExtractorError, match_filter_func
+from youtube_dl.params import Params
 
 TEST_URL = 'http://localhost/sample.mp4'
 
@@ -701,6 +702,22 @@ class TestYoutubeDL(unittest.TestCase):
         ydl.extract_info('foo1:')
         downloaded = ydl.downloaded_info_dicts[0]
         self.assertEqual(downloaded['url'], TEST_URL)
+
+    def test_subparams(self):
+        example_params = {'foo': 'example'}
+        params = Params({'foo': 'base', 'blah': 'base'}, {'example.com': example_params})
+        ydl = YoutubeDL(params)
+
+        class ExampleIE(InfoExtractor):
+            IE_NAME = 'example.com'
+
+        ie = ExampleIE()
+        ydl.add_info_extractor(ie)
+        pars = ie.params
+        self.assertEqual(pars['foo'], 'example')
+        self.assertEqual(pars['blah'], 'base')
+        self.assertEqual(pars.get('blah'), 'base')
+        self.assertEqual(pars.get('nonexistant'), None)
 
 
 if __name__ == '__main__':

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -51,9 +51,9 @@ class YoutubeDL(youtube_dl.YoutubeDL):
         # Don't accept warnings during tests
         raise ExtractorError(message)
 
-    def process_info(self, info_dict):
+    def process_info(self, info_dict, params):
         self.processed_info_dicts.append(info_dict)
-        return super(YoutubeDL, self).process_info(info_dict)
+        return super(YoutubeDL, self).process_info(info_dict, params)
 
 
 def _file_md5(fn):

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -650,12 +650,15 @@ class YoutubeDL(object):
             info_dict.setdefault(key, value)
 
     def extract_info(self, url, download=True, ie_key=None, extra_info={},
-                     process=True, force_generic_extractor=False):
+                     process=True, force_generic_extractor=False, params=None):
         '''
         Returns a list with a dictionary for each video we find.
         If 'download', also downloads the videos.
         extra_info is a dict containing the extra values to add to each result
         '''
+
+        if params is None:
+            params = self.params
 
         if not ie_key and force_generic_extractor:
             ie_key = 'Generic'
@@ -687,7 +690,7 @@ class YoutubeDL(object):
                 if process:
                     return self.process_ie_result(
                         ie_result, download, extra_info,
-                        params=self.params.section(ie.IE_NAME))
+                        params=params.section(ie.IE_NAME))
                 else:
                     return ie_result
             except ExtractorError as e:  # An error we somewhat expected
@@ -741,12 +744,14 @@ class YoutubeDL(object):
             return self.extract_info(ie_result['url'],
                                      download,
                                      ie_key=ie_result.get('ie_key'),
-                                     extra_info=extra_info)
+                                     extra_info=extra_info,
+                                     params=params)
         elif result_type == 'url_transparent':
             # Use the information from the embedding page
             info = self.extract_info(
                 ie_result['url'], ie_key=ie_result.get('ie_key'),
-                extra_info=extra_info, download=False, process=False)
+                extra_info=extra_info, download=False, process=False,
+                params=params)
 
             force_properties = dict(
                 (k, v) for k, v in ie_result.items() if v is not None)

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -355,13 +355,6 @@ class YoutubeDL(object):
             self.print_debug_header()
             self.add_default_info_extractors()
 
-        for pp_def_raw in self.params.get('postprocessors', []):
-            pp_class = get_postprocessor(pp_def_raw['key'])
-            pp_def = dict(pp_def_raw)
-            del pp_def['key']
-            pp = pp_class(self, **compat_kwargs(pp_def))
-            self.add_post_processor(pp)
-
         for ph in self.params.get('progress_hooks', []):
             self.add_progress_hook(ph)
 
@@ -1786,6 +1779,13 @@ class YoutubeDL(object):
         pps_chain = []
         if ie_info.get('__postprocessors') is not None:
             pps_chain.extend(ie_info['__postprocessors'])
+        for pp_def_raw in params.get('postprocessors', []):
+            pp_class = get_postprocessor(pp_def_raw['key'])
+            pp_def = dict(pp_def_raw)
+            del pp_def['key']
+            pp = pp_class(self, **compat_kwargs(pp_def))
+            pp.set_downloader(self)
+            pps_chain.append(pp)
         pps_chain.extend(self._pps)
         for pp in pps_chain:
             files_to_delete = []

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -94,6 +94,7 @@ from .postprocessor import (
     get_postprocessor,
 )
 from .version import __version__
+from .params import Params
 
 if compat_os_name == 'nt':
     import ctypes
@@ -122,7 +123,9 @@ class YoutubeDL(object):
     options instead. These options are available through the params
     attribute for the InfoExtractors to use. The YoutubeDL also
     registers itself as the downloader in charge for the InfoExtractors
-    that are added to it, so this is a "mutual registration".
+    that are added to it, so this is a "mutual registration". To use different
+    parameters in an extractor, the youtube_dl.params.Params class must be
+    used.
 
     Available options:
 
@@ -294,11 +297,14 @@ class YoutubeDL(object):
         self._num_downloads = 0
         self._screen_file = [sys.stdout, sys.stderr][params.get('logtostderr', False)]
         self._err_file = sys.stderr
-        self.params = {
+        if not isinstance(params, Params):
+            params = Params(params)
+        self.params = params
+        default_params = {
             # Default parameters
             'nocheckcertificate': False,
         }
-        self.params.update(params)
+        self.add_extra_info(self.params, default_params)
         self.cache = Cache(self)
 
         if params.get('bidi_workaround', False):

--- a/youtube_dl/compat.py
+++ b/youtube_dl/compat.py
@@ -582,11 +582,17 @@ if sys.version_info >= (3, 0):
 else:
     from tokenize import generate_tokens as compat_tokenize_tokenize
 
+try:
+    import configparser as compat_configparser
+except ImportError:
+    import ConfigParser as compat_configparser
+
 __all__ = [
     'compat_HTMLParser',
     'compat_HTTPError',
     'compat_basestring',
     'compat_chr',
+    'compat_configparser',
     'compat_cookiejar',
     'compat_cookies',
     'compat_etree_fromstring',

--- a/youtube_dl/extractor/brightcove.py
+++ b/youtube_dl/extractor/brightcove.py
@@ -343,7 +343,7 @@ class BrightcoveLegacyIE(InfoExtractor):
                 'url': video_info['FLVFullLengthURL'],
             })
 
-        if self._downloader.params.get('include_ads', False):
+        if self.params.get('include_ads', False):
             adServerURL = video_info.get('_youtubedl_adServerURL')
             if adServerURL:
                 ad_info = {

--- a/youtube_dl/extractor/ccc.py
+++ b/youtube_dl/extractor/ccc.py
@@ -37,7 +37,7 @@ class CCCIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
 
-        if self._downloader.params.get('prefer_free_formats'):
+        if self.params.get('prefer_free_formats'):
             preference = qualities(['mp3', 'opus', 'mp4-lq', 'webm-lq', 'h264-sd', 'mp4-sd', 'webm-sd', 'mp4', 'webm', 'mp4-hd', 'h264-hd', 'webm-hd'])
         else:
             preference = qualities(['opus', 'mp3', 'webm-lq', 'mp4-lq', 'webm-sd', 'h264-sd', 'mp4-sd', 'webm', 'mp4', 'webm-hd', 'mp4-hd', 'h264-hd'])

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -331,6 +331,7 @@ class InfoExtractor(object):
     def set_downloader(self, downloader):
         """Sets the downloader for this IE."""
         self._downloader = downloader
+        self.params = downloader.params if downloader else {}
 
     def _real_initialize(self):
         """Real initialization process. Redefine in subclasses."""
@@ -419,7 +420,7 @@ class InfoExtractor(object):
             webpage_bytes = prefix + webpage_bytes
         if not encoding:
             encoding = self._guess_encoding_from_content(content_type, webpage_bytes)
-        if self._downloader.params.get('dump_intermediate_pages', False):
+        if self.params.get('dump_intermediate_pages', False):
             try:
                 url = url_or_request.get_full_url()
             except AttributeError:
@@ -427,7 +428,7 @@ class InfoExtractor(object):
             self.to_screen('Dumping request to ' + url)
             dump = base64.b64encode(webpage_bytes).decode('ascii')
             self._downloader.to_screen(dump)
-        if self._downloader.params.get('write_pages', False):
+        if self.params.get('write_pages', False):
             try:
                 url = url_or_request.get_full_url()
             except AttributeError:
@@ -610,7 +611,7 @@ class InfoExtractor(object):
                 if mobj:
                     break
 
-        if not self._downloader.params.get('no_color') and compat_os_name != 'nt' and sys.stderr.isatty():
+        if not self.params.get('no_color') and compat_os_name != 'nt' and sys.stderr.isatty():
             _name = '\033[0;34m%s\033[0m' % name
         else:
             _name = name
@@ -650,7 +651,7 @@ class InfoExtractor(object):
 
         username = None
         password = None
-        downloader_params = self._downloader.params
+        downloader_params = self.params
 
         # Attempt to use provided username and password or .netrc data
         if downloader_params.get('username') is not None:
@@ -678,7 +679,7 @@ class InfoExtractor(object):
         """
         if self._downloader is None:
             return None
-        downloader_params = self._downloader.params
+        downloader_params = self.params
 
         if downloader_params.get('twofactor') is not None:
             return downloader_params['twofactor']
@@ -869,7 +870,7 @@ class InfoExtractor(object):
 
             if f.get('vcodec') == 'none':  # audio only
                 preference -= 50
-                if self._downloader.params.get('prefer_free_formats'):
+                if self.params.get('prefer_free_formats'):
                     ORDER = ['aac', 'mp3', 'm4a', 'webm', 'ogg', 'opus']
                 else:
                     ORDER = ['webm', 'opus', 'ogg', 'mp3', 'aac', 'm4a']
@@ -881,7 +882,7 @@ class InfoExtractor(object):
             else:
                 if f.get('acodec') == 'none':  # video only
                     preference -= 40
-                if self._downloader.params.get('prefer_free_formats'):
+                if self.params.get('prefer_free_formats'):
                     ORDER = ['flv', 'mp4', 'webm']
                 else:
                     ORDER = ['webm', 'flv', 'mp4']
@@ -948,7 +949,7 @@ class InfoExtractor(object):
         """ Either "http:" or "https:", depending on the user's preferences """
         return (
             'http:'
-            if self._downloader.params.get('prefer_insecure', False)
+            if self.params.get('prefer_insecure', False)
             else 'https:')
 
     def _proto_relative_url(self, url, scheme=None):
@@ -1614,8 +1615,8 @@ class InfoExtractor(object):
         return not any_restricted
 
     def extract_subtitles(self, *args, **kwargs):
-        if (self._downloader.params.get('writesubtitles', False) or
-                self._downloader.params.get('listsubtitles')):
+        if (self.params.get('writesubtitles', False) or
+                self.params.get('listsubtitles')):
             return self._get_subtitles(*args, **kwargs)
         return {}
 
@@ -1640,8 +1641,8 @@ class InfoExtractor(object):
         return ret
 
     def extract_automatic_captions(self, *args, **kwargs):
-        if (self._downloader.params.get('writeautomaticsub', False) or
-                self._downloader.params.get('listsubtitles')):
+        if (self.params.get('writeautomaticsub', False) or
+                self.params.get('listsubtitles')):
             return self._get_automatic_captions(*args, **kwargs)
         return {}
 
@@ -1649,9 +1650,9 @@ class InfoExtractor(object):
         raise NotImplementedError('This method must be implemented by subclasses')
 
     def mark_watched(self, *args, **kwargs):
-        if (self._downloader.params.get('mark_watched', False) and
+        if (self.params.get('mark_watched', False) and
                 (self._get_login_info()[0] is not None or
-                    self._downloader.params.get('cookiefile') is not None)):
+                    self.params.get('cookiefile') is not None)):
             self._mark_watched(*args, **kwargs)
 
     def _mark_watched(self, *args, **kwargs):

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -53,6 +53,7 @@ from ..utils import (
     update_Request,
     update_url_query,
 )
+from ..params import ParamsSection
 
 
 class InfoExtractor(object):
@@ -331,7 +332,7 @@ class InfoExtractor(object):
     def set_downloader(self, downloader):
         """Sets the downloader for this IE."""
         self._downloader = downloader
-        self.params = downloader.params if downloader else {}
+        self.params = downloader.params.section(self.IE_NAME) if downloader else ParamsSection()
 
     def _real_initialize(self):
         """Real initialization process. Redefine in subclasses."""

--- a/youtube_dl/extractor/commonmistakes.py
+++ b/youtube_dl/extractor/commonmistakes.py
@@ -24,7 +24,7 @@ class CommonMistakesIE(InfoExtractor):
             'That doesn\'t make any sense. '
             'Simply remove the parameter in your command or configuration.'
         ) % url
-        if not self._downloader.params.get('verbose'):
+        if not self.params.get('verbose'):
             msg += ' Add -v to the command line to see what arguments and configuration youtube-dl got.'
         raise ExtractorError(msg, expected=True)
 

--- a/youtube_dl/extractor/daum.py
+++ b/youtube_dl/extractor/daum.py
@@ -190,7 +190,7 @@ class DaumListIE(InfoExtractor):
         query_dict = compat_parse_qs(compat_urlparse.urlparse(url).query)
         if 'clipid' in query_dict:
             clip_id = query_dict['clipid'][0]
-            if self._downloader.params.get('noplaylist'):
+            if self.params.get('noplaylist'):
                 self.to_screen('Downloading just video %s because of --no-playlist' % clip_id)
                 return self.url_result(DaumClipIE._URL_TEMPLATE % clip_id, 'DaumClip')
             else:

--- a/youtube_dl/extractor/deezer.py
+++ b/youtube_dl/extractor/deezer.py
@@ -26,7 +26,7 @@ class DeezerPlaylistIE(InfoExtractor):
     }
 
     def _real_extract(self, url):
-        if 'test' not in self._downloader.params:
+        if 'test' not in self.params:
             self._downloader.report_warning('For now, this extractor only supports the 30 second previews. Patches welcome!')
 
         mobj = re.match(self._VALID_URL, url)

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1212,7 +1212,7 @@ class GenericIE(InfoExtractor):
 
         parsed_url = compat_urlparse.urlparse(url)
         if not parsed_url.scheme:
-            default_search = self._downloader.params.get('default_search')
+            default_search = self.params.get('default_search')
             if default_search is None:
                 default_search = 'fixup_error'
 
@@ -1301,8 +1301,8 @@ class GenericIE(InfoExtractor):
             info_dict['formats'] = formats
             return info_dict
 
-        if not self._downloader.params.get('test', False) and not is_intentional:
-            force = self._downloader.params.get('force_generic_extractor', False)
+        if not self.params.get('test', False) and not is_intentional:
+            force = self.params.get('force_generic_extractor', False)
             self._downloader.report_warning(
                 '%s on generic information extractor.' % ('Forcing' if force else 'Falling back'))
 

--- a/youtube_dl/extractor/leeco.py
+++ b/youtube_dl/extractor/leeco.py
@@ -124,7 +124,7 @@ class LeIE(InfoExtractor):
         play_json_req = sanitized_Request(
             'http://api.le.com/mms/out/video/playJson?' + compat_urllib_parse_urlencode(params)
         )
-        cn_verification_proxy = self._downloader.params.get('cn_verification_proxy')
+        cn_verification_proxy = self.params.get('cn_verification_proxy')
         if cn_verification_proxy:
             play_json_req.add_header('Ytdl-request-proxy', cn_verification_proxy)
 

--- a/youtube_dl/extractor/nba.py
+++ b/youtube_dl/extractor/nba.py
@@ -113,7 +113,7 @@ class NBAIE(InfoExtractor):
     def _extract_playlist(self, orig_path, video_id, webpage):
         team = orig_path.split('/')[0]
 
-        if self._downloader.params.get('noplaylist'):
+        if self.params.get('noplaylist'):
             self.to_screen('Downloading just video because of --no-playlist')
             video_path = self._search_regex(
                 r'nbaVideoCore\.firstVideo\s*=\s*\'([^\']+)\';', webpage, 'video path')

--- a/youtube_dl/extractor/neteasemusic.py
+++ b/youtube_dl/extractor/neteasemusic.py
@@ -392,7 +392,7 @@ class NetEaseMusicProgramIE(NetEaseMusicBaseIE):
         name = info['name']
         description = info['description']
 
-        if not info['songs'] or self._downloader.params.get('noplaylist'):
+        if not info['songs'] or self.params.get('noplaylist'):
             if info['songs']:
                 self.to_screen(
                     'Downloading just the main audio %s because of --no-playlist'

--- a/youtube_dl/extractor/pluralsight.py
+++ b/youtube_dl/extractor/pluralsight.py
@@ -167,18 +167,18 @@ class PluralsightIE(PluralsightBaseIE):
         # In order to minimize the number of calls to ViewClip API and reduce
         # the probability of being throttled or banned by Pluralsight we will request
         # only single format until formats listing was explicitly requested.
-        if self._downloader.params.get('listformats', False):
+        if self.params.get('listformats', False):
             allowed_qualities = ALLOWED_QUALITIES
         else:
             def guess_allowed_qualities():
-                req_format = self._downloader.params.get('format') or 'best'
+                req_format = self.params.get('format') or 'best'
                 req_format_split = req_format.split('-', 1)
                 if len(req_format_split) > 1:
                     req_ext, req_quality = req_format_split
                     for allowed_quality in ALLOWED_QUALITIES:
                         if req_ext == allowed_quality.ext and req_quality in allowed_quality.qualities:
                             return (AllowedQuality(req_ext, (req_quality, )), )
-                req_ext = 'webm' if self._downloader.params.get('prefer_free_formats') else 'mp4'
+                req_ext = 'webm' if self.params.get('prefer_free_formats') else 'mp4'
                 return (AllowedQuality(req_ext, (best_quality, )), )
             allowed_qualities = guess_allowed_qualities()
 

--- a/youtube_dl/extractor/smotri.py
+++ b/youtube_dl/extractor/smotri.py
@@ -170,7 +170,7 @@ class SmotriIE(InfoExtractor):
             'getvideoinfo': '1',
         }
 
-        video_password = self._downloader.params.get('videopassword')
+        video_password = self.params.get('videopassword')
         if video_password:
             video_form['pass'] = hashlib.md5(video_password.encode('utf-8')).hexdigest()
 
@@ -356,7 +356,7 @@ class SmotriBroadcastIE(InfoExtractor):
 
         url = 'http://smotri.com/broadcast/view/url/?ticket=%s' % ticket
 
-        broadcast_password = self._downloader.params.get('videopassword')
+        broadcast_password = self.params.get('videopassword')
         if broadcast_password:
             url += '&pass=%s' % hashlib.md5(broadcast_password.encode('utf-8')).hexdigest()
 

--- a/youtube_dl/extractor/sohu.py
+++ b/youtube_dl/extractor/sohu.py
@@ -98,7 +98,7 @@ class SohuIE(InfoExtractor):
 
             req = sanitized_Request(base_data_url + vid_id)
 
-            cn_verification_proxy = self._downloader.params.get('cn_verification_proxy')
+            cn_verification_proxy = self.params.get('cn_verification_proxy')
             if cn_verification_proxy:
                 req.add_header('Ytdl-request-proxy', cn_verification_proxy)
 

--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -250,7 +250,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
             return mobj.group(1)
 
     def _verify_video_password(self, url, video_id, webpage):
-        password = self._downloader.params.get('videopassword')
+        password = self.params.get('videopassword')
         if password is None:
             raise ExtractorError('This video is protected by a password, use the --video-password option', expected=True)
         token, vuid = self._extract_xsrft_and_vuid(webpage)
@@ -270,7 +270,7 @@ class VimeoIE(VimeoBaseInfoExtractor):
             'Verifying the password', 'Wrong password')
 
     def _verify_player_video_password(self, url, video_id):
-        password = self._downloader.params.get('videopassword')
+        password = self.params.get('videopassword')
         if password is None:
             raise ExtractorError('This video is protected by a password, use the --video-password option')
         data = urlencode_postdata({'password': password})
@@ -567,7 +567,7 @@ class VimeoChannelIE(VimeoBaseInfoExtractor):
         if not login_form:
             return webpage
 
-        password = self._downloader.params.get('videopassword')
+        password = self.params.get('videopassword')
         if password is None:
             raise ExtractorError('This album is protected by a password, use the --video-password option', expected=True)
         fields = self._hidden_inputs(login_form)

--- a/youtube_dl/extractor/youku.py
+++ b/youtube_dl/extractor/youku.py
@@ -206,7 +206,7 @@ class YoukuIE(InfoExtractor):
             self._set_cookie('youku.com', 'xreferrer', 'http://www.youku.com')
             req = sanitized_Request(req_url, headers=headers)
 
-            cn_verification_proxy = self._downloader.params.get('cn_verification_proxy')
+            cn_verification_proxy = self.params.get('cn_verification_proxy')
             if cn_verification_proxy:
                 req.add_header('Ytdl-request-proxy', cn_verification_proxy)
 
@@ -214,7 +214,7 @@ class YoukuIE(InfoExtractor):
 
             return raw_data['data']
 
-        video_password = self._downloader.params.get('videopassword')
+        video_password = self.params.get('videopassword')
 
         # request basic data
         basic_data_url = 'http://play.youku.com/play/get.json?vid=%s&ct=12' % video_id

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -888,7 +888,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         download_note = (
             'Downloading player %s' % player_url
-            if self._downloader.params.get('verbose') else
+            if self.params.get('verbose') else
             'Downloading %s player %s' % (player_type, player_id)
         )
         if player_type == 'js':
@@ -985,7 +985,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 )
                 self._player_cache[player_id] = func
             func = self._player_cache[player_id]
-            if self._downloader.params.get('youtube_print_sig_code'):
+            if self.params.get('youtube_print_sig_code'):
                 self._print_sig_code(func, s)
             return func(s)
         except Exception as e:
@@ -1179,7 +1179,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         url, smuggled_data = unsmuggle_url(url, {})
 
         proto = (
-            'http' if self._downloader.params.get('prefer_insecure', False)
+            'http' if self.params.get('prefer_insecure', False)
             else 'https')
 
         start_time = None
@@ -1253,7 +1253,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     add_dash_mpd(video_info)
                 if args.get('livestream') == '1' or args.get('live_playback') == 1:
                     is_live = True
-            if not video_info or self._downloader.params.get('youtube_include_dash_manifest', True):
+            if not video_info or self.params.get('youtube_include_dash_manifest', True):
                 # We also try looking in get_video_info since it may contain different dashmpd
                 # URL that points to a DASH manifest with possibly different itag set (some itags
                 # are missing from DASH manifest pointed by webpage's dashmpd, some - from DASH
@@ -1331,7 +1331,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 video_description = ''
 
         if 'multifeed_metadata_list' in video_info and not smuggled_data.get('force_singlefeed', False):
-            if not self._downloader.params.get('noplaylist'):
+            if not self.params.get('noplaylist'):
                 entries = []
                 feed_ids = []
                 multifeed_metadata_list = video_info['multifeed_metadata_list'][0]
@@ -1457,7 +1457,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
         # annotations
         video_annotations = None
-        if self._downloader.params.get('writeannotations', False):
+        if self.params.get('writeannotations', False):
             video_annotations = self._extract_annotations(video_id)
 
         def _map_to_format_list(urlmap):
@@ -1532,7 +1532,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                             video_webpage, 'age gate player URL')
                         player_url = json.loads(player_url_json)
 
-                    if self._downloader.params.get('verbose'):
+                    if self.params.get('verbose'):
                         if player_url is None:
                             player_version = 'unknown'
                             player_desc = 'unknown'
@@ -1627,7 +1627,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             raise ExtractorError('no conn, hlsvp or url_encoded_fmt_stream_map information found in video info')
 
         # Look for the DASH manifest
-        if self._downloader.params.get('youtube_include_dash_manifest', True):
+        if self.params.get('youtube_include_dash_manifest', True):
             dash_mpd_fatal = True
             for mpd_url in dash_mpds:
                 dash_formats = {}
@@ -1862,7 +1862,7 @@ class YoutubePlaylistIE(YoutubePlaylistBaseInfoExtractor):
         query_dict = compat_urlparse.parse_qs(compat_urlparse.urlparse(url).query)
         if 'v' in query_dict:
             video_id = query_dict['v'][0]
-            if self._downloader.params.get('noplaylist'):
+            if self.params.get('noplaylist'):
                 self.to_screen('Downloading just video %s because of --no-playlist' % video_id)
                 return self.url_result(video_id, 'Youtube', video_id=video_id)
             else:

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -756,7 +756,7 @@ def parseOpts(overrideArguments=None):
 
         def convert_opts(opts):
             return [
-                '--' + opt + ('' if not arg else ('=' + arg))
+                ('-' if len(opt) == 1 else '--') + opt + ('' if not arg else ('=' + arg))
                 for opt, arg in opts]
         global_opts = convert_opts(parser.items('@GLOBAL@'))
         section_opts = dict((section, convert_opts(parser.items(section))) for section in parser.sections() if section != '@GLOBAL@')

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -781,15 +781,20 @@ def parseOpts(overrideArguments=None):
         userConf = _readOptions(userConfFile, None)
         userIni = _readIni(userIniFile, None)
 
-        if userConf is None:
+        if userConf is None or userIni is None:
             appdata_dir = compat_getenv('appdata')
             if appdata_dir:
-                userConf = _readOptions(
-                    os.path.join(appdata_dir, 'youtube-dl', 'config'),
-                    default=None)
+                if userConf is None:
+                    userConf = _readOptions(
+                        os.path.join(appdata_dir, 'youtube-dl', 'config'),
+                        default=None)
                 if userConf is None:
                     userConf = _readOptions(
                         os.path.join(appdata_dir, 'youtube-dl', 'config.txt'),
+                        default=None)
+                if userIni is None:
+                    userIni = _readIni(
+                        os.path.join(appdata_dir, 'youtube-dl', 'config.ini'),
                         default=None)
 
         if userConf is None:
@@ -799,6 +804,15 @@ def parseOpts(overrideArguments=None):
         if userConf is None:
             userConf = _readOptions(
                 os.path.join(compat_expanduser('~'), 'youtube-dl.conf.txt'),
+                default=None)
+
+        if userIni is None:
+            userIni = _readIni(
+                os.path.join(compat_expanduser('~'), 'youtube-dl.ini'),
+                default=None)
+        if userIni is None:
+            userIni = _readIni(
+                os.path.join(compat_expanduser('~'), 'youtube-dl.ini.txt'),
                 default=None)
 
         if userConf is None:

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -854,6 +854,9 @@ def parseOpts(overrideArguments=None):
             user_sections = {}
         else:
             system_conf = compat_conf(_readOptions('/etc/youtube-dl.conf'))
+            system_global, system_sections = _readIni('/etc/youtube-dl.ini')
+            system_conf.extend(system_global)
+
             if '--ignore-config' in system_conf:
                 user_conf = []
                 user_sections = {}
@@ -865,6 +868,8 @@ def parseOpts(overrideArguments=None):
         opts, args = parser.parse_args(argv)
         if opts.verbose:
             write_string('[debug] System config: ' + repr(_hide_login_info(system_conf)) + '\n')
+            for section, section_args in system_sections.items():
+                write_string('[debug] System config for "' + section + '": ' + repr(_hide_login_info(section_args)) + '\n')
             write_string('[debug] User config: ' + repr(_hide_login_info(user_conf)) + '\n')
             for section, section_args in user_sections.items():
                 write_string('[debug] User config for "' + section + '": ' + repr(_hide_login_info(section_args)) + '\n')
@@ -873,6 +878,7 @@ def parseOpts(overrideArguments=None):
         def build_section_args(*sections):
             res = system_conf + user_conf
             for section in sections:
+                res.extend(system_sections.get(section, []))
                 res.extend(user_sections.get(section, []))
             res.extend(command_line_conf)
             return res

--- a/youtube_dl/params.py
+++ b/youtube_dl/params.py
@@ -41,3 +41,10 @@ class ParamsSection(object):
             return self[key]
         except KeyError:
             return default
+
+    @property
+    def sections(self):
+        return self.parent.sections
+
+    def section(self, section):
+        return ParamsSection(self.parent.sections.get(section, {}), self)

--- a/youtube_dl/params.py
+++ b/youtube_dl/params.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals
+
+
+class Params(dict):
+    """Params class
+
+    The params class holds the parameters for YoutubeDL objects, in its
+    simplest form it's initialized with a dictionary with the parameters. To
+    override some parameter in an info extractor a dictionary can be passed as
+    the second argument, its keys must match the IE_NAME properties of the
+    extractors.
+    """
+    def __init__(self, params, sections=None):
+        super(Params, self).__init__(params)
+        if sections is None:
+            sections = {}
+        self.sections = sections
+
+    def section(self, section):
+        """Return the params for the specified section"""
+        return ParamsSection(self.sections.get(section, {}), self)
+
+
+class ParamsSection(object):
+    def __init__(self, main=None, parent=None):
+        if main is None:
+            main = {}
+        if parent is None:
+            parent = Params({})
+        self.main = main
+        self.parent = parent
+
+    def __getitem__(self, key):
+        if key in self.main:
+            return self.main[key]
+        else:
+            return self.parent[key]
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default


### PR DESCRIPTION
This is for #3101.

Still to be done:
- [x] Add filenames for Windows
- [x] Read a global configuration file, porbably `/etc/youtube-dl.ini`
- [x] Postprocessors support (-x, --embed-sub and others).
- [x] Add documentation to the manual
- [ ] Deprecate old config files and add migration guide?

Example config:

``` ini
extract-audio=

[youtube]
audio-format=mp3

[youtube:playlist]
output=%(playlist)s/%(title)s.%(ext)s
```

Options that accept no arguments must still be written as `write-thumbnail=` because the  `allow_no_value`  option for `ConfigParser`  is not supported in python 2.6.

There's probably some parameter that is still global which should be local, I'll try to look for them, but point them out if you find one.
