### PR TITLE
[atresplayer] Support to new Manifest object URL

### DIFF
--- a/youtube_dl/extractor/atresplayer.py
+++ b/youtube_dl/extractor/atresplayer.py
@@ -132,9 +132,11 @@ class AtresPlayerIE(InfoExtractor):
                 'url': video_url,
                 'format_id': 'http',
             }
-            mobj = re.search(r'(?P<bitrate>\d+)K_(?P<width>\d+)x(?P<height>\d+)', video_url)
+            mobj = re.search(r'(?P<bitrate>\d+)K_(?P<width>\d+)x(?P<height>\d+)', video_url)\
+                    or re.search(r'video_(?P<width>\d+)(x(?P<height>\d+))?_(?P<bitrate>\d+)', video_url)
             if mobj:
                 format_info.update({
+                    'preference': -40,
                     'width': int_or_none(mobj.group('width')),
                     'height': int_or_none(mobj.group('height')),
                     'tbr': int_or_none(mobj.group('bitrate')),


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Atresplayer was failing with new videos, apparently **they changed the Manifest format**. This PR fixes DASH format downloads (which are the ones with the highest quality).

Also, f4m endpoint was removed, since it can't be reached anymore.

**Note 1:** MD5 of test 2 was changed. Download is done through DASH (better quality than the standard HTTP MP4 file).
**Note 2:** Added test 3 with a video that was failing. But it requires to be signed in to be able to run it.
