### PR TITLE
[imgur] Don't assume gallery contains single image

### DIFF
--- a/youtube_dl/extractor/imgur.py
+++ b/youtube_dl/extractor/imgur.py
@@ -12,7 +12,7 @@ from ..utils import (
 
 
 class ImgurIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:i\.)?imgur\.com/(?:(?:gallery|(?:topic|r)/[^/]+)/)?(?P<id>[a-zA-Z0-9]{6,})(?:[/?#&]+|\.[a-z0-9]+)?$'
+    _VALID_URL = r'https?://(?:i\.)?imgur\.com/(?:(?:topic|r)/[^/]+/)?(?P<id>[a-zA-Z0-9]{6,})(?:[/?#&]+|\.[a-z0-9]+)?$'
 
     _TESTS = [{
         'url': 'https://i.imgur.com/A61SaA1.gifv',
@@ -31,7 +31,7 @@ class ImgurIE(InfoExtractor):
             'description': 'Imgur: The magic of the Internet',
         },
     }, {
-        'url': 'https://imgur.com/gallery/YcAQlkx',
+        'url': 'https://imgur.com/YcAQlkx',
         'info_dict': {
             'id': 'YcAQlkx',
             'ext': 'mp4',
@@ -113,7 +113,7 @@ class ImgurIE(InfoExtractor):
 
 
 class ImgurAlbumIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:i\.)?imgur\.com/(?:(?:a|gallery|topic/[^/]+)/)?(?P<id>[a-zA-Z0-9]{5})(?:[/?#&]+)?$'
+    _VALID_URL = r'https?://(?:i\.)?imgur\.com/(?:(?:a|gallery|topic/[^/]+)/)?(?P<id>[a-zA-Z0-9]{5,})(?:[/?#&]+)?$'
 
     _TESTS = [{
         'url': 'http://imgur.com/gallery/Q95ko',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Previously, galleries on imgur that contained a single video would share the hash for the gallery and hash for that video, but this is no loner the case for new submissions. Further, the Imgur extractor would match galleries with no checks performed to ensure the given gallery only contains a single item.

There is already a separate ImgurAlbum extractor that properly determines the media items contained in a gallery.

This pull request:
- Removes gallery urls from being matched by the Imgur Extractor
- Relaxes the restrictions on the hash length of the ImgurAlbum Extractor
- Removes gallery from the url of the 3rd test case of the Imgur Extractor
   - The Imgur Extractor pulls title and description which the gallery extractor does not. It is more appropriate to leave this test case under the Imgur Extractor, but remove gallery from the url so it is still matched by the Imgur Extractor
