### PR TITLE
[openload] fix js evaluation (phantomjs version related?)

### DIFF
--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -95,7 +95,7 @@ class PhantomJSwrapper(object):
           phantom.exit();
         }};
         page.onLoadFinished = function(status) {{
-          if(page.url === "") {{
+          if(page.url === "" || page.url === "about:blank") {{
             page.setContent(fs.read("{html}", read), "{url}");
           }}
           else {{


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I was getting 'ERROR: Unable to extract title' from openload:

```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://openload.co/embed/7iw4d48TpqQ/SOU.CP.ENGLISH.mp4', u'--verbose']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2017.12.31
[debug] Python version 2.7.14 - Linux-4.15.0-rc4-x86_64-with-glibc2.2.5
[debug] exe versions: ffmpeg 3.4.1, ffprobe 3.4.1, phantomjs 2.1.1, rtmpdump 2.4
[debug] Proxy map: {}
[Openload] 7iw4d48TpqQ: Downloading embed webpage
[Openload] 7iw4d48TpqQ: Executing JS on webpage
ERROR: Unable to extract title; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/YoutubeDL.py", line 784, in extract_info
    ie_result = ie.extract(url)
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/extractor/common.py", line 438, in extract
    ie_result = self._real_extract(url)
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/extractor/openload.py", line 343, in _real_extract
    'description', webpage, 'title', fatal=True)
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/extractor/common.py", line 924, in _html_search_meta
    html, display_name, fatal=fatal, group='content', **kwargs)
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/extractor/common.py", line 803, in _html_search_regex
    res = self._search_regex(pattern, string, name, default, fatal, flags, group)
  File "/nix/store/7y1mbqjqhi0lg6hil5phijm7dq8302nf-youtube-dl-2017.12.31/lib/python2.7/site-packages/youtube_dl/extractor/common.py", line 794, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract title; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

Apparently onLoadFinished gets called with 'about:blank' for me, so the html never gets loaded.  I couldn't find any suspect commits in phantomjs, so I'm not sure what's actually causing it.  I left the previous check for compatibility.  The output with this patch is:

```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://openload.co/embed/7iw4d48TpqQ/SOU.CP.ENGLISH.mp4', u'--verbose']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2017.12.31
[debug] Python version 2.7.14 - Linux-4.15.0-rc4-x86_64-with-glibc2.2.5
[debug] exe versions: phantomjs 2.1.1
[debug] Proxy map: {}
[Openload] 7iw4d48TpqQ: Downloading embed webpage
[Openload] 7iw4d48TpqQ: Executing JS on webpage
[debug] Default format spec: best/bestvideo+bestaudio
[debug] Invoking downloader on u'https://openload.co/stream/7iw4d48TpqQ~1515040046~134.41.0.0~O-h9Ik4S?mime=true'
[download] Destination: SOU.CP.ENGLISH.mp4-7iw4d48TpqQ.mp4
[download] 100% of 744.52MiB in 13:06

```