### PR TITLE
[BrightcoveNew] Fix: find videos embedded in xilinx.com site

### DIFF
--- a/youtube_dl/extractor/brightcove.py
+++ b/youtube_dl/extractor/brightcove.py
@@ -485,6 +485,19 @@ class BrightcoveNewIE(AdobePassIE):
             'skip_download': True,
         }
     }, {
+        # xilinx.com url embed
+        'url': 'https://www.xilinx.com/video/soc/how-to-use-the-zynq-7000-verification-ip-verify-debug-simulation.html',
+        'info_dict': {
+            'id': '5607699465001',
+            'ext': 'mp4',
+            'title': 'How to use the Zynq 7000 Verification IP to verify and debug using simulation',
+            'description': 'Learn how to efficiently verify designs that use Zynq 7000 Processing System using the Zynq 7000 VIP. This video introduces you to how to configure and how to simulate with the example project.',
+            'duration': 456.66,
+            'timestamp': 1507851806,
+            'upload_date': '20171012',
+            'uploader_id': '17209957001',
+        },
+    }, {
         # ref: prefixed video id
         'url': 'http://players.brightcove.net/3910869709001/21519b5c-4b3b-4363-accb-bdc8f358f823_default/index.html?videoId=ref:7069442',
         'only_matching': True,
@@ -561,6 +574,29 @@ class BrightcoveNewIE(AdobePassIE):
                 continue
 
             entries.append(bc_url)
+
+        for account_id, player_id, embed in re.findall(
+                r'''<script[^>]+src=["\'](?:https?:)?//players\.brightcove\.net/(\d+)/([^/]+)_([^/]+)/index(?:\.min)?\.js''', webpage):
+            for video_id in re.findall(r'''<div[^>]*data-video-id=['"](\d+)['"]''', webpage):
+
+                if not video_id:
+                    continue
+
+                if not account_id:
+                    continue
+
+                player_id = player_id or 'default'
+
+                embed = embed or 'default'
+
+                bc_url = 'http://players.brightcove.net/%s/%s_%s/index.html?videoId=%s' % (
+                    account_id, player_id, embed, video_id)
+
+                if not ie._is_valid_url(
+                        bc_url, video_id, 'possible brightcove video'):
+                    continue
+
+                entries.append(bc_url)
 
         return entries
 

--- a/youtube_dl/extractor/brightcove.py
+++ b/youtube_dl/extractor/brightcove.py
@@ -485,19 +485,6 @@ class BrightcoveNewIE(AdobePassIE):
             'skip_download': True,
         }
     }, {
-        # xilinx.com url embed
-        'url': 'https://www.xilinx.com/video/soc/how-to-use-the-zynq-7000-verification-ip-verify-debug-simulation.html',
-        'info_dict': {
-            'id': '5607699465001',
-            'ext': 'mp4',
-            'title': 'How to use the Zynq 7000 Verification IP to verify and debug using simulation',
-            'description': 'Learn how to efficiently verify designs that use Zynq 7000 Processing System using the Zynq 7000 VIP. This video introduces you to how to configure and how to simulate with the example project.',
-            'duration': 456.66,
-            'timestamp': 1507851806,
-            'upload_date': '20171012',
-            'uploader_id': '17209957001',
-        },
-    }, {
         # ref: prefixed video id
         'url': 'http://players.brightcove.net/3910869709001/21519b5c-4b3b-4363-accb-bdc8f358f823_default/index.html?videoId=ref:7069442',
         'only_matching': True,
@@ -574,29 +561,6 @@ class BrightcoveNewIE(AdobePassIE):
                 continue
 
             entries.append(bc_url)
-
-        for account_id, player_id, embed in re.findall(
-                r'''<script[^>]+src=["\'](?:https?:)?//players\.brightcove\.net/(\d+)/([^/]+)_([^/]+)/index(?:\.min)?\.js''', webpage):
-            for video_id in re.findall(r'''<div[^>]*data-video-id=['"](\d+)['"]''', webpage):
-
-                if not video_id:
-                    continue
-
-                if not account_id:
-                    continue
-
-                player_id = player_id or 'default'
-
-                embed = embed or 'default'
-
-                bc_url = 'http://players.brightcove.net/%s/%s_%s/index.html?videoId=%s' % (
-                    account_id, player_id, embed, video_id)
-
-                if not ie._is_valid_url(
-                        bc_url, video_id, 'possible brightcove video'):
-                    continue
-
-                entries.append(bc_url)
 
         return entries
 

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1320,6 +1320,7 @@ from .xiami import (
     XiamiArtistIE,
     XiamiCollectionIE
 )
+from .xilinx import XilinxIE
 from .xminus import XMinusIE
 from .xnxx import XNXXIE
 from .xstream import XstreamIE

--- a/youtube_dl/extractor/xilinx.py
+++ b/youtube_dl/extractor/xilinx.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+from .brightcove import BrightcoveNewIE
+
+
+class XilinxIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?xilinx\.com/video/(?P<cat>[^/]+)/(?P<id>[\w-]+)\.html'
+    _TEST = {
+        'url': 'https://www.xilinx.com/video/hardware/model-composer-product-overview.html',
+        'info_dict': {
+            'id': '5678303886001',
+            'ext': 'mp4',
+            'title': 'Model Composer Product Overview',
+            'description': 'md5:806e3831788848342777cdc3947c3d58',
+            'timestamp': 1513121997,
+            'upload_date': '20171212',
+            'uploader_id': '17209957001',
+            'categories': 'hardware',
+        },
+        'params': {
+            't': True,
+        },
+    }
+
+    BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/%s/%s_%s/index.html?videoId=%s'
+
+    def _real_extract(self, url):
+
+        page_id = self._match_id(url)
+        category = re.match(self._VALID_URL, url).group('cat')
+        webpage = self._download_webpage(url, page_id)
+
+        urls = []
+        for account_id, player_id, embed in re.findall(
+                r'''<script[^>]+src=["\'](?:https?:)?//players\.brightcove\.net/(\d+)/([^/]+)_([^/]+)/index(?:\.min)?\.js''', webpage):
+            for video_id in re.findall(r'''<div[^>]*data-video-id=['"](\d+)['"]''', webpage):
+
+                if not video_id:
+                    continue
+
+                if not account_id:
+                    continue
+
+                player_id = player_id or 'default'
+
+                embed = embed or 'default'
+
+                bc_url = self.BRIGHTCOVE_URL_TEMPLATE % (account_id, player_id, embed, video_id)
+
+                urls.append(bc_url)
+
+        if (len(urls) == 0):
+            self.report_warning("Couldn't get any video urls.")
+
+        if (len(urls) > 1):
+            self.report_warning("Got more than one video urls, using the first one.")
+
+        return {
+            '_type': 'url_transparent',
+            'url': urls[0],
+            'categories': category,
+            'ie_key': BrightcoveNewIE.ie_key(),
+        }


### PR DESCRIPTION
In xilinx.com sites there are no video tags, the video_id can be found in a div tag.
(the brightcove script is before the div (video-id) tag.)

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The xilinx.com site uses embedded brightcove videos, but there is no html video tag, so the original BrightcoveNewIE could not determine the video_id.
These sites uses a script tag (similar to what the original code search for), and after that there is a div tag, where the data-video-id (video_id) can be found.

Example sites:
https://www.xilinx.com/video/soc/how-to-use-the-zynq-7000-verification-ip-verify-debug-simulation.html
https://www.xilinx.com/video/hardware/model-composer-product-overview.html

