### PR TITLE
Updated Wimp.com extractor to work with newer jPlayer code using data…

### DIFF
--- a/youtube_dl/extractor/wimp.py
+++ b/youtube_dl/extractor/wimp.py
@@ -12,22 +12,28 @@ class WimpIE(JWPlatformBaseIE):
         'info_dict': {
             'id': 'maru-is-exhausted',
             'ext': 'mp4',
-            'title': 'Maru is exhausted.',
+            'title': 'Maru Is Exhausted.',
             'description': 'md5:57e099e857c0a4ea312542b684a869b8',
         }
     }, {
         'url': 'http://www.wimp.com/clowncar/',
-        'md5': '5c31ad862a90dc5b1f023956faec13fe',
+        'md5': '4e2986c793694b55b37cf92521d12bb4',
         'info_dict': {
-            'id': 'cG4CEr2aiSg',
-            'ext': 'webm',
-            'title': 'Basset hound clown car...incredible!',
-            'description': '5 of my Bassets crawled in this dog loo! www.bellinghambassets.com\n\nFor licensing/usage please contact: licensing(at)jukinmediadotcom',
-            'upload_date': '20140303',
-            'uploader': 'Gretchen Hoey',
-            'uploader_id': 'gretchenandjeff1',
+            'id': 'clowncar',
+            'ext': 'mp4',
+            'title': 'It\'s Like A Clown Car.',
+            'description': 'Gretchen Hoey raises Basset Hounds and on this particular day, she catches a few of them snuggling together in one doghouse. After one of them notices her, they all begin to funnel out of the doghouse like clowns in a clown car to greet her.'
         },
         'add_ie': ['Youtube'],
+    }, {
+        'url': 'http://www.wimp.com/bird-does-funny-march/',
+        'md5': 'f2833774cf4d680849989a1cf92a06cc',
+        'info_dict': {
+            'id': 'bird-does-funny-march',
+            'ext': 'mp4',
+            'title': 'Bird Does Funny March',
+            'description': 'This bird\'s walk might look pretty silly, but as soon as you add some military marching music over it, it becomes the most regal sight you\'ve ever seen.\r\n'
+        }
     }]
 
     def _real_extract(self, url):
@@ -45,13 +51,23 @@ class WimpIE(JWPlatformBaseIE):
                 'ie_key': YoutubeIE.ie_key(),
             }
 
-        info_dict = self._extract_jwplayer_data(
-            webpage, video_id, require_title=False)
+        url = self._search_regex(r'class=\'oyt-container .*? data-src=\'(.*?)\'', webpage, 'Video URL', default=None, fatal=False)
 
-        info_dict.update({
-            'id': video_id,
-            'title': self._og_search_title(webpage),
-            'description': self._og_search_description(webpage),
-        })
+        if url:
+            info_dict = {
+                'id': video_id,
+                'title': self._og_search_title(webpage),
+                'description': self._og_search_description(webpage),
+                'url': url
+            }
+        else:
+            info_dict = self._extract_jwplayer_data(
+                webpage, video_id, require_title=False)
+
+            info_dict.update({
+                'id': video_id,
+                'title': self._og_search_title(webpage),
+                'description': self._og_search_description(webpage),
+            })
 
         return info_dict


### PR DESCRIPTION
…-dash values in the video div tag

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x ] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The Wimp.com extractor in master is broken because Wimp.com has changed how it uploads videos and the code on its site.

The old version had the jwplayer values in JavaScript, the new code stores the values in HTML5 data attributes of the video player div. 

It seems that they have also re-encoded some videos and updated titles and descriptions on some older videos. 

This pull request: 

1) Fixes the existing tests to work again. 
2) Adds detection of the new way they're embedding videos.
3) Adds a new test for the new embed method case.
4) Falls back on the old/existing method of downloading videos if the new method is not detected. 

I've tried to follow the youtube-dl coding standards as I understand them and the flake8 doesn't complain. 
--
Michael / stuporglue