### PR TITLE
[Generic] Check iframes for known file extensions

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -21,6 +21,7 @@ from ..utils import (
     HEADRequest,
     is_html,
     js_to_json,
+    KNOWN_EXTENSIONS,
     orderedSet,
     sanitized_Request,
     smuggle_url,
@@ -1881,6 +1882,14 @@ class GenericIE(InfoExtractor):
 
         video_description = self._og_search_description(webpage, default=None)
         video_thumbnail = self._og_search_thumbnail(webpage, default=None)
+
+        # Maybe the video is actually in an iframe we don't have special knowledge of.
+        # Let's look for direct links in file extensions.
+        matches = re.findall(
+            r'<iframe[^>]+?src="([^"]+\.(?:%s)(?:\?[^"]*)?)"' % '|'.join(KNOWN_EXTENSIONS),
+            webpage)
+        if matches:
+            return self.playlist_from_matches(matches, video_id, video_title)
 
         # Look for Brightcove Legacy Studio embeds
         bc_urls = BrightcoveLegacyIE._extract_brightcove_urls(webpage)


### PR DESCRIPTION
As discussed in  #12692, this is the easy option, 1.:

> 1. Check file extension of iframes for ../utils/KNOWN_EXTENSIONS. (This could happen fairly early in GenericIE)

Since Sergey said

> By default only 1 can be applied.

_Unfortunately_, between then and now(*), the test case I had updated to point to a Youtube video, and I don't have a test case for the direct iframe link. I searched https://publicwww.com/ and didn't come up with anything. I guess they're not common.

So I don't know if this is worth committing without a test. It works against my local webserver with the iframe from yesterday inserted:

```
<iframe height="360" width="640"
      src="https://cdn-e2.streamable.com/video/mp4/wfatk.mp4?token=1492919903_c3707bc86745b37c149c2be0da56b98a275b2b74"
    >
    </iframe>
```
Or I could add a test to `test_InfoExtractor.py`?

---
(*) I suppose maybe it's fortunate that it happened so quickly, rather than happening next week after this was committed and breaking the test case while no one was watching.