### PR TITLE
[ceskatelevize] Extend the extractor for ceskatelevize.cz

### DIFF
--- a/test/test_subtitles.py
+++ b/test/test_subtitles.py
@@ -190,6 +190,14 @@ class TestCeskaTelevizeSubtitles(BaseTestSubtitles):
     url = 'http://www.ceskatelevize.cz/ivysilani/10600540290-u6-uzasny-svet-techniky'
     IE = CeskaTelevizeIE
 
+    #get the subtitles from the first video, if need be
+    def getInfoDict(self):
+        idict = super(TestCeskaTelevizeSubtitles, self).getInfoDict()
+        if not idict.get('requested_subtitles') and idict.get('entries') and len(idict['entries']) > 0 and \
+            idict['entries'][0].get('requested_subtitles'):
+            idict['requested_subtitles'] = idict['entries'][0].get('requested_subtitles')
+        return idict
+
     def test_allsubtitles(self):
         self.DL.expect_warning('Automatic Captions not supported by this server')
         self.DL.params['writesubtitles'] = True

--- a/youtube_dl/extractor/ceskatelevize.py
+++ b/youtube_dl/extractor/ceskatelevize.py
@@ -108,7 +108,7 @@ class CeskaTelevizeIE(InfoExtractor):
             elif qs_dict.get('IDEC'):
                 playlist_id = qs_dict['IDEC'][0]
             else:
-                self.report_warning("Could not extract ID from iFramePlayer URL %s" % url)
+                self._downloader.report_warning("Could not extract ID from iFramePlayer URL %s" % url)
 
         webpage = self._download_webpage(url, playlist_id)
 
@@ -117,7 +117,7 @@ class CeskaTelevizeIE(InfoExtractor):
             raise ExtractorError(NOT_AVAILABLE_STRING, expected=True)
         if 'Neplatný kód pro videopřehrávač' in webpage:
             if retries < 1:
-                self._report_warning('Invalid code on the page, retrying...')
+                self._downloader._report_warning('Invalid code on the page, retrying...')
                 time.sleep(15)
                 return self._real_extract(url, retries + 1)
             else:

--- a/youtube_dl/extractor/ceskatelevize.py
+++ b/youtube_dl/extractor/ceskatelevize.py
@@ -390,7 +390,7 @@ class CeskaTelevizePoradyIE(InfoExtractor):
                 return data_url
 
         # This would be so much easier with XPath
-        webpage_nolive = re.sub(r'<section\b[^>]*\bid=[\'"]live.*?</section>', '', webpage, flags=re.S)
+        webpage_nolive = re.sub(r'(?s)<section\b[^>]*\bid=[\'"]live.*?</section>', '', webpage)
 
         matches = [compat_urlparse.urljoin('http://www.ceskatelevize.cz', fixup_hash(unescapeHTML(m.group('url')))) for m in
                    re.finditer(r'(?:<span[^>]*\bdata-url=|<iframe[^>]*\bsrc=)(["\'])(?P<url>[^"\']*)["\']',


### PR DESCRIPTION
  Download videos from:
   - articles on the news site (http://ceskatelevize.cz/ct24)
   - sports articles
   - sports videos and live videos, incl. streams exlcusive for the internet

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Ceskatelevize.cz contains many pages with videos that cannot be downloaded with the current extractor. This includes article pages (on news and sports subsites), some of which are not broadcast elsewhere, videos on the sport site and live streams of the sport site. I hope this will also work for the streams of the upcoming Ice Hockey World Championship streams (although I can't be sure until it actually starts).
