### PR TITLE
[viu:ott] Add support to download entire series with --yes-playlist

### DIFF
--- a/youtube_dl/extractor/expressen.py
+++ b/youtube_dl/extractor/expressen.py
@@ -15,7 +15,7 @@ from ..utils import (
 class ExpressenIE(InfoExtractor):
     _VALID_URL = r'''(?x)
                     https?://
-                        (?:www\.)?expressen\.se/
+                        (?:www\.)?(?:expressen|di)\.se/
                         (?:(?:tvspelare/video|videoplayer/embed)/)?
                         tv/(?:[^/]+/)*
                         (?P<id>[^/?#&]+)
@@ -42,13 +42,16 @@ class ExpressenIE(InfoExtractor):
     }, {
         'url': 'https://www.expressen.se/videoplayer/embed/tv/ditv/ekonomistudion/experterna-har-ar-fragorna-som-avgor-valet/?embed=true&external=true&autoplay=true&startVolume=0&partnerId=di',
         'only_matching': True,
+    }, {
+        'url': 'https://www.di.se/videoplayer/embed/tv/ditv/borsmorgon/implantica-rusar-70--under-borspremiaren-hor-styrelsemedlemmen/?embed=true&external=true&autoplay=true&startVolume=0&partnerId=di',
+        'only_matching': True,
     }]
 
     @staticmethod
     def _extract_urls(webpage):
         return [
             mobj.group('url') for mobj in re.finditer(
-                r'<iframe[^>]+\bsrc=(["\'])(?P<url>(?:https?:)?//(?:www\.)?expressen\.se/(?:tvspelare/video|videoplayer/embed)/tv/.+?)\1',
+                r'<iframe[^>]+\bsrc=(["\'])(?P<url>(?:https?:)?//(?:www\.)?(?:expressen|di)\.se/(?:tvspelare/video|videoplayer/embed)/tv/.+?)\1',
                 webpage)]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/viu.py
+++ b/youtube_dl/extractor/viu.py
@@ -168,7 +168,7 @@ class ViuPlaylistIE(ViuBaseIE):
 
 class ViuOTTIE(InfoExtractor):
     IE_NAME = 'viu:ott'
-    _VALID_URL = r'https?://(?:www\.)?viu\.com/ott/(?P<country_code>[a-z]{2})/[a-z]{2}-[a-z]{2}/vod/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?viu\.com/ott/(?P<country_code>[a-z]{2})/(?P<lang_code>[a-z]{2}-[a-z]{2})/vod/(?P<id>\d+)'
     _TESTS = [{
         'url': 'http://www.viu.com/ott/sg/en-us/vod/3421/The%20Prime%20Minister%20and%20I',
         'info_dict': {
@@ -201,9 +201,13 @@ class ViuOTTIE(InfoExtractor):
         'TH': 4,
         'PH': 5,
     }
+    _LANGUAGE_FLAG = {
+        'zh-hk': 1,
+        'en-us': 3,
+    }
 
     def _real_extract(self, url):
-        country_code, video_id = re.match(self._VALID_URL, url).groups()
+        country_code, lang_code, video_id = re.match(self._VALID_URL, url).groups()
 
         query = {
             'r': 'vod/ajax-detail',
@@ -227,6 +231,7 @@ class ViuOTTIE(InfoExtractor):
             'https://d1k2us671qcoau.cloudfront.net/distribute_web_%s.php' % country_code,
             video_id, 'Downloading stream info', query={
                 'ccs_product_id': video_data['ccs_product_id'],
+                'language_flag_id': self._LANGUAGE_FLAG.get(lang_code.lower()) or '3',
             }, headers={
                 'Referer': url,
                 'Origin': re.search(r'https?://[^/]+', url).group(0),

--- a/youtube_dl/extractor/viu.py
+++ b/youtube_dl/extractor/viu.py
@@ -13,6 +13,8 @@ from ..compat import (
 from ..utils import (
     ExtractorError,
     int_or_none,
+    smuggle_url,
+    unsmuggle_url,
 )
 import json
 
@@ -183,6 +185,7 @@ class ViuOTTIE(InfoExtractor):
         },
         'params': {
             'skip_download': 'm3u8 download',
+            'noplaylist': True,
         },
         'skip': 'Geo-restricted to Singapore',
     }, {
@@ -195,6 +198,19 @@ class ViuOTTIE(InfoExtractor):
         },
         'params': {
             'skip_download': 'm3u8 download',
+            'noplaylist': True,
+        },
+        'skip': 'Geo-restricted to Hong Kong',
+    }, {
+        'url': 'https://www.viu.com/ott/hk/zh-hk/vod/68776/%E6%99%82%E5%B0%9A%E5%AA%BD%E5%92%AA',
+        'playlist_count': 12,
+        'info_dict': {
+            'id': '3916',
+            'title': '時尚媽咪',
+        },
+        'params': {
+            'skip_download': 'm3u8 download',
+            'noplaylist': False,
         },
         'skip': 'Geo-restricted to Hong Kong',
     }]
@@ -249,6 +265,7 @@ class ViuOTTIE(InfoExtractor):
         return self._user_info
 
     def _real_extract(self, url):
+        url, idata = unsmuggle_url(url, {})
         country_code, lang_code, video_id = re.match(self._VALID_URL, url).groups()
 
         query = {
@@ -268,6 +285,37 @@ class ViuOTTIE(InfoExtractor):
         video_data = product_data.get('current_product')
         if not video_data:
             raise ExtractorError('This video is not available in your region.', expected=True)
+
+        # return entire series as playlist if not --no-playlist
+        if not (self._downloader.params.get('noplaylist') or idata.get('force_noplaylist')):
+            series = product_data.get('series', {})
+            product = series.get('product')
+            if product:
+                entries = []
+                for entry in sorted(product, key=lambda x: int_or_none(x.get('number', 0))):
+                    item_id = entry.get('product_id')
+                    if not item_id:
+                        continue
+                    item_id = compat_str(item_id)
+                    entries.append(self.url_result(
+                        smuggle_url(
+                            'http://www.viu.com/ott/%s/%s/vod/%s/' % (country_code, lang_code, item_id),
+                            {'force_noplaylist': True}),  # prevent infinite recursion
+                        'ViuOTT',
+                        item_id,
+                        entry.get('synopsis', '').strip()))
+
+                return self.playlist_result(
+                    entries,
+                    video_data.get('series_id'),
+                    series.get('name'),
+                    series.get('description'))
+        # else fall-through
+
+        if self._downloader.params.get('noplaylist'):
+            self.to_screen(
+                'Downloading only video %s in series %s because of --no-playlist' %
+                (video_id, video_data.get('series_id')))
 
         duration_limit = False
         query = {

--- a/youtube_dl/extractor/viu.py
+++ b/youtube_dl/extractor/viu.py
@@ -320,7 +320,10 @@ class ViuOTTIE(InfoExtractor):
             if duration_limit:
                 temp = compat_urlparse.urlparse(stream_url)
                 query = dict(compat_urlparse.parse_qsl(temp.query, keep_blank_values=True))
-                query.update({'duration': '9999999', 'duration_start': '0'})
+                query.update({
+                    'duration': video_data.get('time_duration', '9999999'),
+                    'duration_start': '0'
+                })
                 stream_url = temp._replace(query=compat_urlparse.urlencode(query)).geturl()
 
             formats.append({


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Dear maintainers:
**Fix:**
Passing `--yes-playlist` is identical to not passing any `--xxx-playlist` option since there is a default False value.
**Improvement:**
The video info got from `viu:ott` has all the video ids of the entire series. So maybe we can support downloading of all the episodes with the `--yes-playlist` flag.
