### PR TITLE
[requestforcomments] new extractor for requestforcomments podcast

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -885,6 +885,7 @@ from .rentv import (
     RENTVIE,
     RENTVArticleIE,
 )
+from .requestforcomments import RequestForCommentsIE
 from .restudy import RestudyIE
 from .reuters import ReutersIE
 from .reverbnation import ReverbNationIE

--- a/youtube_dl/extractor/requestforcomments.py
+++ b/youtube_dl/extractor/requestforcomments.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+
+
+class RequestForCommentsIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?requestforcomments.de/(?:archives/|\?p=)(?P<id>[^\s]+)'
+    _TESTS = [{
+        'url': 'https://requestforcomments.de/archives/412',
+        'info_dict': {
+            'id': '412',
+            'ext': 'ogg',
+            'formats': 'mincount:4',
+            'title': 'RFCE014: IPv6',
+            'description': 'md5:e0924fc2a3536107c2055b3c36bef2e9',
+            'site_name': 'Request for Comments',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://requestforcomments.de/?p=412',
+        'info_dict': {
+            'id': '412',
+            'ext': 'ogg',
+            'formats': 'mincount:4',
+            'title': 'RFCE014: IPv6',
+            'description': 'md5:e0924fc2a3536107c2055b3c36bef2e9',
+            'site_name': 'Request for Comments',
+            'thumbnail': r're:^https?://.*\.jpg$',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
+
+    def _real_extract(self, url):
+
+        content_id = self._match_id(url).strip('/')
+        webpage = self._download_webpage(url, content_id)
+
+        audio_reg = self._og_regexes('audio')
+        audio_type_reg = self._og_regexes('audio:type')
+
+        formats = []
+        for audio_url, audio_type in zip(
+                re.findall(audio_reg[0], webpage),
+                re.findall(audio_type_reg[0], webpage)):
+            formats.append({
+                'url': audio_url[0],
+                'format_id': audio_type[0]})
+
+        return {
+            'id': content_id,
+            'title': self._og_search_title(webpage),
+            'site_name': self._og_search_property('site_name', webpage),
+            'description': self._og_search_description(webpage),
+            'thumbnail': self._og_search_thumbnail(webpage),
+            'formats': formats,
+        }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] New extractor

---

### Description of your *pull request* and other information

RequestForComments is another podcast, which also uses more or less the same webpage as the Metaebene podcasts (see #15872), but from another producer. This is an extractor for the page (requestforcomments.de). It is not associated with the IETF.
I decided to make two seperate extractors because:
- I did not want RequestForComments to appear as one of the podcasts of the Metaebene producer, because that would be wrong
- I did not find a way, to use the logic of MetaebeneIE in RequestForCommentsIE without instantating an object of it or stuff.

As the extraction is very simple, I think it is okay, to keep them as two. This might also help in the future, if either one of the Metaebene pages or the RequestForComments page should change.
