### PR TITLE
[RT] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -936,6 +936,7 @@ from .roosterteeth import RoosterTeethIE
 from .rottentomatoes import RottenTomatoesIE
 from .roxwel import RoxwelIE
 from .rozhlas import RozhlasIE
+from .rt import RTIE
 from .rtbf import RTBFIE
 from .rte import RteIE, RteRadioIE
 from .rtlnl import RtlNlIE

--- a/youtube_dl/extractor/rt.py
+++ b/youtube_dl/extractor/rt.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from .ora import OraTVIE
+from .youtube import YoutubeIE
+
+
+class RTIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?rt\.com/.*/(?P<id>\d+)-.*'
+    _TESTS = [
+        {
+            'url': 'https://www.rt.com/shows/alex-salmond-show/438343-britain-railway-london-communities/',
+            'md5': '0d8f6f86673ee8d72215c8d060170a5e',
+            'info_dict': {
+                'id': '438343',
+                'ext': 'mp4',
+                'title': 'HS2: The human cost… RT — The Alex Salmond Show'
+            },
+            'params': {
+                'skip_download': False,
+            }
+        },
+        {
+            'url': 'https://www.rt.com/shows/larry-king-now/438502-andie-macdowell-on-ageism-in/',
+            'md5': '5852a10576b4add6b250f864546033f4',
+            'info_dict': {
+                'id': '57786',
+                'ext': 'mp4',
+                'title': 'Andie MacDowell on ageism in Hollywood, fame, & forest protection',
+                'description': 'md5:07b6bce4ad4043b136e21ef9539d46c5'
+            },
+            'params': {
+                'skip_download': False,
+            }
+        },
+        {
+            'url': 'https://www.rt.com/shows/icymi-with-polly-boiko/438450-musk-smoke-marijuana-radio/',
+            'md5': '2c2fe0f78f1ca225e82fb7b27c8fd3f5',
+            'info_dict': {
+                'id': 'SHxygmDAkNE',
+                'ext': 'mp4',
+                'title': u'ICYMI: Is Elon Musk Tony Stark, or just stark raving mad?',
+                'description': 'md5:99e8c3456f6904383399aeeb10784c8b',
+                'upload_date': '20180914',
+                'uploader_id': 'UCdgFmrDeP9nWj_eDKW6j9kQ',
+                'uploader': 'ICYMI'
+            },
+            'params': {
+                'skip_download': False,
+            }
+        }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, video_id)
+
+        video_title = self._search_regex(
+            r'<title>(.+?)</title>', webpage, 'title')
+        # default RT's CDN
+        video_url = self._search_regex(
+            r'file: "(https://cdnv.+?)",', webpage, 'url', fatal=False, default=None)
+
+        if video_url is None:
+
+            oratv = self._search_regex(
+                r'src="(//www\.ora\.tv.+?)"', webpage, 'oratv', fatal=False, default=None)
+
+            if oratv is not None:
+                # some videos are embedded from ORATV
+
+                oratv_embedded_webpage = self._download_webpage(oratv, video_id)
+                ora_website_url = self._search_regex(
+                    r'<link rel="canonical" href="(.+?)"', oratv_embedded_webpage, 'orawebsite')
+                oratvie = OraTVIE()
+                oratvie._downloader = self._downloader
+                return oratvie._real_extract(ora_website_url)
+            else:
+                # some videos are embedded from youtube
+
+                yturl = self._search_regex(
+                    r'data-url="(//www\.youtube\.com/embed.+?)"', webpage, 'youtube', fatal=False, default=None)
+                ytie = YoutubeIE()
+                ytie._downloader = self._downloader
+                return ytie._real_extract(yturl)
+
+        return {
+            'id': video_id,
+            'title': video_title,
+            'url': video_url
+        }

--- a/youtube_dl/extractor/rt.py
+++ b/youtube_dl/extractor/rt.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 from .ora import OraTVIE
 from .youtube import YoutubeIE
+from .generic import GenericIE
 
 
 class RTIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?rt\.com/.*/(?P<id>\d+)-.*'
+    _VALID_URL = r'https?://(?:www\.)?rt\.com/.+/(?P<id>\d+)-.+'
     _TESTS = [
         {
             'url': 'https://www.rt.com/shows/alex-salmond-show/438343-britain-railway-london-communities/',
@@ -27,7 +28,7 @@ class RTIE(InfoExtractor):
             'info_dict': {
                 'id': '57786',
                 'ext': 'mp4',
-                'title': 'Andie MacDowell on ageism in Hollywood, fame, & forest protection',
+                'title': 'md5:fa0da906fbfc7974da14ca53424b1a3a',
                 'description': 'md5:07b6bce4ad4043b136e21ef9539d46c5'
             },
             'params': {
@@ -40,7 +41,7 @@ class RTIE(InfoExtractor):
             'info_dict': {
                 'id': 'SHxygmDAkNE',
                 'ext': 'mp4',
-                'title': 'ICYMI: Is Elon Musk Tony Stark, or just stark raving mad?',
+                'title': 'md5:004bcbc650d8294c5cdefcc470c3cd3d',
                 'description': 'md5:99e8c3456f6904383399aeeb10784c8b',
                 'upload_date': '20180914',
                 'uploader_id': 'UCdgFmrDeP9nWj_eDKW6j9kQ',
@@ -49,44 +50,61 @@ class RTIE(InfoExtractor):
             'params': {
                 'skip_download': False,
             }
+        },
+        {
+            'url': 'https://www.rt.com/news/438686-syria-russia-s200-il20/',
+            'md5': '03acfb2a27a13fb74eb5c192e53bf7e0',
+            'info_dict': {
+                'id': 'YEioP7zJzMc',
+                'ext': 'mp4',
+                'title': 'md5:e703b7c8d88725c1530661d61a626303',
+                'description': 'md5:8ab844abcd296d15f4a99b089e1e1347',
+                'upload_date': '20180918',
+                'uploader_id': 'RussiaToday',
+                'uploader': 'RT'
+            },
+            'params': {
+                'skip_download': False,
+            }
         }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         webpage = self._download_webpage(url, video_id)
+        video_title = self._html_search_regex(
+            r'<title>(.+?)</title>', webpage, 'title', fatal=False) or self._html_search_meta(['og:title', 'twitter:title'], webpage)
 
-        video_title = self._search_regex(
-            r'<title>(.+?)</title>', webpage, 'title')
+        oratv = self._search_regex(
+            r'src=["\']((https?:)?//(?:www\.)ora\.tv[^\'"]+)', webpage, 'oratv', fatal=False, default=None)
+
+        # some videos are embedded from ORATV
+        if oratv is not None:
+
+            oratv_embedded_webpage = self._download_webpage(oratv, video_id)
+            ora_website_url = self._search_regex(
+                r'<link[^>]rel=["\']canonical["\'].+href=["\']([^\'"]+)', oratv_embedded_webpage, 'orawebsite')
+
+            return self.url_result(ora_website_url, ie=OraTVIE.ie_key())
+
+        # some videos are embedded from youtube
+        yturl = self._search_regex(
+            r'<div[^>]+\bdata-url=["\']((https?:)?//(?:www\.)youtube\.[^\'"]+)', webpage, 'youtube', fatal=False, default=None) or self._search_regex(
+            r'<iframe[^>]+\bsrc=["\']((https?:)?//(?:www\.)youtube\.[^\'"]+)', webpage, 'youtube', fatal=False, default=None)
+
+        if yturl is not None:
+            return self.url_result(yturl, ie=YoutubeIE.ie_key())
+
         # default RT's CDN
         video_url = self._search_regex(
-            r'file: "(https://cdnv.+?)",', webpage, 'url', fatal=False, default=None)
+            r'file:\s*["\'](https?://[^\'"]+)', webpage, 'url', fatal=False, default=None)
 
-        if video_url is None:
+        if video_url is not None:
 
-            oratv = self._search_regex(
-                r'src="(//www\.ora\.tv.+?)"', webpage, 'oratv', fatal=False, default=None)
+            return {
+                'id': video_id,
+                'title': video_title,
+                'url': video_url
+            }
 
-            if oratv is not None:
-                # some videos are embedded from ORATV
-
-                oratv_embedded_webpage = self._download_webpage(oratv, video_id)
-                ora_website_url = self._search_regex(
-                    r'<link rel="canonical" href="(.+?)"', oratv_embedded_webpage, 'orawebsite')
-                oratvie = OraTVIE()
-                oratvie._downloader = self._downloader
-                return oratvie._real_extract(ora_website_url)
-            else:
-                # some videos are embedded from youtube
-
-                yturl = self._search_regex(
-                    r'data-url="(//www\.youtube\.com/embed.+?)"', webpage, 'youtube', fatal=False, default=None)
-                ytie = YoutubeIE()
-                ytie._downloader = self._downloader
-                return ytie._real_extract(yturl)
-
-        return {
-            'id': video_id,
-            'title': video_title,
-            'url': video_url
-        }
+        # attempt to use generic
+        return self.url_result(url, ie=GenericIE.ie_key())

--- a/youtube_dl/extractor/rt.py
+++ b/youtube_dl/extractor/rt.py
@@ -40,7 +40,7 @@ class RTIE(InfoExtractor):
             'info_dict': {
                 'id': 'SHxygmDAkNE',
                 'ext': 'mp4',
-                'title': u'ICYMI: Is Elon Musk Tony Stark, or just stark raving mad?',
+                'title': 'ICYMI: Is Elon Musk Tony Stark, or just stark raving mad?',
                 'description': 'md5:99e8c3456f6904383399aeeb10784c8b',
                 'upload_date': '20180914',
                 'uploader_id': 'UCdgFmrDeP9nWj_eDKW6j9kQ',


### PR DESCRIPTION

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Adds support for rt.com website (shows and articles) (issue https://github.com/rg3/youtube-dl/issues/17382)
RT uses several ways to embed videos and the extractor attempts to deal with them in this order:
- RT's own video CDN
- embeded videos from ora.tv
page contains ora.tv embedded url, which is retrieved to get full url to ora.tv, which is then passed to existing OraTVIE
- embeded videos from youtube
youtube url is passed to existing YoutubeIE

There are 3 tests that cover these cases.