### PR TITLE
Add warning for --audio-format without -x

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -445,6 +445,13 @@ def _real_main(argv=None):
         if opts.rm_cachedir:
             ydl.cache.remove()
 
+        # Warn if no-effect args are given
+        if opts.audioformat and not opts.extractaudio:
+            ydl.report_warning(
+                'You have specified "--audio-format", '
+                'but have not given "--extract-audio". '
+                'Audio will not be extracted.')
+
         # Maybe do nothing
         if (len(all_urls) < 1) and (opts.load_info_filename is None):
             if opts.update_self or opts.rm_cachedir:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Just adding a warning if someone includes the `--audio-format` argument but isn't extracting audio; this situation is most likely to be user error, and in a long chain of options it's easy to miss a short one (I did it myself, earlier today). This change does not break from prior behaviour (in that it does not prevent the use of `--audio-format` without `-x`), only warning the user so they can cancel quickly if they meant to use `-x`.