### PR TITLE
[Flixel] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -352,6 +352,7 @@ from .fivemin import FiveMinIE
 from .fivetv import FiveTVIE
 from .flickr import FlickrIE
 from .flipagram import FlipagramIE
+from .flixel import FlixelIE
 from .folketinget import FolketingetIE
 from .footyroom import FootyRoomIE
 from .formula1 import Formula1IE

--- a/youtube_dl/extractor/flixel.py
+++ b/youtube_dl/extractor/flixel.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class FlixelIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?flixel\.com/cinemagraph/(?P<id>[0-9a-zA-Z]+)'
+    _TEST = {
+        'url': 'https://flixel.com/cinemagraph/tg64m4fmxbqu5yrywoz5/',
+        'md5': '374a8a8f8902f7db0f4a8d6f580c23ed',
+        'info_dict': {
+            'id': 'tg64m4fmxbqu5yrywoz5',
+            'ext': 'mp4',
+            'title': 'ROSSIO',
+            'uploader': 'capn',
+            'duration': 3.575,
+            'thumbnail': 'https://cdn.flixel.com/flixel/tg64m4fmxbqu5yrywoz5.thumbnail.jpg?v=1',
+            'webpage_url': 'https://flixel.com/cinemagraph/tg64m4fmxbqu5yrywoz5/',
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        json_url = 'https://api.flixel.com/2/flixels/{0}'.format(video_id)
+        meta = self._download_json(json_url, video_id)
+        return {
+            'id': video_id,
+            'title': meta.get('caption'),
+            'url': meta.get('hd_mp4'),
+            'uploader': meta.get('username'),
+            'duration': meta.get('duration'),
+            'thumbnail': meta.get('thumbnail'),
+            'webpage_url': meta.get('link'),
+        }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds an extractor for cinemagraphs from [Flixel's gallery](https://flixel.com/cinemagraphs/fresh/). One example of [valid URL](https://flixel.com/cinemagraph/esgyxix95j55m9f6ptp9/) is `https://flixel.com/cinemagraph/esgyxix95j55m9f6ptp9/`.