### PR TITLE
Add welt.de extractor.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1371,6 +1371,7 @@ from .weibo import (
     WeiboMobileIE
 )
 from .weiqitv import WeiqiTVIE
+from .welt import WeltIE
 from .wimp import WimpIE
 from .wistia import WistiaIE
 from .worldstarhiphop import WorldStarHipHopIE

--- a/youtube_dl/extractor/welt.py
+++ b/youtube_dl/extractor/welt.py
@@ -4,15 +4,23 @@ import re
 
 from .common import InfoExtractor
 
+from ..utils import (
+    remove_end,
+    int_or_none
+)
+
+
 class WeltIE(InfoExtractor):
     IE_NAME = 'welt.de'
-    _VALID_URL = r'''https?://(?:www\.)?welt\.de/mediathek/dokumentation/.*sendung(?P<id>\d+)/.*'''
+    _VALID_URL = r'''https?://(?:www\.)?welt\.de/[^\.]+/(?P<id>[a-z]+\d+)(?:/.*)?'''
     _TESTS = [
         {
-            'url': 'https://www.welt.de/mediathek/dokumentation/space/sendung170058475/ISS-Leben-auf-der-Weltraumstation.html',
+            # All videos have a predefined lifetime, usually just 30-45 days
+            'url': 'https://www.welt.de/mediathek/dokumentation/natur-und-wildlife/sendung157940018/Mega-Croc-vs-Superschlange.html',
             'info_dict': {
+                'id': 'sendung157940018',
                 'ext': 'mp4',
-                'title': 'ISS - Leben auf der Weltraumstation',
+                'title': 'Mega Croc vs. Superschlange',
             }
         }
     ]
@@ -20,12 +28,29 @@ class WeltIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-        title = self._html_search_regex(r'<title>([^<]+)</title>', webpage, 'title')
-        video_url = self._html_search_regex(r'<source data-content="Video.source" src="(https://weltn24.+?_2000.mp4)"', webpage, 'video_url')
+        title = remove_end(self._html_search_regex(r'<title>([^<]+)</title>', webpage, 'title')
+                           .strip(), ' - Video - WELT')
 
-        return [{
-            'id':   video_id,
-            'url':  video_url,
-            'ext':  'mp4',
+        sources = self._search_regex(r'(["\'])?sources\1\s*:\s*\[({\s*\1file\1\s*:\s*\1([^\1,])+\1\s*}\s*,?)+', webpage, 'sources', group=0)
+        files = re.findall(r'http[^\'"]+', sources)
+
+        formats = []
+        for url in files:
+            number = re.search(r'_(\d+)\.mp4', url).group(1)
+            formats.append({
+                'url': url,
+                'quality_key': int_or_none(number)
+            })
+        self._remove_duplicate_formats(formats)
+        formats = sorted(formats, key=lambda x: x['quality_key'])
+        quality_counter = -1
+        for i in range(len(formats) - 1, 0, -1):
+            formats[i] = {'url': formats[i]['url'], 'quality': quality_counter}
+            quality_counter -= 1
+
+        return {
+            'id': video_id,
+            'ext': 'mp4',
             'title': title,
-        }]
+            'formats': formats
+        }

--- a/youtube_dl/extractor/welt.py
+++ b/youtube_dl/extractor/welt.py
@@ -1,0 +1,31 @@
+from __future__ import unicode_literals
+
+import re
+
+from .common import InfoExtractor
+
+class WeltIE(InfoExtractor):
+    IE_NAME = 'welt.de'
+    _VALID_URL = r'''https?://(?:www\.)?welt\.de/mediathek/dokumentation/.*sendung(?P<id>\d+)/.*'''
+    _TESTS = [
+        {
+            'url': 'https://www.welt.de/mediathek/dokumentation/space/sendung170058475/ISS-Leben-auf-der-Weltraumstation.html',
+            'info_dict': {
+                'ext': 'mp4',
+                'title': 'ISS - Leben auf der Weltraumstation',
+            }
+        }
+    ]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        title = self._html_search_regex(r'<title>([^<]+)</title>', webpage, 'title')
+        video_url = self._html_search_regex(r'<source data-content="Video.source" src="(https://weltn24.+?_2000.mp4)"', webpage, 'video_url')
+
+        return [{
+            'id':   video_id,
+            'url':  video_url,
+            'ext':  'mp4',
+            'title': title,
+        }]


### PR DESCRIPTION
Hello,

this is my first PR for youtube-dl. So please just let me know, if I don't match the standards here.

Question: How could I provide multiple formats? The videos on welt.de are usually provided in four different resolutions, which can be determined by the _xxx.mp4 in the URL. 

Fixes #17553

- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### purpose of this *pull request*?
- [x] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

Basic function for welt.de. Instead of loading the worst quality with the generic extractor, you'll get the best quality.

TODO: Provide list of all qualities and resolutions available.