### PR TITLE
Apply fixups to individual streams (fixes #10644/#9913)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1762,11 +1762,14 @@ class YoutubeDL(object):
                                 new_info['__postprocessors'] = []
                                 self.add_fixup_post_processors(fname, new_info, protocol_only=True)
 
+                                _pps = self._pps
+                                self._pps = []
                                 try:
                                     self.post_process(fname, new_info)
                                 except (PostProcessingError) as err:
                                     self.report_error('fixup postprocessing: %s' % str(err))
                                     success = False
+                                self._pps = _pps
 
                         info_dict['__postprocessors'] = postprocessors
                         info_dict['__files_to_merge'] = downloaded


### PR DESCRIPTION
This isn't very pretty as it calls post_process multiple times, so _pps needs to be cleared temporarily to avoid duplicate processing. Maybe someone has a more elegant solution?

In the case where `info_dict['protocol'] == 'm3u8'` in `process_info`, FFmpegFixupM3u8PP may be applied multiple times: once for each stream, and once for the whole file. I don't know if it can happen, or if it's a problem if it happens. Perhaps we don't need to apply it to the whole file.

Note that in the example from #10644, `new_info['protocol'] == 'm3u8'` for the audio stream but `info_dict['protocol']` is not set, so that problem does not appear.
