### PR TITLE
[funimation] Extract more format info from site

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -228,6 +228,7 @@
  - **freespeech.org**
  - **FreeVideo**
  - **Funimation**
+ - **funimation:playlist**
  - **FunnyOrDie**
  - **GameInformer**
  - **Gamekings**

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -258,7 +258,10 @@ from .francetv import (
 from .freesound import FreesoundIE
 from .freespeech import FreespeechIE
 from .freevideo import FreeVideoIE
-from .funimation import FunimationIE
+from .funimation import (
+    FunimationIE,
+    FunimationShowPlaylistIE,
+)
 from .funnyordie import FunnyOrDieIE
 from .gameinformer import GameInformerIE
 from .gamekings import GamekingsIE


### PR DESCRIPTION
Use the JSON playlist information provided by Funimation to extract more
attributes about the stream formats, such as season and episode
number. Also fixed the returned video information to use the 'series'
key rather than the 'artist' key, the latter of which is meant for
albums.

Also, determine whether the user supplied the subtitle or English dub
URL based on the query parameters, and set the language preference based
on that and the site-provided stream info.
