### PR TITLE
Bandwidth throttling mitigation

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -325,6 +325,7 @@ def _real_main(argv=None):
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,
         'ratelimit': opts.ratelimit,
+        'avoid_throttling': opts.avoid_throttling,
         'nooverwrites': opts.nooverwrites,
         'retries': opts.retries,
         'fragment_retries': opts.fragment_retries,

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -40,7 +40,7 @@ class HttpFD(FileDownloader):
                     "(peak rate = %.2fKiB/s, block rate = %.2fKiB/s, downloaded %.0fKiB before throttling)") % (
                     peak_rate / 1024, block_rate / 1024, (byte_counter - last_range_start) / 1024))
             request.add_header('Range', 'bytes=%d-' % byte_counter)
-            request = sanitized_Request(request.full_url, None, request.headers)
+            request = sanitized_Request(request.get_full_url(), None, request.headers)
             try:
                 new_data = self.ydl.urlopen(request)
                 throttled = True

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -233,7 +233,11 @@ class HttpFD(FileDownloader):
             block_start = time.time()
             data_block = data.read(block_size if not is_test else min(block_size, data_len - byte_counter))
             byte_counter += len(data_block)
-            block_rate = block_size / (time.time() - block_start)
+            block_time = time.time() - block_start
+            if block_time != 0:
+                block_rate = block_size / block_time
+            else:
+                block_rate = float('+inf')
 
             # exit loop when download is finished
             if len(data_block) == 0:

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -18,6 +18,7 @@ from ..utils import (
     XAttrUnavailableError,
 )
 
+
 class HttpFD(FileDownloader):
     def report_will_throttle(self):
         self.report_warning(("\r[download] This website does not support Content-Range header, "

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -227,7 +227,7 @@ class HttpFD(FileDownloader):
         now = None  # needed for slow_down() in the first loop run
         before = start  # start measuring
         peak_rate = 0
-        throttling_start = time.time()
+        throttling_start = None
         throttling_threshold = None
         throttling_start_size = 0
         while True:

--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -285,7 +285,7 @@ class HttpFD(FileDownloader):
             else:
                 eta = self.calc_eta(start, time.time(), data_len - resume_len, byte_counter - resume_len)
             
-            if self.avoid_throttling and speed and speed > peak_rate and time.time() - start > 1:
+            if self.avoid_throttling and speed and speed > peak_rate and time.time() - start > 1 and block_size >= 65536:
                 peak_rate = speed
 
             # Initial throttling detection mechanism.
@@ -307,7 +307,8 @@ class HttpFD(FileDownloader):
                     if throttling_rate > peak_rate * 0.7:
                         if self.params.get('verbose', False):
                             self.to_screen(("[throttling] Wasn't a throttle, temporary network hiccup "
-                                "(current rate = %.3f, peak rate = %.3f.") % (throttling_rate, peak_rate))
+                                "(current rate = %.2fKiB/s, peak rate = %.2fKiB/s.") % (
+                                throttling_rate / 1024, peak_rate / 1024))
                         throttling_start = None
                         throttling_start_size = 0
                     else:

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -435,6 +435,11 @@ def parseOpts(overrideArguments=None):
         dest='ratelimit', metavar='RATE',
         help='Maximum download rate in bytes per second (e.g. 50K or 4.2M)')
     downloader.add_option(
+        '--avoid-throttling',
+        action="store_true", dest='avoid_throttling', 
+        help='Make a new request when bandwidth throttling is detected. Content-Range header must be supported',
+        default=False)
+    downloader.add_option(
         '-R', '--retries',
         dest='retries', metavar='RETRIES', default=10,
         help='Number of retries (default is %default), or "infinite".')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

#6923 
Pretty much self explanatory.
Some websites only let you download a little bit at maximum speed and then slow it down to some value (may be media bitrate, may be just an arbitrary limit they decided upon)
If this website also supports Range header, a new request can be made to get full speed again. Repeat until ready.

In a nutshell, that's all this code does: monitors the overall (to get the peak) and separate block transfer rates and makes a new request when the block rate falls below a certain threshold.
And a new option is added, of course.
A few unnecessary reconnections here and there, but mostly stable chunks are downloaded before each new request is made, so I'm rather pleased with it.

Important notes:
1. When disabled, downloader behaves exactly as before (other than a few excessive calcuations, perhaps), so it _should_ be safe to replace the original downloader with it (instead of a making a separate one).
2. I can't (easily) simulate various network conditions, so more testing is required to see if the strategies used are actually good and robust enough.
3. Tested mainly in clear network conditions and on two websites only, with high and not so high peak rates (5-6MiB/s and ~1.2MiB/s) and similar throttling rates (50-100KiB/s), so all of the constant values and dynamic formulae, while thought out, are approximate and obtained partially empirically to maximaize the overall mean download rate on my computer. ymmv, as always. Any suggestions are welcomed, testing of various different websites is greatly appreciated,
4. Mean download rate of around 50-80% of the reported peak can be achieved,
5. It behaves quite well in absence of throttling, only a few spurious reconnections might occur due to temporary network issues. Not with a bad internet, however.






Boring explanations of the strategies, can be easily seen in code but just so that it is documented:
First of all, no way to tell if throttling started or your network became bad (or downloading lots of porn in parallel, for instance), so if you start a second network-intesive task, well, things will break.
The main thing with throttling is the block size. Too small — slow overall download and/or unreliable instantaneous rate measurements. Too large — you'll become old before throttling is detected. 512KiB seemed like a reasonable enough compromise to set as a starting point.
1. First second of the download is ignored, nothing can happen there,
2. Peak rate is only set if block size is 64KiB or more, because if it's less, block rate measurements will be  _very_ inaccurate (orders of magnitute) and this also means your connections is not probably not good enough to suffer from throttling,
3. When peak rate is set and current block rate falls below 70% of that peak, timer starts,
4. After each consequent block with rate below 70%, a check is made to see if 3 seconds have passed, at which point it is assessed if the download rate starting from time recorded in point 2 is still below 70%. This helps deal with false positives when those blocks are a good amount of time apart from each other,
5. If throttling, the block size is set to the power of two nearest to the download rate during throttling, to download as little as possible during each subsequent throttle (i.e. detect it fast),
6. Threshold is set to the first quarter between throttling and peak rates (e.g. 400K peak and 50K throttling wil result in a 137.5K, or ~0.35 threshold) to cactch it early (e.g. if it was enabled in the middle of the block). However, unless you have shitty internet, throttling rate will be almost negligible, leading to the threshold of ~0.25-7
7. When this threshold is acquired, after each block a check is made to see if the current block rate fell below this threshold, and a new request is issued if so, replacing the `data` variable.
Voila, grab some pizza and enjoy the thing you've just downloaded!