### PR TITLE
[vevo] fix playlist extractor, tweak authentication

### DIFF
--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -367,6 +367,9 @@ class VevoPlaylistIE(VevoBaseIE):
             'genre': 'Hip-Hop',
         },
         'expected_warnings': ['Unable to download SMIL file'],
+        'params': {
+            'noplaylist': True,
+        },
     }, {
         'url': 'http://www.vevo.com/watch/genre/rock?index=0',
         'only_matching': True,
@@ -400,8 +403,15 @@ class VevoPlaylistIE(VevoBaseIE):
         qs = compat_urlparse.parse_qs(compat_urlparse.urlparse(url).query)
         index = qs.get('index', [None])[0]
 
-        if index:
-            return self._url_result(playlist['videos'][int(index)]['isrc'], 0)
+        if self._downloader.params.get('noplaylist') and index:
+            isrc = playlist['videos'][int(index)]['isrc']
+            self.to_screen(
+                'Downloading just video %s because of --no-playlist' % isrc)
+            return self._url_result(isrc, 0)
+
+        self.to_screen(
+            'Downloading playlist %s - add --no-playlist'
+            ' to just download video' % playlist_id)
 
         entries = [
             self._url_result(src['isrc'], i)

--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -342,29 +342,29 @@ class VevoPlaylistIE(VevoBaseIE):
         'url': 'http://www.vevo.com/watch/playlist/dadbf4e7-b99f-4184-9670-6f0e547b6a29',
         'info_dict': {
             'id': 'dadbf4e7-b99f-4184-9670-6f0e547b6a29',
-            'title': 'Best-Of: Birdman',
+            'title': 'Best Of: Birdman',
+            'description': 'Ca$h Money Records\' ballin\' boss turns 48 today.',
         },
-        'playlist_count': 10,
+        'playlist_count': 24,
     }, {
         'url': 'http://www.vevo.com/watch/genre/rock',
         'info_dict': {
             'id': 'rock',
-            'title': 'Rock',
         },
         'playlist_count': 20,
     }, {
-        'url': 'http://www.vevo.com/watch/playlist/dadbf4e7-b99f-4184-9670-6f0e547b6a29?index=0',
+        'url': 'http://www.vevo.com/watch/playlist/dadbf4e7-b99f-4184-9670-6f0e547b6a29?index=1',
         'md5': '32dcdfddddf9ec6917fc88ca26d36282',
         'info_dict': {
             'id': 'USCMV1100073',
             'ext': 'mp4',
-            'title': 'Birdman - Y.U. MAD',
+            'title': 'Birdman ft. Lil Wayne & Nicki Minaj - Y.U. MAD',
             'timestamp': 1323417600,
             'upload_date': '20111209',
             'uploader': 'Birdman',
             'track': 'Y.U. MAD',
             'artist': 'Birdman',
-            'genre': 'Rap/Hip-Hop',
+            'genre': 'Hip-Hop',
         },
         'expected_warnings': ['Unable to download SMIL file'],
     }, {

--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -228,6 +228,8 @@ class VevoIE(VevoBaseIE):
             version = self._VERSIONS.get(video_version.get('version'), 'generic')
             version_url = video_version.get('url')
             if not version_url:
+                if video_version.get('errorCode') == 'video-not-viewable-in-country':
+                    raise self.raise_geo_restricted()
                 continue
 
             if '.ism' in version_url:

--- a/youtube_dl/extractor/vevo.py
+++ b/youtube_dl/extractor/vevo.py
@@ -214,13 +214,14 @@ class VevoIE(VevoBaseIE):
 
         uploader = None
         artist = None
-        featured_artist = None
+        featured_artists = []
         artists = video_info.get('artists')
         for curr_artist in artists:
             if curr_artist.get('role') == 'Featured':
-                featured_artist = curr_artist['name']
+                featured_artists.append(curr_artist['name'])
             else:
                 artist = uploader = curr_artist['name']
+        featured_artists.sort()
 
         formats = []
         for video_version in video_versions:
@@ -269,8 +270,8 @@ class VevoIE(VevoBaseIE):
         self._sort_formats(formats)
 
         track = video_info['title']
-        if featured_artist:
-            artist = '%s ft. %s' % (artist, featured_artist)
+        if len(featured_artists) > 0:
+            artist = '%s ft. %s' % (artist, ' & '.join(featured_artists))
         title = '%s - %s' % (artist, track) if artist else track
 
         genres = video_info.get('genres')


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

- token is reused when downloading playlist
- added token refreshing mechanism
- moved authentication code to `VevoBaseIE` so it can be used by playlist extractor
- fixed playlist extractor
- added token smuggling from playlist to video extractor
- updated playlist tests
- made use of  `--no-playlist`