### PR TITLE
[utils] merge TTML subtitle cues with same timecodes while converting to SRT

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1196,18 +1196,15 @@ The first line
         srt_data = '''1
 00:00:02,080 --> 00:00:05,839
 <font color="white" face="sansSerif" size="16">default style<font color="red">custom style</font></font>
-
-2
-00:00:02,080 --> 00:00:05,839
 <b><font color="cyan" face="sansSerif" size="16"><font color="lime">part 1
 </font>part 2</font></b>
 
-3
+2
 00:00:05,839 --> 00:00:09,560
 <u><font color="lime">line 3
 part 3</font></u>
 
-4
+3
 00:00:09,560 --> 00:00:12,359
 <i><u><font color="yellow"><font color="lime">inner
  </font>style</font></u></i>

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2850,6 +2850,9 @@ def dfxp2srt(dfxp_data):
             index_offset += 1
             out.append('%s\n' % (parse_node(para)))
         else:
+            if out:
+                out.append('\n')
+            out.append('%d\n%s --> %s\n%s\n' % (
                 index - index_offset,
                 srt_subtitles_timecode(begin_time),
                 srt_subtitles_timecode(end_time),

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2831,6 +2831,9 @@ def dfxp2srt(dfxp_data):
             continue
         default_style.update(style)
 
+    last_begin_time = None
+    last_end_time = None
+
     for para, index in zip(paras, itertools.count(1)):
         begin_time = parse_dfxp_time_expr(para.attrib.get('begin'))
         end_time = parse_dfxp_time_expr(para.attrib.get('end'))
@@ -2841,12 +2844,20 @@ def dfxp2srt(dfxp_data):
             if not dur:
                 continue
             end_time = begin_time + dur
-        out.append('%d\n%s --> %s\n%s\n\n' % (
-            index,
-            srt_subtitles_timecode(begin_time),
-            srt_subtitles_timecode(end_time),
-            parse_node(para)))
 
+        if begin_time == last_begin_time and end_time == last_end_time:
+            out.append('%s\n' % (parse_node(para)))
+        else:
+            out.append('\n%d\n%s --> %s\n%s\n' % (
+                index,
+                srt_subtitles_timecode(begin_time),
+                srt_subtitles_timecode(end_time),
+                parse_node(para)))
+
+        last_begin_time = begin_time
+        last_end_time = end_time
+
+    out.append('\n')
     return ''.join(out)
 
 

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2833,6 +2833,7 @@ def dfxp2srt(dfxp_data):
 
     last_begin_time = None
     last_end_time = None
+    index_offset = 0
 
     for para, index in zip(paras, itertools.count(1)):
         begin_time = parse_dfxp_time_expr(para.attrib.get('begin'))
@@ -2846,10 +2847,10 @@ def dfxp2srt(dfxp_data):
             end_time = begin_time + dur
 
         if begin_time == last_begin_time and end_time == last_end_time:
+            index_offset += 1
             out.append('%s\n' % (parse_node(para)))
         else:
-            out.append('\n%d\n%s --> %s\n%s\n' % (
-                index,
+                index - index_offset,
                 srt_subtitles_timecode(begin_time),
                 srt_subtitles_timecode(end_time),
                 parse_node(para)))


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

When playing SRT subtitles converted from TTML by youtube-dl, media players such as VLC and mpv (but not Kodi) show subtitle cues that share the exact same timecode in the wrong order. While there is no official specification for SRT subtitles, VLC and mpv stack up overlapping cues, which means that subtitles converted by youtube-dl are shown incorrectly. This fix merges cues with the same TTML timecode (which is used by websites such as NBC) so they're shown in the right order.


Previous SRT output:
```
4
00:00:08,160 --> 00:00:12,179
if they'd just gotten a push

5
00:00:08,160 --> 00:00:12,179
in the right direction.
```
![screenshot_20181002_203455](https://user-images.githubusercontent.com/13526985/46369272-c2bcc780-c682-11e8-8cc4-c16814c1b15f.png)

Merged SRT output:
```
4
00:00:08,160 --> 00:00:12,179
if they'd just gotten a push
in the right direction.
```
![screenshot_20181002_191640](https://user-images.githubusercontent.com/13526985/46365025-bda64b00-c677-11e8-8ef9-a6705e53eef0.png)