### PR TITLE
--metadata option, allows the user to specify key/value pairs for encoding metadata

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1033,7 +1033,7 @@ class YoutubeDL(object):
             '!=': operator.ne,
         }
         operator_rex = re.compile(r'''(?x)\s*
-            (?P<key>width|height|tbr|abr|vbr|asr|filesize|fps)
+            (?P<key>width|height|tbr|abr|vbr|asr|filesize|filesize_approx|fps)
             \s*(?P<op>%s)(?P<none_inclusive>\s*\?)?\s*
             (?P<value>[0-9.]+(?:[kKmMgGtTpPeEzZyY]i?[Bb]?)?)
             $

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1033,7 +1033,7 @@ class YoutubeDL(object):
             '!=': operator.ne,
         }
         operator_rex = re.compile(r'''(?x)\s*
-            (?P<key>width|height|tbr|abr|vbr|asr|filesize|filesize_approx|fps)
+            (?P<key>width|height|tbr|abr|vbr|asr|filesize|fps)
             \s*(?P<op>%s)(?P<none_inclusive>\s*\?)?\s*
             (?P<value>[0-9.]+(?:[kKmMgGtTpPeEzZyY]i?[Bb]?)?)
             $

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -256,8 +256,7 @@ def _real_main(argv=None):
     if opts.metafromuser:
         postprocessors.append({
             'key': 'MetadataFromUser',
-            'metadata': opts.metafromuser
-                
+            'metadata': opts.metafromuser                
         })
     
     if opts.extractaudio:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -252,6 +252,14 @@ def _real_main(argv=None):
             'key': 'MetadataFromTitle',
             'titleformat': opts.metafromtitle
         })
+    
+    if opts.metafromuser:
+        postprocessors.append({
+            'key': 'MetadataFromUser',
+            'metadata': opts.metafromuser
+                
+        })
+    
     if opts.extractaudio:
         postprocessors.append({
             'key': 'FFmpegExtractAudio',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -816,10 +816,10 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--metadata',
         metavar='METADATA', dest='metafromuser', default=False,
-        help='Allows the user to specify key/value pairs for encoding metadata, sepatated by equal sign.'
-             'Example: --metadata "album = Movie Title artist = Various artists year = "2010"'
-             'Note:- Should be used with --add-metadata to write the specified data to the video/audio file'
-             'Also tries to capture artist information from the file description, if otherwise not available')
+        help='Allows the user to specify key/value pairs for encoding metadata, sepatated by equal sign. '
+             'Example: --metadata "album = Movie Title artist = Various Artists". '
+             'Note:- Should be used with --add-metadata to write the specified data into a video/audio file. '
+             'Also tries to capture artist information from the file description, if otherwise not available.')
     postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -814,6 +814,12 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
+        '--metadata',
+        metavar='METADATA', dest='metafromuser', default=False,
+        help='Allows the user to specify key/value pairs for encoding metadata, sepatated by equal sign.'
+             'Example: --metadata "album = Movie Title artist = Various artists year = "2010"'
+             'Also tries to capture artist information from the file description, if otherwise not available')
+    postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',
         help='Parse additional metadata like song title / artist from the video title. '

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -818,6 +818,7 @@ def parseOpts(overrideArguments=None):
         metavar='METADATA', dest='metafromuser', default=False,
         help='Allows the user to specify key/value pairs for encoding metadata, sepatated by equal sign.'
              'Example: --metadata "album = Movie Title artist = Various artists year = "2010"'
+             'Note:- Should be used with --add-metadata to write the specified data to the video/audio file'
              'Also tries to capture artist information from the file description, if otherwise not available')
     postproc.add_option(
         '--metadata-from-title',

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -16,6 +16,7 @@ from .ffmpeg import (
 from .xattrpp import XAttrMetadataPP
 from .execafterdownload import ExecAfterDownloadPP
 from .metadatafromtitle import MetadataFromTitlePP
+from .metadatafromuser import MetadataFromUserPP
 
 
 def get_postprocessor(key):
@@ -37,4 +38,5 @@ __all__ = [
     'FFmpegVideoConvertorPP',
     'MetadataFromTitlePP',
     'XAttrMetadataPP',
+    'MetadataFromUserPP'
 ]

--- a/youtube_dl/postprocessor/metadatafromuser.py
+++ b/youtube_dl/postprocessor/metadatafromuser.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Feb  9 16:23:16 2018
+
+@author: Niras C. Vayalil
+"""
+
+from __future__ import unicode_literals
+from .common import PostProcessor
+import re
+
+
+class MetadataFromUserPP(PostProcessor):
+    def __init__(self, downloader, metadata):
+        super(MetadataFromUserPP, self).__init__(downloader)
+        self._metadata = metadata
+        
+
+    def run(self, info):
+        lastpos = 0
+        attribute = None
+        # Search for key words
+        for match in re.finditer(r'(\w+) *=', self._metadata):
+            if attribute is not None:
+                # The data exists between previous math end and new match start
+                value = self._metadata[lastpos:match.start()].strip()
+                self._downloader.to_screen(
+                    '[fromuser] %s: %s'
+                    %(attribute, value if value else 'NA'))
+                info[attribute] = value
+            attribute = match.group(1)    
+            lastpos = match.end()
+
+        if attribute is None:
+            # No attributes is given user, default assume the text as album name
+            attribute = 'album' 
+        # Add the last key
+        value = self._metadata[lastpos:].strip()
+        self._downloader.to_screen(
+            '[fromuser] %s: %s'
+            %(attribute, value if value else 'NA'))
+        info[attribute] = value
+
+        # If nothing specified for artist, extract from comments/description
+        if (('artist' not in info) and ('description' in info)):
+            artist = re.findall('music(?![ia]).*$', info['description'], re.MULTILINE | re.IGNORECASE)
+            artist = artist + re.findall('sing.*$', info['description'], re.MULTILINE | re.IGNORECASE)
+            artist = ', '.join(artist).title().strip()
+            
+            self._downloader.to_screen(
+                    '[artist] : %s : parsed from description' %(artist if artist else 'NA'))
+            info['artist'] = artist
+        
+        return [], info

--- a/youtube_dl/postprocessor/metadatafromuser.py
+++ b/youtube_dl/postprocessor/metadatafromuser.py
@@ -1,7 +1,7 @@
-"""
-Created on Fri Feb  9 16:23:16 2018
-"""
 from __future__ import unicode_literals
+
+# Created on Fri Feb  9 16:23:16 2018
+
 from .common import PostProcessor
 import re
 
@@ -10,7 +10,6 @@ class MetadataFromUserPP(PostProcessor):
     def __init__(self, downloader, metadata):
         super(MetadataFromUserPP, self).__init__(downloader)
         self._metadata = metadata
-        
 
     def run(self, info):
         lastpos = 0
@@ -22,19 +21,18 @@ class MetadataFromUserPP(PostProcessor):
                 value = self._metadata[lastpos:match.start()].strip()
                 self._downloader.to_screen(
                     '[fromuser] %s: %s'
-                    %(attribute, value if value else 'NA'))
+                    % (attribute, value if value else 'NA'))
                 info[attribute] = value
-            attribute = match.group(1)    
+            attribute = match.group(1)
             lastpos = match.end()
 
         if attribute is None:
             # No attributes is given user, default assume the text as album name
-            attribute = 'album' 
+            attribute = 'album'
         # Add the last key
         value = self._metadata[lastpos:].strip()
         self._downloader.to_screen(
-            '[fromuser] %s: %s'
-            %(attribute, value if value else 'NA'))
+            '[fromuser] %s: %s' % (attribute, value if value else 'NA'))
         info[attribute] = value
 
         # If nothing specified for artist, extract from comments/description
@@ -42,9 +40,8 @@ class MetadataFromUserPP(PostProcessor):
             artist = re.findall('music(?![ia]).*$', info['description'], re.MULTILINE | re.IGNORECASE)
             artist = artist + re.findall('sing.*$', info['description'], re.MULTILINE | re.IGNORECASE)
             artist = ', '.join(artist).title().strip()
-            
             self._downloader.to_screen(
-                    '[artist] : %s : parsed from description' %(artist if artist else 'NA'))
+                '[artist] : %s : parsed from description' % (artist if artist else 'NA'))
             info['artist'] = artist
-        
+
         return [], info

--- a/youtube_dl/postprocessor/metadatafromuser.py
+++ b/youtube_dl/postprocessor/metadatafromuser.py
@@ -1,11 +1,6 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
 """
 Created on Fri Feb  9 16:23:16 2018
-
-@author: Niras C. Vayalil
 """
-
 from __future__ import unicode_literals
 from .common import PostProcessor
 import re


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

1. Have you even tried to check your changes? It does not work since it's not wired into the code.
2. It must not do anything apart from taking user provided metadata. No extraction from description, etc.
3. Core tests are broken.
4. Duplicate of #6064.

1 & 2. Bug fixed
3. Core test was failed with test_unicode_literals -> Fixed
4. The behaviour of #6064 is different. The #6064 is nearly the same as "--metadata-from-title" option, whilst the proposed modification allows user to override the parsed values by the "--add-metadata" or "--metadata-from-title", with user specified values. The proposed option allows user to specify all key/value pairs in a single --metadata call, i.e. "key1 = value1 key2 = value2", much easier than #6064.
--


