### PR TITLE
[vimeo] fix album extraction (issue #15704)

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -834,14 +834,14 @@ class VimeoAlbumIE(VimeoChannelIE):
         'url': 'https://vimeo.com/album/2632481',
         'info_dict': {
             'id': '2632481',
-            'title': 'Vimeo / Staff Favorites: November 2013',
+            'title': 'Staff Favorites: November 2013',
         },
         'playlist_mincount': 13,
     }, {
         'url': 'https://vimeo.com/album/4786409',
         'info_dict': {
             'id': '4786409',
-            'title': 'Vimeo / NSSpain 2017',
+            'title': 'NSSpain 2017',
         },
         'playlist_mincount': 25,
     }, {
@@ -871,16 +871,19 @@ class VimeoAlbumIE(VimeoChannelIE):
         album_id = self._match_id(url)
         rss_url = url + '/rss'
 
-        doc = self._download_xml(rss_url, album_id, fatal=True)
+        doc = self._download_xml(rss_url, album_id, fatal=False)
 
         playlist_title = doc.find('./channel/title').text
+        re_clean_title = re.compile('(?:Vimeo / )(.*)')
+        playlist_title = re_clean_title.findall(playlist_title)[0]
+
         playlist_desc_el = doc.find('./channel/description')
         playlist_desc = None if playlist_desc_el is None else playlist_desc_el.text
 
         entries = []
         for it in doc.findall('./channel/item'):
             next_title = it.find('title').text
-            next_url = xpath_text(it, 'link', fatal=False)
+            next_url = xpath_text(it, 'link')
             if not next_url:
                 continue
 

--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -838,6 +838,20 @@ class VimeoAlbumIE(VimeoChannelIE):
         },
         'playlist_mincount': 13,
     }, {
+        'url': 'https://vimeo.com/album/2632481/sort:plays/format:thumbnail',
+        'info_dict': {
+            'id': '2632481',
+            'title': 'Staff Favorites: November 2013',
+        },
+        'playlist_mincount': 13,
+    }, {
+        'url': 'https://vimeo.com/album/2632481/page:2/sort:plays/format:thumbnail',
+        'info_dict': {
+            'id': '2632481',
+            'title': 'Staff Favorites: November 2013',
+        },
+        'playlist_mincount': 13,
+    }, {
         'url': 'https://vimeo.com/album/4786409',
         'info_dict': {
             'id': '4786409',
@@ -869,7 +883,12 @@ class VimeoAlbumIE(VimeoChannelIE):
 
     def _real_extract(self, url):
         album_id = self._match_id(url)
-        rss_url = url + '/rss'
+
+        # we only want the base url with the id, excluding possibly appended
+        # options like e.g 'sort:plays'.
+        re_clean_url = re.compile(r'https://vimeo\.com/album/\d+')
+        clean_url = re_clean_url.findall(url)[0]
+        rss_url = clean_url + '/rss'
 
         doc = self._download_xml(rss_url, album_id, fatal=False)
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

(Mixed, took some snippets from elsewhere in youtube-dl)

### What is the purpose of your *pull request*?
- [x] Bug fix
---

### Description of your *pull request* and other information

Fixes the vimeo album playlist extraction. I added a test (from the original bug report). So, this resolves #15704.