### PR TITLE
Makefile: Add missing uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,18 @@ install: youtube-dl youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtu
 	install -d $(DESTDIR)$(SYSCONFDIR)/fish/completions
 	install -m 644 youtube-dl.fish $(DESTDIR)$(SYSCONFDIR)/fish/completions/youtube-dl.fish
 
+uninstall:
+	rm -v -f $(DESTDIR)$(BINDIR)/youtube-dl
+	rmdir -p $(DESTDIR)$(BINDIR) || true
+	rm -v -f $(DESTDIR)$(MANDIR)/man1/youtube-dl.1
+	rmdir -p $(DESTDIR)$(MANDIR)/man1 || true
+	rm -v -f $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/youtube-dl
+	rmdir -p $(DESTDIR)$(SYSCONFDIR)/bash_completion.d || true
+	rm -v -f $(DESTDIR)$(SHAREDIR)/zsh/site-functions/_youtube-dl/youtube-dl.zsh
+	rmdir -p $(DESTDIR)$(SHAREDIR)/zsh/site-functions/_youtube-dl || true
+	rm -v -f $(DESTDIR)$(SYSCONFDIR)/fish/completions/youtube-dl.fish
+	rmdir -p $(DESTDIR)$(SYSCONFDIR)/fish/completions || true
+
 codetest:
 	flake8 .
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This commit adds the uninstall Makefile target, which reverts the effect of install.