### PR TITLE
add libsecret support

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ which means you can modify it, redistribute it or use it however you like.
 ## Authentication Options:
     -u, --username USERNAME          Login with this account ID
     -p, --password PASSWORD          Account password. If this option is left
-                                     out, youtube-dl will ask interactively.
+                                     out, youtube-dl will query libsecret, if
+                                     available, or ask interactively.
     -2, --twofactor TWOFACTOR        Two-factor auth code
     -n, --netrc                      Use .netrc authentication data
     --video-password PASSWORD        Video password (vimeo, smotri, youku)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -129,7 +129,15 @@ def _real_main(argv=None):
     if opts.usetitle and opts.useid:
         parser.error('using title conflicts with using video ID')
     if opts.username is not None and opts.password is None:
-        opts.password = compat_getpass('Type account password and press [Return]: ')
+        try:
+            from gi import require_version
+            require_version('Secret', '1')
+            from gi.repository import Secret
+            opts.password = Secret.Service.get_sync(
+                    Secret.ServiceFlags.NONE, None).lookup_sync(None, {
+                        "username": opts.username}).get_text()
+        except:
+            opts.password = compat_getpass('Type account password and press [Return]: ')
     if opts.ratelimit is not None:
         numeric_limit = FileDownloader.parse_bytes(opts.ratelimit)
         if numeric_limit is None:


### PR DESCRIPTION
Instead of asking a user to type the password, libsecret can be asked for a password corresponding to a username, when present.

Several web browsers, most notably Firefox and Chrome, support storing passwords via libsecret out of the box or via Add-Ons. When these facilities are in use, the password is most probably already available.
