### PR TITLE
liveleak: add original format without watermark

### DIFF
--- a/youtube_dl/extractor/liveleak.py
+++ b/youtube_dl/extractor/liveleak.py
@@ -120,7 +120,17 @@ class LiveLeakIE(InfoExtractor):
             }
 
         for idx, info_dict in enumerate(entries):
+            source_found = False
             for a_format in info_dict['formats']:
+                if not source_found:
+                    source_url = re.sub(r'(https?://(?:\w+\.)?liveleak\.com/.*?\.\w+)\.\w+\.mp4((?:\?.+)?)', r'\1\2', a_format['url'])
+                    if source_url != a_format['url']:
+                        source_found = True
+                        info_dict['formats'].append({
+                            'url': source_url,
+                            'format_note': 'original, without watermark',
+                            'format_id': 'source'
+                        })
                 if not a_format.get('height'):
                     a_format['height'] = int_or_none(self._search_regex(
                         r'([0-9]+)p\.mp4', a_format['url'], 'height label',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information


LiveLeak video filenames commonly look somewhat like `something.mp4.zxcvbn.mp4`, which has a watermark and lower quality compared to `something.mp4`.

This PR adds an additional format that uses the original filename where possible.