### PR TITLE
[wdr] add support for wdrmaus.de content pages as playlists

### DIFF
--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -103,34 +103,32 @@ class WDRIE(WDRBaseIE):
 
     _TESTS = [
         {
-            'url': 'http://www1.wdr.de/mediathek/video/sendungen/doku-am-freitag/video-geheimnis-aachener-dom-100.html',
-            # HDS download, MD5 is unstable
+            'url': 'http://www1.wdr.de/mediathek/video/sendungen/lokalzeit/video-lokalzeit-am-samstag-206.html',
             'info_dict': {
-                'id': 'mdb-1058683',
-                'ext': 'flv',
-                'display_id': 'doku-am-freitag/video-geheimnis-aachener-dom-100',
-                'title': 'Geheimnis Aachener Dom',
-                'alt_title': 'Doku am Freitag',
-                'upload_date': '20160304',
-                'description': 'md5:87be8ff14d8dfd7a7ee46f0299b52318',
+                'id': 'mdb-1378846',
+                'ext': 'mp4',
+                'display_id': 'lokalzeit/video-lokalzeit-am-samstag-206',
+                'title': 'Lokalzeit am Samstag',
+                'alt_title': 'Lokalzeit',
+                'upload_date': '20170520',
+                'description': 'md5:4a6785498658eabd870ada34dfd6580c',
                 'is_live': False,
                 'subtitles': {'de': [{
-                    'url': 'http://ondemand-ww.wdr.de/medp/fsk0/105/1058683/1058683_12220974.xml',
+                    'url': 'http://ondemand-ww.wdr.de/medp/fsk0/137/1378846/1378846_15999051.xml',
                     'ext': 'ttml',
                 }]},
             },
         },
         {
-            'url': 'http://www1.wdr.de/mediathek/audio/wdr3/wdr3-gespraech-am-samstag/audio-schriftstellerin-juli-zeh-100.html',
-            'md5': 'f4c1f96d01cf285240f53ea4309663d8',
+            'url': 'http://www1.wdr.de/mediathek/audio/wdr-aktuell/audio-in-duesseldorf-wollen-fdp-und-cdu-koalitionsverhandlungen-aufnehm-100.html',
             'info_dict': {
-                'id': 'mdb-1072000',
+                'id': 'mdb-1378415',
                 'ext': 'mp3',
-                'display_id': 'wdr3-gespraech-am-samstag/audio-schriftstellerin-juli-zeh-100',
-                'title': 'Schriftstellerin Juli Zeh',
-                'alt_title': 'WDR 3 Gespräch am Samstag',
-                'upload_date': '20160312',
-                'description': 'md5:e127d320bc2b1f149be697ce044a3dd7',
+                'display_id': 'audio-in-duesseldorf-wollen-fdp-und-cdu-koalitionsverhandlungen-aufnehm-100',
+                'title': u'In D\u00fcsseldorf wollen FDP und CDU Koalitionsverhandlungen aufnehm',
+                'alt_title': 'WDR Aktuell',
+                'upload_date': '20170519',
+                'description': 'md5:da9c9e242037b030fd3845b5e2e2068e',
                 'is_live': False,
                 'subtitles': {}
             },

--- a/youtube_dl/extractor/wdr.py
+++ b/youtube_dl/extractor/wdr.py
@@ -128,15 +128,15 @@ class WDRIE(WDRBaseIE):
             },
         },
         {
-            'url': 'http://www1.wdr.de/mediathek/audio/wdr-aktuell/audio-in-duesseldorf-wollen-fdp-und-cdu-koalitionsverhandlungen-aufnehm-100.html',
+            'url': 'http://www1.wdr.de/mediathek/audio/wdr5/wdr5-erlebte-geschichten/audio-dieter-rams-designer-mr-braun-100.html',
             'info_dict': {
-                'id': 'mdb-1378415',
+                'id': 'mdb-1376845',
                 'ext': 'mp3',
-                'display_id': 'audio-in-duesseldorf-wollen-fdp-und-cdu-koalitionsverhandlungen-aufnehm-100',
-                'title': u'In D\u00fcsseldorf wollen FDP und CDU Koalitionsverhandlungen aufnehm',
-                'alt_title': 'WDR Aktuell',
-                'upload_date': '20170519',
-                'description': 'md5:da9c9e242037b030fd3845b5e2e2068e',
+                'display_id': 'wdr5-erlebte-geschichten/audio-dieter-rams-designer-mr-braun-100',
+                'title': 'Dieter Rams, Designer "Mr. Braun"',
+                'alt_title': 'WDR 5 Erlebte Geschichten',
+                'upload_date': '20170521',
+                'description': 'md5:0fd731f515ae4fb013b4323a4d7ea946',
                 'is_live': False,
                 'subtitles': {}
             },


### PR DESCRIPTION
The wdrmaus.de content pages directly contain multiple video players without linking to a separate page for each video, like the WDR Mediathek pages do. Therefore, we cannot delegate loading the info_dict from a "video URL" (because it does not exist), but instead we have to grab each video separately from their video player <divs> and load the info_dict from the respective JSONP.

On the other hand, Mediathek pages only contain links to the separate video pages, and no JSONP URL, so we still need to support the old way of loading each video page separately when playing the playlist.

This pull-request implements both ways of loading playlists, and also fixes some outdated tests which fail due to HTTP 404 errors.