### PR TITLE
[Roosterteeth] Update extractor to support new site.

### DIFF
--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -336,8 +336,8 @@ class OpenloadIE(InfoExtractor):
                       get_element_by_id('streamuri', webpage) or
                       get_element_by_id('streamurj', webpage) or
                       self._search_regex(
-                          (r'>\s*([\da-zA-Z]+~\d{10,}~\d+\.\d+\.0\.0~[\da-zA-Z]+)\s*<',
-                           r'>\s*([\w~]+~\d+\.\d+\.\d+\.\d+~[\w~]+)'), webpage,
+                          (r'>\s*([\w-]+~\d{10,}~\d+\.\d+\.0\.0~[\w-]+)\s*<',
+                           r'>\s*([\w~-]+~\d+\.\d+\.\d+\.\d+~[\w~-]+)'), webpage,
                           'stream URL'))
 
         video_url = 'https://openload.co/stream/%s?mime=true' % decoded_id

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -96,7 +96,11 @@ class RoosterTeethIE(InfoExtractor):
         title = attributes.get('title')
         description = attributes.get('caption')
         series = attributes.get('show_title')
-        thumbnail = self._get_thumbnail(data.get('included', {}).get('images'))
+
+        images = data.get('included', {}).get('images')
+        if images and len(images) > 0:
+            images = images[0]
+        thumbnail = images.get('attributes', {}).get('thumb')
 
         video_response = self._call_api(
             display_id,
@@ -153,13 +157,6 @@ class RoosterTeethIE(InfoExtractor):
 
     def _golive_error(self, video_id, member_level):
         raise ExtractorError('{0} is not yet live for {1}'.format(video_id, member_level))
-
-    def _get_thumbnail(self, images):
-        if not images or len(images) == 0:
-            return None
-
-        images = images[0]
-        return images.get('attributes', {}).get('thumb')
 
     def _call_api(self, video_id, path=None, **kwargs):
         url = self._API_URL + video_id

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -97,13 +97,11 @@ class RoosterTeethIE(InfoExtractor):
             headers=headers,
         )
 
-        if len(api_response.get('data', [])) == 0:
-            raise ExtractorError('Unable to download video information')
-        data = api_response.get('data')[0]
+        data = api_response['data'][0]
 
-        attributes = data.get('attributes', {})
+        attributes = data['attributes']
         episode = attributes.get('display_title')
-        title = attributes.get('title')
+        title = attributes['title']
         description = attributes.get('caption')
         series = attributes.get('show_title')
 
@@ -139,8 +137,6 @@ class RoosterTeethIE(InfoExtractor):
                 else:
                     raise ExtractorError('Video is not available')
 
-        if len(video_response.get('data', [])) == 0:
-            raise ExtractorError('Unable to download video information')
         video_attributes = video_response.get('data')[0].get('attributes')
 
         m3u8_url = video_attributes.get('url')

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -78,12 +78,7 @@ class RoosterTeethIE(InfoExtractor):
         created_at = response.get('created_at', 0)
         expires_in = response.get('expires_in', 0)
 
-        self._set_cookie(
-            '.roosterteeth.com',
-            'rt_access_token',
-            self._ACCESS_TOKEN,
-            created_at + expires_in
-        )
+        self._set_cookie('.roosterteeth.com', 'rt_access_token', self._ACCESS_TOKEN, created_at + expires_in)
 
     def _real_initialize(self):
         self._login()
@@ -93,7 +88,7 @@ class RoosterTeethIE(InfoExtractor):
 
         headers = {}
         if self._ACCESS_TOKEN:
-            headers['Authorization'] = 'Bearer {}'.format(self._ACCESS_TOKEN)
+            headers['Authorization'] = 'Bearer ' + self._ACCESS_TOKEN
 
         api_response = self._call_api(
             display_id,
@@ -178,11 +173,7 @@ class RoosterTeethIE(InfoExtractor):
         if path:
             url = url + path
 
-        return self._download_json(
-            url,
-            video_id,
-            **kwargs
-        )
+        return self._download_json(url, video_id, **kwargs)
 
     def _get_cookie(self, name):
         for cookie in self._downloader.cookiejar:

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -6,7 +6,9 @@ import time
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    compat_str,
     str_or_none,
+    try_get,
     unified_timestamp,
     urlencode_postdata,
 )
@@ -105,10 +107,7 @@ class RoosterTeethIE(InfoExtractor):
         description = attributes.get('caption')
         series = attributes.get('show_title')
 
-        images = data.get('included', {}).get('images')
-        if images and len(images) > 0:
-            images = images[0]
-        thumbnail = images.get('attributes', {}).get('thumb')
+        thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes']['thumb'], compat_str)
 
         video_response = self._call_api(
             display_id,
@@ -137,7 +136,7 @@ class RoosterTeethIE(InfoExtractor):
                 else:
                     raise ExtractorError('Video is not available')
 
-        video_attributes = video_response.get('data')[0].get('attributes')
+        video_attributes = try_get(video_response, lambda x: x['data'][0]['attributes'])
 
         m3u8_url = video_attributes.get('url')
         if not m3u8_url:

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -15,7 +15,7 @@ from ..utils import (
 class RoosterTeethIE(InfoExtractor):
     _VALID_URL = r'https?://(?:.+?\.)?roosterteeth\.com/episode/(?P<id>[^/?#&]+)'
     _LOGIN_URL = 'https://auth.roosterteeth.com/oauth/token'
-    _API_URL = "https://svod-be.roosterteeth.com/api/v1/episodes/"
+    _API_URL = 'https://svod-be.roosterteeth.com/api/v1/episodes/'
     _ACCESS_TOKEN = None
     _NETRC_MACHINE = 'roosterteeth'
     _TESTS = [{
@@ -78,7 +78,7 @@ class RoosterTeethIE(InfoExtractor):
 
         headers = {}
         if self._ACCESS_TOKEN:
-            headers["Authorization"] = "Bearer {}".format(self._ACCESS_TOKEN)
+            headers['Authorization'] = 'Bearer {}'.format(self._ACCESS_TOKEN)
 
         api_response = self._call_api(
             display_id,

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -107,7 +107,11 @@ class RoosterTeethIE(InfoExtractor):
         description = attributes.get('caption')
         series = attributes.get('show_title')
 
-        thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes']['large'], compat_str)
+        thumbnails = []
+        for size in ['thumb', 'small', 'medium', 'large']:
+            thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes'][size], compat_str)
+            if thumbnail:
+                thumbnails.append({'url': thumbnail})
 
         video_response = self._call_api(
             display_id,
@@ -154,7 +158,7 @@ class RoosterTeethIE(InfoExtractor):
             'display_id': display_id,
             'title': title,
             'description': description,
-            'thumbnail': thumbnail,
+            'thumbnails': thumbnails,
             'series': series,
             'episode': episode,
             'formats': formats,

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -108,10 +108,10 @@ class RoosterTeethIE(InfoExtractor):
         series = attributes.get('show_title')
 
         thumbnails = []
-        for size in ['thumb', 'small', 'medium', 'large']:
+        for i, size in enumerate(['thumb', 'small', 'medium', 'large']):
             thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes'][size], compat_str)
             if thumbnail:
-                thumbnails.append({'url': thumbnail})
+                thumbnails.append({'url': thumbnail, 'id': i})
 
         video_response = self._call_api(
             display_id,

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -107,7 +107,7 @@ class RoosterTeethIE(InfoExtractor):
         description = attributes.get('caption')
         series = attributes.get('show_title')
 
-        thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes']['thumb'], compat_str)
+        thumbnail = try_get(data, lambda x: x['included']['images'][0]['attributes']['large'], compat_str)
 
         video_response = self._call_api(
             display_id,

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -106,10 +106,10 @@ class RoosterTeethIE(InfoExtractor):
         data = api_response.get('data')[0]
 
         attributes = data.get('attributes', {})
-        episode = str_or_none(attributes.get('display_title'))
-        title = str_or_none(attributes.get('title'))
-        description = str_or_none(attributes.get('caption'))
-        series = str_or_none(attributes.get('show_title'))
+        episode = attributes.get('display_title')
+        title = attributes.get('title')
+        description = attributes.get('caption')
+        series = attributes.get('show_title')
         thumbnail = self.get_thumbnail(data.get('included', {}).get('images'))
 
         video_response = self._download_json(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This updates the extractor for Roosterteeth.com to support the recent changes to the website. It now uses the officially provided API rather than scraping HTML. Addresses issue #16094.

There are some issues that need to be fixed before it can be merged.

- ~~Videos that do not require log in can be downloaded with no issue, but attempting to log in fails. I have not yet found a way to log in through the new API. The old log in URL stills exists, and can be used to log in through a browser. However, the form is now loaded through Javascript after the page loads, so youtube-dl seems unable to grab it.~~ Logging in and downloading FIRST-only videos now works.

- ~~The changes I made don't look great, as I just wanted to get it mostly working before hopefully getting feedback on the log in issue. I'll be going through and fixing things up over the weekend.~~ I've cleaned things up and made user-facing strings less generic. I'm open to any suggestions for further changes.

Logging in is done by POSTing username and password to an authorization URL, and an access token is returned. ~~This access token is a cookie in the browser, so it could be saved as a cookie here, but I'm not sure how to do that, or how to check if a saved cookie is expired. I'll look more in to it.~~

Barring any requested changes, this seems ready to be merged.

Edit: The access token is a standard JWT that is valid for 8 hours after logging in. I have implemented saving the access token as a cookie and re-downloading it after it expires, so users who download multiple videos in a short time will not have to log in every time.