### PR TITLE
[generic] misc. fixes (lazyYT test, first_bytes whitespace)

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -902,12 +902,13 @@ class GenericIE(InfoExtractor):
         },
         # LazyYT
         {
-            'url': 'http://discourse.ubuntu.com/t/unity-8-desktop-mode-windows-on-mir/1986',
+            'url': 'https://skiplagged.com/',
             'info_dict': {
-                'id': '1986',
-                'title': 'Unity 8 desktop-mode windows on Mir! - Ubuntu Discourse',
+                'id': 'skiplagged',
+                'title': 'Skiplagged: The smart way to find cheap flights',
             },
-            'playlist_mincount': 2,
+            'playlist_mincount': 1,
+            'add_ie': ['Youtube'],
         },
         # Cinchcast embed
         {

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1759,7 +1759,7 @@ class GenericIE(InfoExtractor):
             self._sort_formats(info_dict['formats'])
             return info_dict
 
-        if re.match(r'^\s+$', first_bytes):
+        if re.match(r'^\s+$', first_bytes.decode('utf-8', 'replace')):
             self._downloader.report_warning(
                 'First block is just whitespace? Continuing...')
         elif not is_html(first_bytes):

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -1759,9 +1759,12 @@ class GenericIE(InfoExtractor):
             self._sort_formats(info_dict['formats'])
             return info_dict
 
-        # Maybe it's a direct link to a video?
-        # Be careful not to download the whole thing!
-        if not is_html(first_bytes):
+        if re.match(r'^\s+$', first_bytes):
+            self._downloader.report_warning(
+                'First block is just whitespace? Continuing...')
+        elif not is_html(first_bytes):
+            # Maybe it's a direct link to a video?
+            # Be careful not to download the whole thing!
             self._downloader.report_warning(
                 'URL could be a direct video link, returning it as such.')
             info_dict.update({


### PR DESCRIPTION
I happened to have b68a812ea839e44148516a34a15193189e58ba77 open recently, and wound up at the English version, i.e. http://www8.hp.com/us/en/solutions/security/thewolf.html?jumpid=va_87trme41uf# via http://www.hp.com, and noted it doesn't work with Youtube-DL.

Unlike the Chinese version, nothing to do with Brightcove.
#12501 is one problem, filed separately (not fixed here).

Here are two fixes for other issues I found, first 00bc75c, that this webpage starts with 512 bytes of whitespace so it fails the `is_html(first_bytes)` check:
```
(Pdb) p first_bytes
'\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n                                            \r\n                                            \r\n                                            \r\n                                            \r\n                                                          \r\n                                            \r\n                                            \r\n\r\n\r\n'
(Pdb) 
```

and also  	6206194, that it uses a pattern similar to LazyYT, whose test is broken because the domain is gone:

```
pb3:extractor jhawk$ host -t a  discourse.ubuntu.com
discourse.ubuntu.com is an alias for ubuntu.bydiscourse.com.
pb3:extractor jhawk$ host -t a  ubuntu.bydiscourse.com.
ubuntu.bydiscourse.com has no A record
```

Of course, after that, Youtube-DL still doesn't work. I'm not sure how much we care, since it's a YouTube embed, so presumably users will know they can click on the YouTube button and find the YouTube URL. But here's the mechanism:

```html
    <div  class="youtube-popup no-default-transition" 
          data-playlist="PLoMwRIIUViGQ48XKzXNxTjvICAiZTLv8I" 
          data-full-video-id="U3QXMMV-Srs">
      <div id="play-list"></div>
      <iframe id="full-video" frameborder="0" allowfullscreen="1" title="YouTube video player" width="640" height="360"></iframe>
      <div class="close-popup"></div>
    </div>
```

which is quite similar to the LazyYT pattern:
```html
<div class="lazyYT"
  data-youtube-id="y9r6qp8UBQc"
  data-ratio="16:9">
    What is Skiplagged?
</div>
```

but it doesn't seem to be used on other sites that I could find, so perhaps it doesn't meet the standards for inclusion. Not sure.