### PR TITLE
Support --ffmpeg-format

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -253,7 +253,6 @@ class YoutubeDL(object):
                        Progress hooks are guaranteed to be called at least once
                        (with status "finished") if the download is successful.
     merge_output_format: Extension to use when merging formats.
-    outputformat:      Extension and format to use when using an external downloader
     fixup:             Automatically correct known faults of the file.
                        One of:
                        - "never": do nothing
@@ -299,7 +298,7 @@ class YoutubeDL(object):
     the downloader (see youtube_dl/downloader/common.py):
     nopart, updatetime, buffersize, ratelimit, min_filesize, max_filesize, test,
     noresizebuffer, retries, continuedl, noprogress, consoletitle,
-    xattr_set_filesize, external_downloader_args, hls_use_mpegts.
+    xattr_set_filesize, external_downloader_args, hls_use_mpegts, ffmpeg_format.
 
     The following options are used by the post processors:
     prefer_ffmpeg:     If True, use ffmpeg instead of avconv if both are available,
@@ -636,8 +635,9 @@ class YoutubeDL(object):
                     template_dict['resolution'] = '%sp' % template_dict['height']
                 elif template_dict.get('width'):
                     template_dict['resolution'] = '%dx?' % template_dict['width']
-            if self.params.get('outputformat'):
-                template_dict['ext'] = self.params.get('outputformat')
+            # xxx: this can effect non-ffmpeg downloaders
+            if self.params.get('ffmpeg_format'):
+                template_dict['ext'] = self.params.get('ffmpeg_format')
 
             sanitize = lambda k, v: sanitize_filename(
                 compat_str(v),
@@ -1867,8 +1867,9 @@ class YoutubeDL(object):
                         if filename_real_ext == info_dict['ext']
                         else filename)
                     requested_formats = info_dict['requested_formats']
-                    if self.params.get('outputformat'):
-                        info_dict['ext'] = self.params.get('outputformat')
+                    # xxx: this can effect non-ffmpeg downloaders
+                    if self.params.get('ffmpeg_format'):
+                        info_dict['ext'] = self.params.get('ffmpeg_format')
                     if self.params.get('merge_output_format') is None and not compatible_formats(requested_formats):
                         info_dict['ext'] = 'mkv'
                         self.report_warning(

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -253,6 +253,7 @@ class YoutubeDL(object):
                        Progress hooks are guaranteed to be called at least once
                        (with status "finished") if the download is successful.
     merge_output_format: Extension to use when merging formats.
+    outputformat:      Extension and format to use when using an external downloader
     fixup:             Automatically correct known faults of the file.
                        One of:
                        - "never": do nothing
@@ -635,6 +636,8 @@ class YoutubeDL(object):
                     template_dict['resolution'] = '%sp' % template_dict['height']
                 elif template_dict.get('width'):
                     template_dict['resolution'] = '%dx?' % template_dict['width']
+            if self.params.get('outputformat'):
+                template_dict['ext'] = self.params.get('outputformat')
 
             sanitize = lambda k, v: sanitize_filename(
                 compat_str(v),
@@ -1864,6 +1867,8 @@ class YoutubeDL(object):
                         if filename_real_ext == info_dict['ext']
                         else filename)
                     requested_formats = info_dict['requested_formats']
+                    if self.params.get('outputformat'):
+                        info_dict['ext'] = self.params.get('outputformat')
                     if self.params.get('merge_output_format') is None and not compatible_formats(requested_formats):
                         info_dict['ext'] = 'mkv'
                         self.report_warning(

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -417,7 +417,7 @@ def _real_main(argv=None):
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
-        'outputformat': opts.outputformat,
+        'ffmpeg_format': opts.ffmpeg_format,
         'external_downloader_args': external_downloader_args,
         'postprocessor_args': postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -417,6 +417,7 @@ def _real_main(argv=None):
         'ffmpeg_location': opts.ffmpeg_location,
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
+        'outputformat': opts.outputformat,
         'external_downloader_args': external_downloader_args,
         'postprocessor_args': postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -49,7 +49,7 @@ class FileDownloader(object):
     external_downloader_args:  A list of additional command-line arguments for the
                         external downloader.
     hls_use_mpegts:     Use the mpegts container for HLS videos.
-    outputformat:       Output format for downloader to use
+    ffmpeg_format:       Output format for the ffmpeg downloader to use
 
     Subclasses of this one must re-define the real_download method.
     """

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -49,6 +49,7 @@ class FileDownloader(object):
     external_downloader_args:  A list of additional command-line arguments for the
                         external downloader.
     hls_use_mpegts:     Use the mpegts container for HLS videos.
+    outputformat:       Output format for downloader to use
 
     Subclasses of this one must re-define the real_download method.
     """

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -292,17 +292,25 @@ class FFmpegFD(ExternalFD):
         if self.params.get('test', False):
             args += ['-fs', compat_str(self._TEST_FILE_SIZE)]
 
-        if protocol in ('m3u8', 'm3u8_native'):
+        if self.params.get('outputformat'):
+            args += ['-f', EXT_TO_OUT_FORMATS.get(self.params.get('outputformat'),
+                                                  self.params.get('outputformat'))]
+        elif protocol in ('m3u8', 'm3u8_native'):
             if self.params.get('hls_use_mpegts', False) or tmpfilename == '-':
                 args += ['-f', 'mpegts']
             else:
                 args += ['-f', 'mp4']
-                if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._versions['ffmpeg'], '3.2', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
-                    args += ['-bsf:a', 'aac_adtstoasc']
         elif protocol == 'rtmp':
             args += ['-f', 'flv']
         else:
             args += ['-f', EXT_TO_OUT_FORMATS.get(info_dict['ext'], info_dict['ext'])]
+
+        if (protocol in ('m3u8', 'm3u8_native') and
+           (ffpp.basename == 'ffmpeg' and
+           is_outdated_version(ffpp._versions['ffmpeg'], '3.2', False)) and
+           (not info_dict.get('acodec') or
+           info_dict['acodec'].split('.')[0] in ('aac', 'mp4a'))):
+                    args += ['-bsf:a', 'aac_adtstoasc']
 
         args = [encodeArgument(opt) for opt in args]
         args.append(encodeFilename(ffpp._ffmpeg_filename_argument(tmpfilename), True))

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -517,9 +517,9 @@ def parseOpts(overrideArguments=None):
         dest='external_downloader_args', metavar='ARGS',
         help='Give these arguments to the external downloader')
     downloader.add_option(
-        '-O', '--output-format',
-        metavar='FORMAT', dest='outputformat', default='',
-        help='Ask the downloader to encode the specified video format')
+        '--ffmpeg-format',
+        metavar='FORMAT', dest='ffmpeg_format', default='',
+        help='Ask the ffmpeg downloader to encode the specified video format')
 
     workarounds = optparse.OptionGroup(parser, 'Workarounds')
     workarounds.add_option(

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -516,6 +516,10 @@ def parseOpts(overrideArguments=None):
         '--external-downloader-args',
         dest='external_downloader_args', metavar='ARGS',
         help='Give these arguments to the external downloader')
+    downloader.add_option(
+        '-O', '--output-format',
+        metavar='FORMAT', dest='outputformat', default='',
+        help='Ask the downloader to encode the specified video format')
 
     workarounds = optparse.OptionGroup(parser, 'Workarounds')
     workarounds.add_option(


### PR DESCRIPTION
(previously titled **Support --output-format (and -O)**)

Allow specifying an output format when using an external downloader, either through `--output-format` or `-O`, in preference to the extractor's default. This is particularly helpful as `-O mkv`, to allow Matroska
output from `ffmpeg` in cases where .mp4 isn't a great answer, such as while trying to play during the download.

---
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I frequently run start playing downloads while they are running, and .mp4 written by `ffmpeg` is often problematic. Players (usually VLC) have trouble seeking and even more trouble seeking backwards. Using mkv seems to produce a much better result, presumably because there is no issue with missing `moov` atoms.