### PR TITLE
[bild] don't assume embed url(closes #17876)

### DIFF
--- a/youtube_dl/extractor/bild.py
+++ b/youtube_dl/extractor/bild.py
@@ -3,8 +3,10 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from ..utils import (
+    base_url,
     int_or_none,
     unescapeHTML,
+    urljoin,
 )
 
 
@@ -27,8 +29,16 @@ class BildIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        video_data = self._download_json(
-            url.split('.bild.html')[0] + ',view=json.bild.html', video_id)
+        # if we didn't get a direct link to the video, try to find it on the page
+        if 'bild.de/video/clip/' not in url:
+            json_url = self._search_regex(
+                r'data-video-json="(.*?)"',
+                self._download_webpage(url, video_id), video_id)
+            video_data = self._download_json(
+                urljoin(base_url(url), json_url), video_id)
+        else:
+            video_data = self._download_json(
+                url.split('.bild.html')[0] + ',view=json.bild.html', video_id)
 
         return {
             'id': video_id,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The valid URL for bild is more liberal than what it currently supports. It only supports the embed url. The change verifies if the url is an embed url or not, and if not tries to find it on the web page.