### PR TITLE
FFmpegCutVideo postprocessor, for cutting the video after download

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -283,6 +283,13 @@ def _real_main(argv=None):
         postprocessors.append({
             'key': 'FFmpegEmbedSubtitle',
         })
+    if opts.starttime or opts.endtime:
+        d = {'key': 'FFmpegCutVideo'}
+        if opts.starttime:
+            d['startTime'] = int(opts.starttime)
+        if opts.endtime:
+            d['endTime'] = int(opts.endtime)
+        postprocessors.append(d)
     if opts.embedthumbnail:
         already_have_thumbnail = opts.writethumbnail or opts.write_all_thumbnails
         postprocessors.append({

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -853,6 +853,14 @@ def parseOpts(overrideArguments=None):
         '--convert-subs', '--convert-subtitles',
         metavar='FORMAT', dest='convertsubtitles', default=None,
         help='Convert the subtitles to other format (currently supported: srt|ass|vtt|lrc)')
+    postproc.add_option(
+        '--start-time',
+        metavar='TIME', dest='starttime', default=None,
+        help='Cuts the video/audio starting at start-time')
+    postproc.add_option(
+        '--end-time',
+        metavar='TIME', dest='endtime', default=None,
+        help='Cuts the vidoe/audio up to end-time')
 
     parser.add_option_group(general)
     parser.add_option_group(network)

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from .embedthumbnail import EmbedThumbnailPP
 from .ffmpeg import (
     FFmpegPostProcessor,
+    FFmpegCutVideoPP,
     FFmpegEmbedSubtitlePP,
     FFmpegExtractAudioPP,
     FFmpegFixupStretchedPP,
@@ -26,6 +27,7 @@ __all__ = [
     'EmbedThumbnailPP',
     'ExecAfterDownloadPP',
     'FFmpegEmbedSubtitlePP',
+    'FFmpegCutVideoPP',
     'FFmpegExtractAudioPP',
     'FFmpegFixupM3u8PP',
     'FFmpegFixupM4aPP',

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -227,32 +227,38 @@ class FFmpegCutVideoPP(FFmpegPostProcessor):
         return "%d:%02d:%02d" % (h, m, s)
 
     def run(self, information):
-        if not self._startTime and not self._endTime:
-            self._downloader.to_screen('[ffmpeg] No startTime or endTime. Keeping original')
+        if self._startTime == 0 and self._endTime == None:
+            self._downloader.to_screen('[ffmpeg] No start time or end time. Keeping original')
             return [], information
 
-        if self._endTime <= self._startTime:
-            raise PostProcessingError("WARNING: endTime smaller than startTime")
+        if self._endTime and self._endTime <= self._startTime:
+            raise PostProcessingError("end time smaller or equal to the start time")
 
-        duration = information['duration']
-        if self._endTime and self._endTime > duration:
-            self._downloader.to_screen('WARNING: endTime greater than video duration')
+        if self._endTime == 0:
+            raise PostProcessingError("end time can't be zero")
+
+        duration = information.get('duration')
+
+        if self._endTime and duration and self._endTime >= duration:
+            self._downloader.to_screen('WARNING: end time greater than video duration')
             self._endTime = None
 
         options = ['-c', 'copy']
-        message = '[ffmpeg] Cutting video  '
+        message = '[ffmpeg] Cutting video '
 
         if self._startTime:
             start = self.toTime(self._startTime)
             options.extend(['-ss', start])
             message += 'from %s ' % (start)
-            duration -= self._startTime
+            if duration:
+                duration -= self._startTime
 
-        if self._endTime and self._endTime < duration:
+        if self._endTime:
             end = self.toTime(self._endTime)
             options.extend(['-to', end])
             message += 'to %s' % (end)
-            duration -= self._endTime
+            if duration:
+                duration -= self._endTime
 
         if '-to' not in options and '-ss' not in options:
             self._downloader.to_screen('[ffmpeg] Nothing to cut. Keeping original')
@@ -261,7 +267,8 @@ class FFmpegCutVideoPP(FFmpegPostProcessor):
         path = information['filepath']
         temp_filename = prepend_extension(path, 'temp')
         self._downloader.to_screen(message)
-        information['duration'] = duration
+        if duration:
+            information['duration'] = duration
         self.run_ffmpeg(path, temp_filename, options)
         os.remove(encodeFilename(path))
         os.rename(encodeFilename(temp_filename), encodeFilename(path))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

This is a simple FFmpeg postprocessor for cutting videos at start-time and end-time:

`youtube-dl "URL" --start-time 10 --end-time 12`

There is a similar pull request for this feature that's nearly two years old and hasn't been worked for a long time now. This is understandable a hack: the whole video is downloaded for cutting just a segment. But I believe there is a need for this kind of postprocessing, and I've seen many a one-liner for this in the forums. It updates video duration if available, validates start-time and end-time and cuts only when needed, keeping all original stream codecs (-c copy). I believe this could do for the time being.
