### PR TITLE
[CBC] Fix test errors

### DIFF
--- a/youtube_dl/extractor/cbc.py
+++ b/youtube_dl/extractor/cbc.py
@@ -101,7 +101,7 @@ class CBCIE(InfoExtractor):
         # multiple CBC.APP.Caffeine.initInstance(...)
         'url': 'http://www.cbc.ca/news/canada/calgary/dog-indoor-exercise-winter-1.3928238',
         'info_dict': {
-            'title': 'Keep Rover active during the deep freeze with doggie pushups and other fun indoor tasks',
+            'title': 're:Keep Rover active during the deep freeze with doggie pushups and other fun indoor tasks.*',
             'id': 'dog-indoor-exercise-winter-1.3928238',
             'description': 'md5:c18552e41726ee95bd75210d1ca9194c',
         },
@@ -273,8 +273,20 @@ class CBCWatchBaseIE(InfoExtractor):
             guid = xpath_text(item, 'guid', fatal=True)
             title = xpath_text(item, 'title', fatal=True)
 
-            media_group = xpath_element(item, _add_ns('media:group'), fatal=True)
-            content = xpath_element(media_group, _add_ns('media:content'), fatal=True)
+            media_group = xpath_element(item, _add_ns('media:group'), fatal=False)
+            content = None
+            if media_group is not None:
+                content = xpath_element(media_group, _add_ns('media:content'), fatal=True)
+
+            if content is None:
+                content = xpath_element(item, _add_ns('media:content'), fatal=False)
+
+            if content is None:
+                link = xpath_text(item, 'link', fatal=True)
+                sub_result = self._parse_rss_feed(self._call_api(link, guid))
+                entries.extend(sub_result.get('entries') or [])
+                continue
+
             content_url = content.attrib['url']
 
             thumbnails = []


### PR DESCRIPTION
 Load also indirectly linked playlists (series -> season)

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR fixes the following error:
```

======================================================================
ERROR: test_CBCWatch_1 (test.test_download.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/extras/src/youtube-dl/test/test_download.py", line 159, in test_template
    force_generic_extractor=params.get('force_generic_extractor', False))
  File "/mnt/extras/src/youtube-dl/youtube_dl/YoutubeDL.py", line 815, in extract_info
    self.report_error(compat_str(e), e.format_traceback())
  File "/mnt/extras/src/youtube-dl/youtube_dl/YoutubeDL.py", line 620, in report_error
    self.trouble(error_message, tb)
  File "/mnt/extras/src/youtube-dl/youtube_dl/YoutubeDL.py", line 590, in trouble
    raise DownloadError(message, exc_info)
DownloadError: ERROR: Could not find XML element {http://search.yahoo.com/mrss/}group; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
-------------------- >> begin captured stdout << ---------------------
[debug] Using fake IP 99.253.222.160 (CA) as X-Forwarded-For.
[cbc.ca:watch] 1ed4b385-cd84-49cf-95f0-80f004680057: Downloading XML
[cbc.ca:watch] 1ed4b385-cd84-49cf-95f0-80f004680057: Downloading XML
ERROR: Could not find XML element {http://search.yahoo.com/mrss/}group; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/mnt/extras/src/youtube-dl/youtube_dl/YoutubeDL.py", line 792, in extract_info
    ie_result = ie.extract(url)
  File "/mnt/extras/src/youtube-dl/youtube_dl/extractor/common.py", line 500, in extract
    ie_result = self._real_extract(url)
  File "/mnt/extras/src/youtube-dl/youtube_dl/extractor/cbc.py", line 384, in _real_extract
    return self._parse_rss_feed(rss)
  File "/mnt/extras/src/youtube-dl/youtube_dl/extractor/cbc.py", line 266, in _parse_rss_feed
    media_group = xpath_element(item, _add_ns('media:group'), fatal=True)
  File "/mnt/extras/src/youtube-dl/youtube_dl/utils.py", line 306, in xpath_element
    raise ExtractorError('Could not find XML element %s' % name)
ExtractorError: Could not find XML element {http://search.yahoo.com/mrss/}group; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.


```

It turns out, the Aardvark playlist actually refers to other playlists for individual seasons, not the videos. This patch just downloads and recurses to them if there is no media present.