### PR TITLE
[adobepass] Allow new Comcast auto login message

### DIFF
--- a/youtube_dl/extractor/adobepass.py
+++ b/youtube_dl/extractor/adobepass.py
@@ -1375,13 +1375,20 @@ class AdobePassIE(InfoExtractor):
                     # are on Comcast's network.
                     provider_redirect_page, urlh = provider_redirect_page_res
                     # Check for Comcast auto login
-                    if 'automatically signing you in' in provider_redirect_page:
+                    if 'automatically signed in' in provider_redirect_page:
                         oauth_redirect_url = self._html_search_regex(
-                            r'window\.location\s*=\s*[\'"]([^\'"]+)',
-                            provider_redirect_page, 'oauth redirect')
+                            r'continue:\s*[\'"]([^\'"]+)',
+                            provider_redirect_page, 'oauth redirect [1]')
                         # Just need to process the request. No useful data comes back
                         self._download_webpage(
-                            oauth_redirect_url, video_id, 'Confirming auto login')
+                            oauth_redirect_url, video_id, 'Confirming auto login [1]')
+                    elif 'automatically signing you in' in provider_redirect_page:
+                        oauth_redirect_url = self._html_search_regex(
+                            r'window\.location\s*=\s*[\'"]([^\'"]+)',
+                            provider_redirect_page, 'oauth redirect [2]')
+                        # Just need to process the request. No useful data comes back
+                        self._download_webpage(
+                            oauth_redirect_url, video_id, 'Confirming auto login [2]')
                     else:
                         if '<form name="signin"' in provider_redirect_page:
                             # already have the form, just fill it


### PR DESCRIPTION
## Please follow the guide below
- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your _pull request_ (like that [x])
- Use _Preview_ tab to see how your _pull request_ will actually look like

---
### Before submitting a _pull request_ make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)
### What is the purpose of your _pull request_?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---
### Description of your _pull request_ and other information

Comcast changed the webpage for the auto login process. There is new text for the message notifying you that you have been logged in and a there is a new way to specify the redirection to the confirmation page. 

I don't know if Comcast rolls out changes like this nationally or region by region, therefore I left the old code there as a fallback. 

@sclower I would appreciate if you could try this version since the core team has no way to test the Comcast-specific parts.
