### PR TITLE
[ccma] Fix pattern to support video collection URLs

### DIFF
--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class CCMAIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?ccma\.cat/(?:[^/]+/)*?(?P<type>video|audio)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?ccma\.cat/(?P<channel>tv3|catradio|[^/*])(?:[^/]+/)*?(?P<type>audio|video|[^/]*)/(?P<id>\d+)/?$'
     _TESTS = [{
         'url': 'http://www.ccma.cat/tv3/alacarta/lespot-de-la-marato-de-tv3/lespot-de-la-marato-de-tv3/video/5630208/',
         'md5': '7296ca43977c8ea4469e719c609b0871',
@@ -36,10 +36,33 @@ class CCMAIE(InfoExtractor):
             'upload_date': '20171205',
             'timestamp': 1512507300,
         }
+    }, {
+        'url': 'http://www.ccma.cat/tv3/alacarta/e17-tots-els-videos-de-les-eleccions-del-21d/arrimadas-cs-hem-guanyat-les-eleccions-al-parlament-de-catalunya/coleccio/10970/5711075/',
+        'md5': '4cab47c2c3eb1312ab17771b1848c1ad',
+        'info_dict': {
+            'id': '5711075',
+            'ext': 'mp4',
+            'description': 'md5:feca2bcac2bace0c37395f625ea4065e',
+            'title': 'Arrimadas (Cs): "Hem guanyat les eleccions al Parlament de Catalunya"'
+        }
     }]
 
     def _real_extract(self, url):
-        media_type, media_id = re.match(self._VALID_URL, url).groups()
+        m = re.match(self._VALID_URL, url)
+        url_channel = m.group('channel')
+        url_type = m.group('type')
+        # Heuristics to guess media type
+        if url_type == 'video':
+            media_type = 'video'
+        elif url_type == 'audio':
+            media_type = 'audio'
+        elif url_channel == 'tv3':
+            media_type = 'video'
+        elif url_channel == 'catradio':
+            media_type = 'audio'
+        else:
+            media_type = 'video'
+        media_id = m.group('id')
         media_data = {}
         formats = []
         profiles = ['pc'] if media_type == 'audio' else ['mobil', 'pc']

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -62,9 +62,9 @@ class CCMAIE(InfoExtractor):
         m = re.match(self._VALID_URL, url)
         if m.group('type'):
             media_type = m.group('type')
-            media_id   = m.group('id1')
+            media_id = m.group('id1')
         elif m.group('channel'):
-            channel_to_type = {'tv3':'video','catradio':'audio'}
+            channel_to_type = {'tv3': 'video', 'catradio': 'audio'}
             media_type = channel_to_type[m.group('channel')]
             media_id = m.group('id2')
         media_data = {}

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class CCMAIE(InfoExtractor):
-    _VALID_URL = r'^https?://(?:www\.)?ccma\.cat/(?:[^/]+/)*?(?P<type>video|audio)/(?P<id1>\d+).*$|^https?://(?:www\.)?ccma\.cat/(?P<channel>tv3|catradio)/(?:[^/]+/)*?(?P<id2>\d+)/?$'
+    _VALID_URL = r'^https?://(?:www\.)?ccma\.cat/((?:[^/]+/)*?(?P<type>video|audio)/(?P<id1>\d+)|(?P<channel>tv3|catradio)/(?:[^/]+/)*?(?P<id2>\d+)/?$)'
     _TESTS = [{
         'url': 'http://www.ccma.cat/tv3/alacarta/lespot-de-la-marato-de-tv3/lespot-de-la-marato-de-tv3/video/5630208/',
         'md5': '7296ca43977c8ea4469e719c609b0871',
@@ -44,6 +44,17 @@ class CCMAIE(InfoExtractor):
             'ext': 'mp4',
             'description': 'md5:feca2bcac2bace0c37395f625ea4065e',
             'title': 'Arrimadas (Cs): "Hem guanyat les eleccions al Parlament de Catalunya"'
+        }
+    }, {
+        'url': 'http://www.ccma.cat/catradio/alacarta/lendema-del-21d/sabria-erc-no-ens-podem-entretenir-ni-un-moment-per-formar-govern/coleccio/11011/986031/',
+        'md5': '471586ce88bcbbdd031afafe75ec72e0',
+        'info_dict': {
+            'id': '986031',
+            'ext': 'mp3',
+            'upload_date': '20181210',
+            'title': 'Sabrià (ERC): "No ens podem entretenir ni un moment per formar govern"',
+            'description': 'md5:faf8ec9faf2115fbf462ad3f7ad175df',
+            'timestamp': 1544424300,
         }
     }]
 

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class CCMAIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?ccma\.cat/(?P<channel>tv3|catradio|[^/*])(?:[^/]+/)*?(?P<type>audio|video|[^/]*)/(?P<id>\d+)/?$'
+    _VALID_URL = r'^https?://(?:www\.)?ccma\.cat/(?:[^/]+/)*?(?P<type>video|audio)/(?P<id1>\d+).*$|^https?://(?:www\.)?ccma\.cat/(?P<channel>tv3|catradio)/(?:[^/]+/)*?(?P<id2>\d+)/?$'
     _TESTS = [{
         'url': 'http://www.ccma.cat/tv3/alacarta/lespot-de-la-marato-de-tv3/lespot-de-la-marato-de-tv3/video/5630208/',
         'md5': '7296ca43977c8ea4469e719c609b0871',
@@ -49,20 +49,13 @@ class CCMAIE(InfoExtractor):
 
     def _real_extract(self, url):
         m = re.match(self._VALID_URL, url)
-        url_channel = m.group('channel')
-        url_type = m.group('type')
-        # Heuristics to guess media type
-        if url_type == 'video':
-            media_type = 'video'
-        elif url_type == 'audio':
-            media_type = 'audio'
-        elif url_channel == 'tv3':
-            media_type = 'video'
-        elif url_channel == 'catradio':
-            media_type = 'audio'
-        else:
-            media_type = 'video'
-        media_id = m.group('id')
+        if m.group('type'):
+            media_type = m.group('type')
+            media_id   = m.group('id1')
+        elif m.group('channel'):
+            channel_to_type = {'tv3':'video','catradio':'audio'}
+            media_type = channel_to_type[m.group('channel')]
+            media_id = m.group('id2')
         media_data = {}
         formats = []
         profiles = ['pc'] if media_type == 'audio' else ['mobil', 'pc']


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Videos from CCMA which are part of a collection do not include the media type (audio or video) in the title. I fixed the URL pattern to support those videos, added a new test case, and added some heuristics to guess the media type based on the source ('video' for the TV channel TV3, and 'audio' for the radio channel Cat(alunya)Radio).
