### PR TITLE
[postprocessor/ffmpeg] Avoid outdated avconv

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,3 +231,4 @@ John Dong
 Tatsuyuki Ishi
 Daniel Weber
 Kay Bouché
+Larry Hastings

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -126,11 +126,11 @@ class FFmpegPostProcessor(PostProcessor):
 
         if prefer_ffmpeg is None:
             if not is_outdated_version(self._versions['avconv'],
-                self._avconv_required_version):
+                                       self._avconv_required_version):
                 prefer_ffmpeg = False
                 print("preferring avconv")
             elif not is_outdated_version(self._versions['ffmpeg'],
-                self._ffmpeg_required_version):
+                                         self._ffmpeg_required_version):
                 prefer_ffmpeg = True
                 print("preferring ffmpeg")
 


### PR DESCRIPTION

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Bugfix for issue #10673.

When the user hasn't expressed a preference between avconv and ffmpeg, and avconv is outdated, default to ffmpeg.  Default to avconv in all other cases.