### PR TITLE
[twitch] remove rechat.twitch.tv as a subtitle source

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -310,18 +310,6 @@ class TwitchVodIE(TwitchItemBaseIE):
         if 't' in query:
             info['start_time'] = parse_duration(query['t'][0])
 
-        if info.get('timestamp') is not None:
-            info['subtitles'] = {
-                'rechat': [{
-                    'url': update_url_query(
-                        'https://rechat.twitch.tv/rechat-messages', {
-                            'video_id': 'v%s' % item_id,
-                            'start': info['timestamp'],
-                        }),
-                    'ext': 'json',
-                }],
-            }
-
         return info
 
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I've noticed that youtube-dl returns an url for rechat.twitch.tv as a subtitle, but the domain doesn't even exist anymore. It looks like twitch shut down this service back in october. This also causes some errors when mpv uses youtube-dl to open twitch VODs.

testing with youtube-dl:
```
>youtube-dl.py --verbose --write-sub https://www.twitch.tv/videos/235151000
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'--verbose', u'--write-sub', u'https://www.twitch.tv/videos/235151000']
[debug] Encodings: locale cp1250, fs mbcs, out cp852, pref cp1250
[debug] youtube-dl version 2018.03.10
[debug] Python version 2.7.12 (CPython) - Windows-7-6.1.7601-SP1
[debug] exe versions: ffmpeg N-89127-g8f4702a93f, ffprobe N-89127-g8f4702a93f
[debug] Proxy map: {}
[twitch:vod] 235151000: Downloading vod info JSON
[twitch:vod] 235151000: Downloading vod access token
[twitch:vod] 235151000: Downloading m3u8 information
[debug] Default format spec: bestvideo+bestaudio/best
[info] Writing video subtitles to: Holi _3  La Comarca !sorteo-v235151000.rechat.json
WARNING: Unable to download subtitle for "rechat": Unable to download webpage: <urlopen error [Errno 11004] getaddrinfo failed> (caused by URLError(gaierror(11004, 'getaddrinfo failed'),))
[debug] Invoking downloader on u'https://vod099-ttvnw.akamaized.net/df0e8d367becf8ccaf6b_duendepablo_27810724960_806840479/chunked
/index-muted-I7UUYYDRM4.m3u8'
[hlsnative] Downloading m3u8 manifest

ERROR: Interrupted by user
```

mpv:
```
>mpv https://www.twitch.tv/videos/235151000
Playing: https://www.twitch.tv/videos/235151000
[ffmpeg] tcp: Failed to resolve hostname rechat.twitch.tv: No address associated with hostname
Failed to open https://rechat.twitch.tv/rechat-messages?video_id=v235151000&start=1520175636.
Can not open external file https://rechat.twitch.tv/rechat-messages?video_id=v235151000&start=1520175636.
```

https://github.com/freaktechnik/twitch-chatlog/issues/56
