### PR TITLE
[external] Print executable name  (e.g. avconv) instead of classname

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -51,8 +51,9 @@ class ExternalFD(FileDownloader):
     def get_basename(cls):
         return cls.__name__[:-2].lower()
 
-    def get_execname(self):
-        return self.__class__.get_basename()
+    @classmethod
+    def get_execname(cls):
+        return cls.get_basename()
 
     @property
     def exe(self):
@@ -195,19 +196,19 @@ class FFmpegFD(ExternalFD):
     def available(cls):
         return FFmpegPostProcessor().available
 
+    @classmethod
     def get_execname(self):
-        return self.execname
+        return FFmpegPostProcessor().executable
 
     def _call_downloader(self, tmpfilename, info_dict):
         url = info_dict['url']
         ffpp = FFmpegPostProcessor(downloader=self)
-        self.execname = ffpp.executable
         if not ffpp.available:
             self.report_error('m3u8 download detected but ffmpeg or avconv could not be found. Please install one.')
             return False
         ffpp.check_version()
 
-        args = [self.execname, '-y']
+        args = [ffpp.executable, '-y']
 
         seekable = info_dict.get('_seekable')
         if seekable is not None:


### PR DESCRIPTION
It's confusing that youtube-dl diagnostics will print `ffmpeg` when the actual downloader is `avconv`. This confused me in evalauting #12499, where it ended with:

`ERROR: ffmpeg exited with code 1`

but of course `avconv` was being run:
`[debug] avconv command line: avconv -y -headers ...`

So let's try to make this better.

---
Separate out the concept of the executable used by an ExternalFD
downloader and the name of the class. I'm not entirely sure why we
care about the name of the class at all, but it's used outside of
classes to initialize `_BY_NAME()` and soforth, so it seems impractical
to just change `get_basename() `to return the executable name

So instead, call `get_execname()` not `get_basename()`.

Default `get_execname()` to calling `get_basename()`, but override it in
`FFmpegFD`, where it returns `self.execname`, which is set in
`_call_downloader()`.

Perhaps there is a less complicated way to achieve this goal?

---
