### PR TITLE
Fix for issue 16262

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -115,9 +115,6 @@ class PornHubIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        # playlist loading can lead to cookies here, interferring with platform settings
-        self._downloader.cookiejar.clear('.pornhub.com')
-
         self._set_cookie('pornhub.com', 'age_verified', '1')
 
         def dl_webpage(platform):
@@ -262,6 +259,9 @@ class PornHubPlaylistBaseIE(InfoExtractor):
         title = playlist.get('title') or self._search_regex(
             r'>Videos\s+in\s+(.+?)\s+[Pp]laylist<', webpage, 'title', fatal=False)
 
+        # list loading can lead to cookies in .pornhub.com, interferring with platform settings when loading the pages
+        self._downloader.cookiejar.clear('.pornhub.com')
+
         return self.playlist_result(
             entries, playlist_id, title, playlist.get('description'))
 
@@ -333,5 +333,8 @@ class PornHubUserVideosIE(PornHubPlaylistBaseIE):
             if not page_entries:
                 break
             entries.extend(page_entries)
+
+        # list loading can lead to cookies in .pornhub.com, interferring with platform settings when loading the pages
+        self._downloader.cookiejar.clear('.pornhub.com')
 
         return self.playlist_result(entries, user_id)

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -115,6 +115,9 @@ class PornHubIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
+        # playlist loading can lead to cookies here, interferring with platform settings
+        self._downloader.cookiejar.clear('.pornhub.com')
+
         self._set_cookie('pornhub.com', 'age_verified', '1')
 
         def dl_webpage(platform):


### PR DESCRIPTION
Playlist loading initialize the 'platform' cookie on the domain '.pornhub.com' (with initial dot)
This messes up with the loading of the tv_webpage that specifies another value for the 'platform' cookie but on the 'pornhub.com' domain (no initial dot)
Fix is to clear the .pornhub.com domain cookies

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Playlist loading initializes the 'platform' cookie on the domain '.pornhub.com' (with initial dot)
It is set to 'pc'.
When we then load each video separately in _real_extract, this messes up with the loading of the tv_webpage, as that loading specifies the 'tv' for the 'platform' cookie, but on the 'pornhub.com' domain (no initial dot).
The http request ends up having the cookie set up twice, and reloads the 'pc' version instead.

The proposed fix is to clear the .pornhub.com domain cookies at the begining of the function.
(The listed samples in the bug report do work with the fix)