### PR TITLE
--embed-subs now implies --write-sub

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -280,6 +280,7 @@ def _real_main(argv=None):
             'format': opts.convertsubtitles,
         })
     if opts.embedsubtitles:
+        opts.writesubtitles = True # Required to generate a final file with embed subtitles
         postprocessors.append({
             'key': 'FFmpegEmbedSubtitle',
         })

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -805,7 +805,7 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--embed-subs',
         action='store_true', dest='embedsubtitles', default=False,
-        help='Embed subtitles in the video (only for mp4, webm and mkv videos)')
+        help='Embed subtitles in the video (only for mp4, webm and mkv videos), implies --write-sub')
     postproc.add_option(
         '--embed-thumbnail',
         action='store_true', dest='embedthumbnail', default=False,


### PR DESCRIPTION
`--write-sub` was needed to generate a video file with embed subtitles anyway, so
we simplify the interface

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

We simplify the interface, by not requiring `--write-sub` if `--embed-sub` is present. We do this because `--embed-sub` requires `--write-sub` to actually produce a file with embed subtitles.

```
$ youtube-dl --embed-subs --sub-lang en,fr 'https://www.youtube.com/watch?v=-sGiE10zNQM' # produces a file with *no* subtitles; we fix this issue
$ youtube-dl --write-sub --embed-subs --sub-lang en,fr 'https://www.youtube.com/watch?v=-sGiE10zNQM' # actually works
```