### PR TITLE
[radiocloud.jp] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -865,6 +865,7 @@ from .radiocanada import (
     RadioCanadaIE,
     RadioCanadaAudioVideoIE,
 )
+from .radiocloud import RadioCloudIE
 from .radiode import RadioDeIE
 from .radiojavan import RadioJavanIE
 from .radiobremen import RadioBremenIE

--- a/youtube_dl/extractor/radiocloud.py
+++ b/youtube_dl/extractor/radiocloud.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import re
+
+from .common import InfoExtractor
+
+from ..utils import (
+    ExtractorError,
+    extract_attributes,
+    get_elements_by_class,
+)
+
+
+class RadioCloudIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?radiocloud\.jp/archive/.*?content_id=(?P<id>[0-9]+)'
+    _TEST = {
+        'url': 'https://radiocloud.jp/archive/so?content_id=13165',
+        'md5': '6f97afc008931d72c21db1331dbdce94',
+        'info_dict': {
+            'id': '13165',
+            'ext': 'm4a',
+            'title': '毒蝮三太夫のミュージックプレゼント：千葉県市川市鬼高『お酒の専門店「酒壱番」』編',
+            'description': '1/16(月)放送(11:20～11:40頃)から。訪問先は、千葉県市川市鬼高3-15−5『お酒の専門店「酒壱番」』さん。47年続く国民的中継番組のトーク部分のみをお楽しみください。',
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        def get_input_by_name(html, name):
+            for e in re.finditer(r'<input.*?>', html):
+                a = extract_attributes(e.group())
+                if a.get('name') == name:
+                    return a.get('value')
+            return None
+
+        element = None
+        for e in get_elements_by_class('contents_box', webpage):
+            if get_input_by_name(e, 'content_id') == video_id:
+                element = e
+                break
+
+        if not element:
+            raise ExtractorError('Could not find details of id %s' % video_id)
+
+        file_url = get_input_by_name(element, 'file_url')
+        if not file_url:
+            raise ExtractorError('Could not find player URL')
+        file_url = 'https:' + file_url
+
+        title = get_input_by_name(element, 'title')
+        if not title:
+            title = self._html_search_regex(r'<span>(.+?)</span>', element, 'title')
+        description = self._html_search_regex(r'<div>(.+?)</div>', element,
+                                              'description', fatal=False)
+
+        webpage = self._download_webpage(file_url, video_id,
+                                         headers={'Referer': url},
+                                         note='Downloading player',
+                                         errnote='Unable to download player')
+
+        file_url = self._search_regex(r'var\s+source\s*=\s*"(.+?)"', webpage, 'url')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'url': file_url
+        }


### PR DESCRIPTION
### I have
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### One of the following applies
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### The purpose of this pull request
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description

This is a new extractor for https://radiocloud.jp/.

This is a audio-only website, if that is not within the scope of this project, my apologies, please close the pull request.

Additionally I can also confirm this is not a website which is based around copyright infringement, from the little Japanese that I know it appears to be the official website for some Japanese radio station.

The website restricts access to older recordings to users without an account, however this restriction is not enforced by anything more than a semi-transparent div preventing clicks, therefore authentication was not implemented in the extractor as it is unnecessary.

The website doesn't have any obvious way of getting the URL for a specific recording, to get one you need to view the RSS feed for a radio program and then use one of the URLs provided there.

The extractor currently makes no attempt to create a playlist of all recordings found on the archive page of a program as there could be quite a few recordings and I personally don't see it as a useful feature, but it could be done.

The extractor also makes no attempt to guess which recording you wish to download if the URL provided does not refer to a specific content_id.

A note about some regex:

``` python
        file_url = self._search_regex(r'var\s*source\s*=\s*"(.+?)"', webpage, 'url')
```

I think this regex is a bit iffy, but I couldn't think of a better way.

Thank you for your time.

Edit: removed note about .strip() - I was mistaken.