### PR TITLE
[TastyTrade] Fix old test, handle alt urls

### DIFF
--- a/youtube_dl/extractor/tastytrade.py
+++ b/youtube_dl/extractor/tastytrade.py
@@ -3,8 +3,6 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 from .ooyala import OoyalaIE
 
-import sys
-
 
 class TastyTradeIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?tastytrade\.com/tt/(?:shows|daily_recaps)/[^/]+/episodes/(?P<id>[^/?#&]+)'
@@ -32,8 +30,8 @@ class TastyTradeIE(InfoExtractor):
         'info_dict': {
             'id': 'lud3BtZTE6vnRdolxKRlwNoZQvb3z_LT',
             'ext': 'mp4',
-            'title': 'Soybeans & Corn: It\'s Planting Time',
-            'description': 'md5:a523504b1227de1b81faeba2876a6d23',
+            'title': 'TTL_CTGFE_180309_SEG_EDIT.mp4',
+            'description': 'md5:d41d8cd98f00b204e9800998ecf8427e',
         },
         'params': {
             'skip_download': True,
@@ -49,35 +47,7 @@ class TastyTradeIE(InfoExtractor):
             r'data-media-id=(["\'])(?P<code>(?:(?!\1).)+)\1',
             webpage, 'ooyala code', group='code')
 
-        info = {'id': None, 'title': None, 'description': None}
-
-        json_ld_info = self._search_json_ld(
-            webpage, display_id, default=None, fatal=False)
-
-        if (json_ld_info):
-            info = json_ld_info
-        else:
-            escaped_json_string = self._search_regex(
-                r'var episodeData = \$.parseJSON\("(?P<episode_json>.*)"\)',
-                webpage,
-                'episode json',
-                fatal=False,
-                group='episode_json'
-            )
-
-            if (escaped_json_string):
-                if sys.version_info[0] >= 3:
-                    unescaped_json_string = bytes(
-                        escaped_json_string, "utf-8").decode('unicode_escape')
-                else:
-                    unescaped_json_string = escaped_json_string.decode(
-                        'string_escape')
-                metadata = self._parse_json(unescaped_json_string, ooyala_code)
-                info = {
-                    'id': metadata.get('mediaId'),
-                    'title': metadata.get('title'),
-                    'description': metadata.get('description')
-                }
+        info = self._search_json_ld(webpage, display_id, default={})
 
         info.update({
             '_type': 'url_transparent',

--- a/youtube_dl/extractor/tastytrade.py
+++ b/youtube_dl/extractor/tastytrade.py
@@ -2,19 +2,28 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from .ooyala import OoyalaIE
+from youtube_dl.utils import (
+    ExtractorError,
+)
+
+import json
+import re
+import sys
 
 
 class TastyTradeIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?tastytrade\.com/tt/shows/[^/]+/episodes/(?P<id>[^/?#&]+)'
+    _VALID_URL = r'https?://(?:www\.)?tastytrade\.com/tt/(shows|daily_recaps)/[^/]+/episodes/(?P<id>[^/?#&]+)'
 
     _TESTS = [{
         'url': 'https://www.tastytrade.com/tt/shows/market-measures/episodes/correlation-in-short-volatility-06-28-2017',
         'info_dict': {
-            'id': 'F3bnlzbToeI6pLEfRyrlfooIILUjz4nM',
+            'id': '8xZW5xYjE6aLXhPwseCpyIf50oQw69JM',
             'ext': 'mp4',
-            'title': 'A History of Teaming',
-            'description': 'md5:2a9033db8da81f2edffa4c99888140b3',
-            'duration': 422.255,
+            'title': 'Correlation in Short Volatility',
+            'description': '[Correlation](https://www.tastytrade.com/tt/learn/correlation) is always changing and positions can be more correlated than we suspect. We can even have...',
+            'duration': 753.0,
+            'upload_date': '20170628',
+            'timestamp': 1498608000,
         },
         'params': {
             'skip_download': True,
@@ -23,6 +32,18 @@ class TastyTradeIE(InfoExtractor):
     }, {
         'url': 'https://www.tastytrade.com/tt/shows/daily-dose/episodes/daily-dose-06-30-2017',
         'only_matching': True,
+    }, {
+        'url': 'https://www.tastytrade.com/tt/daily_recaps/2018-03-09/episodes/soybeans-corn-its-planting-time-03-09-2018',
+        'info_dict': {
+            'id': 'lud3BtZTE6vnRdolxKRlwNoZQvb3z_LT',
+            'ext': 'mp4',
+            'title': 'Soybeans & Corn: It\'s Planting Time',
+            'description': 'md5:a523504b1227de1b81faeba2876a6d23',
+        },
+        'params': {
+            'skip_download': True,
+        },
+        'add_ie': ['Ooyala'],
     }]
 
     def _real_extract(self, url):
@@ -33,7 +54,30 @@ class TastyTradeIE(InfoExtractor):
             r'data-media-id=(["\'])(?P<code>(?:(?!\1).)+)\1',
             webpage, 'ooyala code', group='code')
 
-        info = self._search_json_ld(webpage, display_id, fatal=False)
+        info = {'id': None, 'title': None, 'description': None}
+
+        try:
+            info = self._search_json_ld(webpage, display_id, fatal=False)
+        except ExtractorError as ex:
+            json_string_match = re.search(
+                r'var episodeData = \$.parseJSON\("(?P<episode_json>.*)"\)', webpage, 0)
+
+            if (json_string_match):
+                escaped_json_string = json_string_match.group('episode_json')
+
+                if sys.version_info[0] >= 3:
+                    unescaped_json_string = bytes(
+                        escaped_json_string, "utf-8").decode('unicode_escape')
+                else:
+                    unescaped_json_string = escaped_json_string.decode(
+                        'string_escape')
+                metadata = json.loads(unescaped_json_string)
+                info = {
+                    'id': metadata.get('mediaId'),
+                    'title': metadata.get('title'),
+                    'description': metadata.get('description')
+                }
+
         info.update({
             '_type': 'url_transparent',
             'ie_key': OoyalaIE.ie_key(),

--- a/youtube_dl/extractor/tastytrade.py
+++ b/youtube_dl/extractor/tastytrade.py
@@ -12,7 +12,7 @@ import sys
 
 
 class TastyTradeIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?tastytrade\.com/tt/(shows|daily_recaps)/[^/]+/episodes/(?P<id>[^/?#&]+)'
+    _VALID_URL = r'https?://(?:www\.)?tastytrade\.com/tt/(?:shows|daily_recaps)/[^/]+/episodes/(?P<id>[^/?#&]+)'
 
     _TESTS = [{
         'url': 'https://www.tastytrade.com/tt/shows/market-measures/episodes/correlation-in-short-volatility-06-28-2017',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

TastyTrade added a new URL format that's common to their daily email newsletter. (It may also be accessible from the site, but I'm not sure.) I've changed the regex to recognize the new URL format. The change goes deeper, however, because these other URLs use a different content template that doesn't have the JSON-LD content that the scraper was originally using. The scraper will now fallback to looking for an escaped JSON string that's passed to some inline Javascript and use that to gather metadata.

Additionally, the old tests for this were failing, so I updated the data for the original test so that it now passes.