### PR TITLE
[SverigesRadio] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1061,6 +1061,10 @@ from .streamcz import StreamCZIE
 from .streetvoice import StreetVoiceIE
 from .stretchinternet import StretchInternetIE
 from .sunporno import SunPornoIE
+from .sverigesradio import (
+    SverigesRadioArtikelIE,
+    SverigesRadioAvsnittIE,
+)
 from .svt import (
     SVTIE,
     SVTPageIE,
@@ -1366,7 +1370,7 @@ from .webofstories import (
     WebOfStoriesPlaylistIE,
 )
 from .weibo import (
-    WeiboIE, 
+    WeiboIE,
     WeiboMobileIE
 )
 from .weiqitv import WeiqiTVIE

--- a/youtube_dl/extractor/sverigesradio.py
+++ b/youtube_dl/extractor/sverigesradio.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class SverigesRadioIE(InfoExtractor):
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        json = self._download_json('https://sverigesradio.se/sida/playerajax/getaudiourl?type=' + self.SR_type + '&quality=high&format=iis&id=' + video_id, video_id)
+        audioUrl = json.get('audioUrl')
+
+        # TODO more code goes here, for example ...
+        # title = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'title')
+
+        return {
+            'url': audioUrl,
+            'id': video_id,
+            'title': self._og_search_title(webpage),
+            # TODO more properties (see youtube_dl/extractor/common.py)
+        }
+
+class SverigesRadioArtikelIE(SverigesRadioIE):
+    _VALID_URL = r'https?://(?:www\.)?sverigesradio\.se/sida/artikel.aspx\?(.*)artikel=(?P<id>[0-9]*)'
+    _TEST = {
+        'url': 'https://sverigesradio.se/sida/artikel.aspx?programid=83&artikel=7038546',
+        'md5': '6a4917e1923fccb080e5a206a5afa542',
+        'info_dict': {
+            'id': '7038546',
+            'ext': 'm4a',
+            'title': 'Esa Teittinen: Sanningen har inte kommit fram - Nyheter (Ekot)',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type (for example int or float)
+        }
+    }
+    SR_type = 'publication'
+
+class SverigesRadioAvsnittIE(SverigesRadioIE):
+    _VALID_URL = r'https?://(?:www\.)?sverigesradio\.se/sida/avsnitt/(?P<id>[0-9]*)'
+    _TESTS = [{
+        'url': 'https://sverigesradio.se/sida/avsnitt/1140922?programid=1300',
+        'md5': '20dc4d8db24228f846be390b0c59a07c',
+        'info_dict': {
+            'id': '1140922',
+            'ext': 'mp3',
+            'title': 'Metoo och valen - Konflikt',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type (for example int or float)
+        }
+    }, {
+        'url': 'https://sverigesradio.se/sida/avsnitt/1140948?programid=4772',
+        'md5': 'b360f34e1931cbd6dbf9c502a4b2e35d',
+        'info_dict': {
+            'id': '1140948',
+            'ext': 'm4a',
+            'title': 'Anne Sofie von Otter – efter Benny Fredrikssons död - Söndagsintervjun',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type (for example int or float)
+        }
+    },
+    ]
+    SR_type = 'episode'

--- a/youtube_dl/extractor/sverigesradio.py
+++ b/youtube_dl/extractor/sverigesradio.py
@@ -21,6 +21,7 @@ class SverigesRadioIE(InfoExtractor):
             # TODO more properties (see youtube_dl/extractor/common.py)
         }
 
+
 class SverigesRadioArtikelIE(SverigesRadioIE):
     _VALID_URL = r'https?://(?:www\.)?sverigesradio\.se/sida/artikel.aspx\?(.*)artikel=(?P<id>[0-9]*)'
     _TEST = {
@@ -38,6 +39,7 @@ class SverigesRadioArtikelIE(SverigesRadioIE):
         }
     }
     SR_type = 'publication'
+
 
 class SverigesRadioAvsnittIE(SverigesRadioIE):
     _VALID_URL = r'https?://(?:www\.)?sverigesradio\.se/sida/avsnitt/(?P<id>[0-9]*)'


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds rudimentary support for Swedish public radio website SverigesRadio.se (see #9572). This extractor emulates the behavior of the website by fetching the file URL from the same JSON API (```https://sverigesradio.se/sida/playerajax/getaudiourl```) as the website does, when the user presses the play button. In order to do that, it extracts both the show ID and the type of content from the URL.

There seem to be two different types of content:
* Recordings of news articles (e.g. ```https://sverigesradio.se/sida/artikel.aspx?programid=83&artikel=7038546```, type: publication)
* Episodes of recurring shows (e.g. ```https://sverigesradio.se/sida/avsnitt/1140948?programid=4772```, type: episode)

The API returns a JSON object e.g. looking like this for ```https://sverigesradio.se/sida/playerajax/getaudiourl?id=7038548&type=publication&quality=high&format=iis```:
```
{
    "audioUrl": "https://lyssna-cdn.sr.se/isidor/ereg/ekot_nyheter_sthlm/2018/09/6_paverkan_de_app_3a222d3_a192.m4a",
    "codingFormat": 11,
    "duration": 184,
    "isGeoblockEnabled": false,
    "state": 0
}
```

So far, this extractor does not support anything else than returning the audioUrl for these two types of content. There might be more of these types, but I haven't encountered them so far. In a next step, offering all different quality settings and formats would be great, but I'm not sure how to find out which ones are available.