### PR TITLE
[iTunes] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -465,6 +465,7 @@ from .internetvideoarchive import InternetVideoArchiveIE
 from .iprima import IPrimaIE
 from .iqiyi import IqiyiIE
 from .ir90tv import Ir90TvIE
+from .itunes import iTunesIE
 from .itv import ITVIE
 from .ivi import (
     IviIE,

--- a/youtube_dl/extractor/itunes.py
+++ b/youtube_dl/extractor/itunes.py
@@ -1,0 +1,58 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+
+from ..utils import (
+    extract_attributes,
+    int_or_none,
+    unescapeHTML,
+    unified_strdate,
+)
+
+
+class iTunesIE(InfoExtractor):
+    _VALID_URL = r'https?://itunes\.apple\.com/[a-z]{2}?/?[a-z0-9-]+/?(?P<display_id>[a-z0-9-]+)?/(?:id)?(?P<id>[0-9]+)'
+    _TEST = {
+        'url': 'https://itunes.apple.com/us/itunes-u/uc-davis-symphony-orchestra/id403834767',
+        'info_dict': {
+            'id': '403834767',
+            'title': 'UC Davis Symphony Orchestra & University Chorus',
+        },
+        'playlist_count': 31,
+    }
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        playlist_id, display_id = mobj.group('id', 'display_id')
+        if not display_id:
+            display_id = playlist_id
+
+        webpage = self._download_webpage(url, display_id)
+
+        video_infos = re.findall(r'var\s+__desc_popup_d_\d+\s*=\s*({[^><]+});', webpage)
+        html_entries = re.findall(r'<tr\s+[^>]*role="row"[^>]+>', webpage)
+
+        entries = []
+        for idx, html_entry in enumerate(html_entries):
+            video_info = self._parse_json(video_infos[idx], display_id)
+            entry = extract_attributes(html_entry)
+            entries.append({
+                'id': entry['adam-id'],
+                'title': entry['preview-title'],
+                'description': video_info.get('description'),
+                'url': entry.get('audio-preview-url', entry.get('video-preview-url')),
+                'duration': int_or_none(entry.get('duration')),
+                'release_date': unified_strdate(video_info.get('release_date')),
+                'track': unescapeHTML(entry.get('preview-title')),
+                'track_number': int_or_none(entry.get('row-number')),
+                'track_id': entry.get('adam-id'),
+                'artist': unescapeHTML(entry.get('preview-artist')),
+                'album': unescapeHTML(entry.get('preview-album')),
+            })
+
+        title = self._html_search_regex(r'<h1>(.+)</h1>', webpage, 'title')
+
+        return self.playlist_result(entries, playlist_id, title)


### PR DESCRIPTION
The extractor only works for free content, like most podcasts, i.e. it does not download 30-seconds previews of paid songs.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is based on pull request https://github.com/rg3/youtube-dl/pull/9590, which died and had errors. Code tested by flake8, running tests and in action.