### PR TITLE
Updated for new Rooster Teeth site.

### DIFF
--- a/youtube_dl/extractor/openload.py
+++ b/youtube_dl/extractor/openload.py
@@ -243,7 +243,7 @@ class PhantomJSwrapper(object):
 
 
 class OpenloadIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:openload\.(?:co|io|link)|oload\.(?:tv|stream|site|xyz|win|download|cloud))/(?:f|embed)/(?P<id>[a-zA-Z0-9-_]+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:openload\.(?:co|io|link)|oload\.(?:tv|stream|site|xyz|win|download|cloud|cc))/(?:f|embed)/(?P<id>[a-zA-Z0-9-_]+)'
 
     _TESTS = [{
         'url': 'https://openload.co/f/kUEfGclsU9o',
@@ -313,6 +313,9 @@ class OpenloadIE(InfoExtractor):
     }, {
         # Its title has not got its extension but url has it
         'url': 'https://oload.download/f/N4Otkw39VCw/Tomb.Raider.2018.HDRip.XviD.AC3-EVO.avi.mp4',
+        'only_matching': True,
+    }, {
+        'url': 'https://oload.cc/embed/5NEAbI2BDSk',
         'only_matching': True,
     }]
 

--- a/youtube_dl/extractor/roosterteeth.py
+++ b/youtube_dl/extractor/roosterteeth.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 import re
-import requests
+import json
 import time
 
 from .common import InfoExtractor
@@ -73,10 +73,12 @@ class RoosterTeethIE(InfoExtractor):
             'scope': 'user public',
             'grant_type': 'password',
         }
-        response = requests.post(self._LOGIN_URL, data=login_data)
+        if login_data:
+            login_data = json.dumps(login_data).encode()
+        login = self._download_json(self._LOGIN_URL, '1', note="Downloading token JSON data", data=login_data)
 
         try:
-            self._OAUTH_TOKEN = response.json()['access_token']
+            self._OAUTH_TOKEN = login['access_token']
         except KeyError:
             raise self.raise_login_required("Login required.")
         return
@@ -133,4 +135,3 @@ class RoosterTeethIE(InfoExtractor):
             'comment_count': comment_count,
             'formats': formats,
         }
-


### PR DESCRIPTION
NOTE: This removes function of downloading seasons or series at a time.  It was broken anyway.
TODO: Re-add ability to download series and seasons.

PEP 8 compliant (ignoring long lines like the rest of youtube-dl)

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request rewrites a lot of the roosterteeth extractor to work for their new site, that uses an API instead of webpages.

Authentication fully working.

Playlist downloads are not working.
