### PR TITLE
By default, new extractors should match hostnames case-insensitively, c.f. #10882

### DIFF
--- a/README.md
+++ b/README.md
@@ -954,7 +954,7 @@ After you have ensured this site is distributing it's content legally, you can f
 
 
     class YourExtractorIE(InfoExtractor):
-        _VALID_URL = r'https?://(?:www\.)?yourextractor\.com/watch/(?P<id>[0-9]+)'
+        _VALID_URL = r'(?i)https?://(?:www\.)?yourextractor\.com/watch/(?P<id>[0-9]+)'
         _TEST = {
             'url': 'http://yourextractor.com/watch/42',
             'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -327,7 +327,7 @@ class InfoExtractor(object):
         # we have cached the regexp for *this* class, whereas getattr would also
         # match the superclass
         if '_VALID_URL_RE' not in cls.__dict__:
-            cls._VALID_URL_RE = re.compile(cls._VALID_URL, flags=re.IGNORECASE)
+            cls._VALID_URL_RE = re.compile(cls._VALID_URL)
         return cls._VALID_URL_RE.match(url) is not None
 
     @classmethod

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -327,7 +327,7 @@ class InfoExtractor(object):
         # we have cached the regexp for *this* class, whereas getattr would also
         # match the superclass
         if '_VALID_URL_RE' not in cls.__dict__:
-            cls._VALID_URL_RE = re.compile(cls._VALID_URL)
+            cls._VALID_URL_RE = re.compile(cls._VALID_URL, flags=re.IGNORECASE)
         return cls._VALID_URL_RE.match(url) is not None
 
     @classmethod


### PR DESCRIPTION
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] Bug fix

---

Use `(?i)` in the sample extractor in README.md (and CONTRIBUTING.md) to encourage new extractors to match their domain names case-insensitively. See #10882 for discussion.
