### PR TITLE
[generic] Correct apply order on playlist-reverse (closes #6845)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -937,6 +937,9 @@ class YoutubeDL(object):
                     '[%s] playlist %s: Downloading %d videos' %
                     (ie_result['extractor'], playlist, num_entries))
 
+            if self.params.get('playlistreverse', False):
+                ie_entries = ie_entries[::-1]
+
             if isinstance(ie_entries, list):
                 n_all_entries = len(ie_entries)
                 if playlistitems:
@@ -968,9 +971,6 @@ class YoutubeDL(object):
                         ie_entries, playliststart, playlistend))
                 n_entries = len(entries)
                 report_download(n_entries)
-
-            if self.params.get('playlistreverse', False):
-                entries = entries[::-1]
 
             if self.params.get('playlistrandom', False):
                 random.shuffle(entries)

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -937,10 +937,7 @@ class YoutubeDL(object):
                     '[%s] playlist %s: Downloading %d videos' %
                     (ie_result['extractor'], playlist, num_entries))
 
-            if self.params.get('playlistreverse', False):
-                ie_entries = ie_entries[::-1]
-
-            if isinstance(ie_entries, list):
+            def build_entries_list(ie_entries):
                 n_all_entries = len(ie_entries)
                 if playlistitems:
                     entries = make_playlistitems_entries(ie_entries)
@@ -950,6 +947,12 @@ class YoutubeDL(object):
                 self.to_screen(
                     '[%s] playlist %s: Collected %d video ids (downloading %d of them)' %
                     (ie_result['extractor'], playlist, n_all_entries, n_entries))
+                return n_entries, entries
+
+            if isinstance(ie_entries, list):
+                if self.params.get('playlistreverse', False):
+                    ie_entries = ie_entries[::-1]
+                n_entries, entries = build_entries_list(ie_entries)
             elif isinstance(ie_entries, PagedList):
                 if playlistitems:
                     entries = []
@@ -958,19 +961,28 @@ class YoutubeDL(object):
                             item - 1, item
                         ))
                 else:
-                    entries = ie_entries.getslice(
-                        playliststart, playlistend)
+                    if self.params.get('playlistreverse', False):
+                        entries = ie_entries.getslice()
+                        entries = entries[::-1][playliststart:playlistend]
+
+                    else:
+                        entries = ie_entries.getslice(
+                            playliststart, playlistend)
                 n_entries = len(entries)
                 report_download(n_entries)
             else:  # iterable
-                if playlistitems:
-                    entries = make_playlistitems_entries(list(itertools.islice(
-                        ie_entries, 0, max(playlistitems))))
+                if self.params.get('playlistreverse', False):
+                    ie_entries = list(ie_entries)[::-1]
+                    n_entries, entries = build_entries_list(ie_entries)
                 else:
-                    entries = list(itertools.islice(
-                        ie_entries, playliststart, playlistend))
-                n_entries = len(entries)
-                report_download(n_entries)
+                    if playlistitems:
+                        entries = make_playlistitems_entries(list(itertools.islice(
+                            ie_entries, 0, max(playlistitems))))
+                    else:
+                        entries = list(itertools.islice(
+                            ie_entries, playliststart, playlistend))
+                    n_entries = len(entries)
+                    report_download(n_entries)
 
             if self.params.get('playlistrandom', False):
                 random.shuffle(entries)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Allows for the use of the --playlist-reverse and --playlist-start (and/or --playlist-end) flags to be used together

Currently, when you use this --playlist-start and --playlist-reverse command line flags together, it will first apply the limiting from the start(/end), and then reverse the results for download.

As per issue #6845 (and all of the associated bugs attached to it), this is not the intuitive way to understand how these flags should work together.

Instead, one would expect the reversing to occur first, and then from there, the limiting of the download amount to occur.

This change does exactly that, by applying the reverse to the ie_entries prior to it being having the start / end applied to it, instead of reversing the entries after the reverse.
