### PR TITLE
Various CondeNast fixes

### DIFF
--- a/youtube_dl/extractor/condenast.py
+++ b/youtube_dl/extractor/condenast.py
@@ -119,7 +119,7 @@ class CondeNastIE(InfoExtractor):
     def _extract_video_params(self, webpage):
         query = {}
         params = self._search_regex(
-            r'(?s)var params = {(.+?)}[;,]', webpage, 'player params', default=None)
+            r'(?s)\bparams = {(.+?)}[;,]', webpage, 'player params', default=None)
         if params:
             query.update({
                 'videoId': self._search_regex(r'videoId: [\'"](.+?)[\'"]', params, 'video id'),

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -865,13 +865,14 @@ class GenericIE(InfoExtractor):
             'url': 'http://www.newyorker.com/online/blogs/newsdesk/2014/01/always-never-nuclear-command-and-control.html',
             'info_dict': {
                 'id': 'always-never',
-                'title': 'Always / Never - The New Yorker',
+                'title': 'Always / Never',
             },
             'playlist_count': 3,
             'params': {
                 'extract_flat': False,
                 'skip_download': True,
-            }
+            },
+            'add_ie': ['BrightcoveLegacy'],
         },
         # MLB embed
         {

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -740,7 +740,11 @@ class GenericIE(InfoExtractor):
                 'id': '53501be369702d3275860000',
                 'ext': 'mp4',
                 'title': 'Honda’s  New Asimo Robot Is More Human Than Ever',
-            }
+                'upload_date': '99990101',
+                'uploader': 'wired',
+                'timestamp': 253370764800,
+            },
+            'add_ie': ['CondeNast'],
         },
         # Dailymotion embed
         {

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -732,7 +732,7 @@ class GenericIE(InfoExtractor):
                 'Forbidden'
             ]
         },
-        # Condé Nast embed
+        # Condé Nast iframe embed
         {
             'url': 'http://www.wired.com/2014/04/honda-asimo/',
             'md5': 'ba0dfe966fa007657bd1443ee672db0f',
@@ -743,6 +743,20 @@ class GenericIE(InfoExtractor):
                 'upload_date': '99990101',
                 'uploader': 'wired',
                 'timestamp': 253370764800,
+            },
+            'add_ie': ['CondeNast'],
+        },
+        # Condé Nast embed <div data-url="...">
+        {
+            'url': 'http://www.vanityfair.com/hollywood/2017/04/chris-evans-gifted-movie-captain-america-video',
+            'md5': '07e1618750fa14b573c5d1bf6ff01429',
+            'info_dict': {
+                'id': '58e54e8dfd2e615252000010',
+                'ext': 'mp4',
+                'timestamp': 1491472800,
+                'uploader': 'vanityfair',
+                'title': 'Chris Evans Answers Kids’ Questions About The Universe',
+                'upload_date': '20170406',
             },
             'add_ie': ['CondeNast'],
         },
@@ -2403,7 +2417,7 @@ class GenericIE(InfoExtractor):
             return self.url_result(mobj.group('url'), 'MLB')
 
         mobj = re.search(
-            r'<(?:iframe|script)[^>]+?src=(["\'])(?P<url>%s)\1' % CondeNastIE.EMBED_URL,
+            r'<(?:iframe|script|div)[^>]+?(?:src|data-url)=(["\'])(?P<url>%s)\1' % CondeNastIE.EMBED_URL,
             webpage)
         if mobj is not None:
             return self.url_result(self._proto_relative_url(mobj.group('url'), scheme='http:'), 'CondeNast')


### PR DESCRIPTION
After having my test case for #12697 disappear on me, naturally I looked around http://www.vanityfair.com for another example. I did not find one, but I did find other stuff that doesn't work. (...)

So, this PR fixes 2 existing test cases in `CondeNastIE`, fixes some test metadata in `GenericIE`, and adds support for embeds of the form:

```
<div
  class="embed block cneembed"
  data-url="//player.cnevids.com/embedjs/58e54e8dfd2e615252000010/51cc9f86bb8f554e4e000002.js?autoplay=1&amp;muted=1"
>
```

In `GenericIE`, which is just a trivial change to the regexp that already handles iframes and `<script>` embeds there.

Note that in refactoring e70b856e6e11b724f7dfbaca52fadf360b26fed4 it seems there's a case not covered by a test that was added by @remitamine last year. It's marked `# xxx`, but maybe I should remove that comment.
