### PR TITLE
Work around vtt subtitle not announced in nrk JSON

### DIFF
--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -75,8 +75,9 @@ class NRKBaseIE(InfoExtractor):
                 entry_id, entry_title = video_id_and_title(num)
                 duration = parse_duration(asset.get('duration'))
                 subtitles = {}
-                for subtitle in ('webVtt', 'timedText'):
-                    subtitle_url = asset.get('%sSubtitlesUrl' % subtitle)
+                subtitle_base = asset.get('timedTextSubtitlesUrl')
+                for subtitle in ('ttml', 'vtt'):
+                    subtitle_url = re.sub(r"ttml$", subtitle, subtitle_base)
                     if subtitle_url:
                         subtitles.setdefault('no', []).append({
                             'url': compat_urllib_parse_unquote(subtitle_url)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Nowadays, only timedTextSubtitlesUrl is returned in the nrk JSON, but the webVtt one (previously returned as webVttSubtitlesUrl) is still available, just by replacing .ttml by .vtt in the URL.
I’ve created a new variable to store the ttml URL, and I replace the extension by ttml and vtt (so yes, the first iteration is pointless, but I didn’t know how to avoid it without changing the code base)

Also, mpv seems not to be comfortable with ttml subtitles:
```alarig@airmure ~ % mpv http://tv.nrk.no/serie/vikingane/MUHH33000116/sesong-1/episode-1                            
Playing: http://tv.nrk.no/serie/vikingane/MUHH33000116/sesong-1/episode-1
[ffmpeg] tls: The TLS connection was non-properly terminated.
EDL: Could not open source file 'https://undertekst.nrk.no/prod/MUHH33/00/MUHH33000116AA/TMP/MUHH33000116AA.ttml'.
No streams added from file edl://%79%https://undertekst.nrk.no/prod/MUHH33/00/MUHH33000116AA/TMP/MUHH33000116AA.ttml,length=1783;.
Can not open external file edl://%79%https://undertekst.nrk.no/prod/MUHH33/00/MUHH33000116AA/TMP/MUHH33000116AA.ttml,length=1783;.
 (+) Video --vid=1 (h264 1280x720 25.000fps)
 (+) Audio --aid=1 (aac 2ch 48000Hz)
AO: [alsa] 48000Hz stereo 2ch float
VO: [opengl] 1280x720 yuv420p
AV: 00:00:16 / 00:29:43 (0%) A-V:  0.000 Cache: 10s
```

But with the vtt ones it works:
```alarig@airmure ~ % mpv https://tv.nrk.no/serie/vikingane/MUHH33000116/sesong-1/episode-1                            
Playing: https://tv.nrk.no/serie/vikingane/MUHH33000116/sesong-1/episode-1
[ffmpeg] tls: The TLS connection was non-properly terminated.
EDL: entry 0 uses 1783.000000 seconds, but file has only 0.000000 seconds.
 (+) Video --vid=1 (h264 1280x720 25.000fps)
 (+) Audio --aid=1 (aac 2ch 48000Hz)
     Subs  --sid=1 --slang=no 'vtt' (webvtt) (external)
AO: [alsa] 48000Hz stereo 2ch float
VO: [opengl] 1280x720 yuv420p
AV: 00:05:30 / 00:29:43 (18%) A-V: -0.000 Cache:  9s
Track switched:
 (+) Video --vid=1 (h264 1280x720 25.000fps)
 (+) Audio --aid=1 (aac 2ch 48000Hz)
 (+) Subs  --sid=1 --slang=no 'vtt' (webvtt) (external)
(Paused) AV: 00:05:32 / 00:29:43 (18%) A-V:  0.000 Cache:  9s
```
https://bulbizarre.swordarmor.fr/garbage/images/2018-05-12-011459_1676x1011_scrot.png