### PR TITLE
[Makefile] Add option to compile to bytecode when building youtube-dl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ MANDIR ?= $(PREFIX)/man
 SHAREDIR ?= $(PREFIX)/share
 PYTHON ?= /usr/bin/env python
 
+COMPILE ?= no
+COMPILEFLAGS := -q
+# Write to legacy location for python >=3.2, instead of __pycache__
+ifneq ($(shell $(PYTHON) --version 2>&1 | grep '^Python 3\.[2-9]'),)
+COMPILEFLAGS += -b
+endif
+
 # set SYSCONFDIR to /etc if PREFIX=/usr or PREFIX=/usr/local
 SYSCONFDIR = $(shell if [ $(PREFIX) = /usr -o $(PREFIX) = /usr/local ]; then echo /etc; else echo $(PREFIX)/etc; fi)
 
@@ -62,7 +69,10 @@ youtube-dl: youtube_dl/*.py youtube_dl/*/*.py
 	done
 	touch -t 200001010101 zip/youtube_dl/*.py zip/youtube_dl/*/*.py
 	mv zip/youtube_dl/__main__.py zip/
-	cd zip ; zip -q ../youtube-dl youtube_dl/*.py youtube_dl/*/*.py __main__.py
+	if [ "$(COMPILE)" = yes ] ; then \
+	  $(PYTHON) -m compileall $(COMPILEFLAGS) zip/ ;\
+	fi
+	cd zip ; zip -q ../youtube-dl youtube_dl/*.py* youtube_dl/*/*.py* __main__.py*
 	rm -rf zip
 	echo '#!$(PYTHON)' > youtube-dl
 	cat youtube-dl.zip >> youtube-dl


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description
The youtube-dl executable is packaged into a zip file, and this has to be compiled to bytecode each time when run, impacting execution time. However, when packaged with all .py files compiled to bytecode using the `compileall` module, the execution time is significantly reduced, matching that of the lazy-extractors build.

Examples:
```
$ python --version
Python 2.7.12
$ make -s youtube-dl
$ time ./youtube-dl --version
2018.03.03

real	0m0.645s
user	0m0.609s
sys	0m0.036s
$ make -s youtube-dl COMPILE=yes
$ time ./youtube-dl --version
2018.03.03

real	0m0.208s
user	0m0.188s
sys	0m0.020s
$ make -s lazy-extractors youtube-dl
$ time ./youtube-dl --version
2018.03.03

real	0m0.197s
user	0m0.178s
sys	0m0.020s
$ make -s lazy-extractors youtube-dl COMPILE=yes
$ time ./youtube-dl --version
2018.03.03

real	0m0.103s
user	0m0.096s
sys	0m0.008s
```
While bytecode isn't portable, packaging both .py and .pyc files allows the interpreter to fallback to compiling its own bytecode at runtime if versions don't match, making this transparent to the end user (at worst, no downsides in speed). However, since this bloats the executable, it shouldn't be made default without proper reasoning.