### PR TITLE
[novamov] fix for all included provider (WholeCloud, NowVideo, BitVid, CloudTime, AuroraVid)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -165,7 +165,10 @@ from .ccc import CCCIE
 from .ccma import CCMAIE
 from .cctv import CCTVIE
 from .cda import CDAIE
-from .ceskatelevize import CeskaTelevizeIE
+from .ceskatelevize import (
+    CeskaTelevizeIE,
+    CeskaTelevizePoradyIE,
+)
 from .channel9 import Channel9IE
 from .charlierose import CharlieRoseIE
 from .chaturbate import ChaturbateIE
@@ -538,6 +541,7 @@ from .mangomolo import (
 )
 from .matchtv import MatchTVIE
 from .mdr import MDRIE
+from .medici import MediciIE
 from .meipai import MeipaiIE
 from .melonvod import MelonVODIE
 from .meta import METAIE
@@ -980,6 +984,7 @@ from .theplatform import (
 from .thescene import TheSceneIE
 from .thesixtyone import TheSixtyOneIE
 from .thestar import TheStarIE
+from .thesun import TheSunIE
 from .theweatherchannel import TheWeatherChannelIE
 from .thisamericanlife import ThisAmericanLifeIE
 from .thisav import ThisAVIE

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -165,10 +165,7 @@ from .ccc import CCCIE
 from .ccma import CCMAIE
 from .cctv import CCTVIE
 from .cda import CDAIE
-from .ceskatelevize import (
-    CeskaTelevizeIE,
-    CeskaTelevizePoradyIE,
-)
+from .ceskatelevize import CeskaTelevizeIE
 from .channel9 import Channel9IE
 from .charlierose import CharlieRoseIE
 from .chaturbate import ChaturbateIE
@@ -541,7 +538,6 @@ from .mangomolo import (
 )
 from .matchtv import MatchTVIE
 from .mdr import MDRIE
-from .medici import MediciIE
 from .meipai import MeipaiIE
 from .melonvod import MelonVODIE
 from .meta import METAIE
@@ -669,7 +665,7 @@ from .novamov import (
     AuroraVidIE,
     CloudTimeIE,
     NowVideoIE,
-    VideoWeedIE,
+    BitVidIE,
     WholeCloudIE,
 )
 from .nowness import (
@@ -984,7 +980,6 @@ from .theplatform import (
 from .thescene import TheSceneIE
 from .thesixtyone import TheSixtyOneIE
 from .thestar import TheStarIE
-from .thesun import TheSunIE
 from .theweatherchannel import TheWeatherChannelIE
 from .thisamericanlife import ThisAmericanLifeIE
 from .thisav import ThisAVIE

--- a/youtube_dl/extractor/novamov.py
+++ b/youtube_dl/extractor/novamov.py
@@ -107,12 +107,12 @@ class WholeCloudIE(NovaMovIE):
     _DESCRIPTION_REGEX = r'<strong>Description:</strong> ([^<]+)</p>'
 
     _TESTS = [{
-        'url': u'http://www.wholecloud.net/video/e1de95371c94a',
+        'url': 'http://www.wholecloud.net/video/e1de95371c94a',
         'info_dict': {
-            'id': u'e1de95371c94a',
+            'id': 'e1de95371c94a',
             'ext': 'mp4',
-            'title': u'Big Buck Bunny UHD 4K 60fps',
-            'description': u'No description',
+            'title': 'Big Buck Bunny UHD 4K 60fps',
+            'description': 'No description',
         },
         'md5': '909304eb0b75ef231ceb72d84fade33d',
     }, {
@@ -134,12 +134,12 @@ class NowVideoIE(NovaMovIE):
     _DESCRIPTION_REGEX = r'</h4>\s*<p>([^<]+)</p>'
 
     _TESTS = [{
-        'url': u'http://www.nowvideo.sx/video/461ebb17e1a83',
+        'url': 'http://www.nowvideo.sx/video/461ebb17e1a83',
         'info_dict': {
-            'id': u'461ebb17e1a83',
+            'id': '461ebb17e1a83',
             'ext': 'mp4',
-            'title': u'Big Buck Bunny UHD 4K 60fps',
-            'description': u'No description',
+            'title': 'Big Buck Bunny UHD 4K 60fps',
+            'description': 'No description',
         },
         'md5': '909304eb0b75ef231ceb72d84fade33d',
     }, {
@@ -162,11 +162,11 @@ class BitVidIE(NovaMovIE):
     _URL_TEMPLATE = 'http://%s/file/%s'
 
     _TESTS = [{
-        'url': u'http://www.bitvid.sx/file/bceedaa7b969c',
+        'url': 'http://www.bitvid.sx/file/bceedaa7b969c',
         'info_dict': {
-            'id': u'bceedaa7b969c',
+            'id': 'bceedaa7b969c',
             'ext': 'mp4',
-            'title': u'Big Buck Bunny UHD 4K 60fps'
+            'title': 'Big Buck Bunny UHD 4K 60fps'
         },
         'md5': '909304eb0b75ef231ceb72d84fade33d',
     }, {
@@ -186,11 +186,11 @@ class CloudTimeIE(NovaMovIE):
     _FILE_DELETED_REGEX = r'>This file no longer exists on our servers.<'
 
     _TESTS = [{
-        'url': u'http://www.cloudtime.to/video/ef47760a7793d',
+        'url': 'http://www.cloudtime.to/video/ef47760a7793d',
         'info_dict': {
-            'id': u'ef47760a7793d',
+            'id': 'ef47760a7793d',
             'ext': 'mp4',
-            'title': u'Big Buck Bunny UHD 4K 60fps'
+            'title': 'Big Buck Bunny UHD 4K 60fps'
         },
         'md5': '909304eb0b75ef231ceb72d84fade33d',
     }, {
@@ -210,11 +210,11 @@ class AuroraVidIE(NovaMovIE):
     _FILE_DELETED_REGEX = r'This file no longer exists on our servers!<'
 
     _TESTS = [{
-        'url': u'http://www.auroravid.to/video/27851f1e57c95',
+        'url': 'http://www.auroravid.to/video/27851f1e57c95',
         'info_dict': {
-            'id': u'27851f1e57c95',
+            'id': '27851f1e57c95',
             'ext': 'mp4',
-            'title': u'Big Buck Bunny UHD 4K 60fps',
+            'title': 'Big Buck Bunny UHD 4K 60fps',
         },
         'md5': '909304eb0b75ef231ceb72d84fade33d',
     }, {

--- a/youtube_dl/extractor/novamov.py
+++ b/youtube_dl/extractor/novamov.py
@@ -185,18 +185,7 @@ class CloudTimeIE(NovaMovIE):
 
     _FILE_DELETED_REGEX = r'>This file no longer exists on our servers.<'
 
-    _TESTS = [{
-        'url': 'http://www.cloudtime.to/video/ef47760a7793d',
-        'info_dict': {
-            'id': 'ef47760a7793d',
-            'ext': 'mp4',
-            'title': 'Big Buck Bunny UHD 4K 60fps'
-        },
-        'md5': '909304eb0b75ef231ceb72d84fade33d',
-    }, {
-        'url': 'http://www.cloudtime.to/video/ef47760a7793d',
-        'only_matching': True,
-    }]
+    _TEST = None
 
 
 class AuroraVidIE(NovaMovIE):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

NovaMov changed their way of providing video files. Now a form must be posted to get the direct link to the video file. 

This impacts following hoster:
- WholeCloud
- NowVideo
- BitVid (former known as VideoWeed)
- CloudTime
- AuroraVid
