### PR TITLE
Add --break-on-existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --download-archive FILE          Download only videos not listed in the
                                      archive file. Record the IDs of all
                                      downloaded videos in it.
+    --break-on-existing              Stop the download process after attempting
+                                     to download a file that's in the archive.
     --include-ads                    Download advertisements as well
                                      (experimental)
 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -995,13 +995,13 @@ class YoutubeDL(object):
                 }
 
                 reason = self._match_entry(entry, incomplete=True)
-                if reason.endswith('has already been recorded in archive') and self.params.get('break_on_existing'):
-                    self.to_screen('[download] stopping downloading because ' + reason)
-                    break
-
-                elif reason is not None:
-                    self.to_screen('[download] ' + reason)
-                    continue
+                if reason is not None:
+                    if reason.endswith('has already been recorded in the archive') and self.params.get('break_on_existing'):
+                        print('[download] tried downloading a file that\'s already in the archive, stopping since --break-on-existing is set.')
+                        break
+                    else:
+                        self.to_screen('[download] ' + reason)
+                        continue
 
                 entry_result = self.process_ie_result(entry,
                                                       download=download,

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -205,6 +205,8 @@ class YoutubeDL(object):
     download_archive:  File name of a file where all downloads are recorded.
                        Videos already present in the file are not downloaded
                        again.
+    break_on_existing: Stop the download process after attempting to download a file that's
+                       in the archive.
     cookiefile:        File name where cookies should be read from and dumped to.
     nocheckcertificate:Do not verify SSL certificates
     prefer_insecure:   Use HTTP instead of HTTPS to retrieve information.
@@ -993,7 +995,11 @@ class YoutubeDL(object):
                 }
 
                 reason = self._match_entry(entry, incomplete=True)
-                if reason is not None:
+                if reason.endswith('has already been recorded in archive') and self.params.get('break_on_existing'):
+                    self.to_screen('[download] stopping downloading because ' + reason)
+                    break
+
+                elif reason is not None:
                     self.to_screen('[download] ' + reason)
                     continue
 

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -393,6 +393,7 @@ def _real_main(argv=None):
         'youtube_print_sig_code': opts.youtube_print_sig_code,
         'age_limit': opts.age_limit,
         'download_archive': download_archive_fn,
+        'break_on_existing': opts.break_on_existing,
         'cookiefile': opts.cookiefile,
         'nocheckcertificate': opts.no_check_certificate,
         'prefer_insecure': opts.prefer_insecure,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -345,6 +345,10 @@ def parseOpts(overrideArguments=None):
         dest='download_archive',
         help='Download only videos not listed in the archive file. Record the IDs of all downloaded videos in it.')
     selection.add_option(
+        '--break-on-existing',
+        action='store_true', dest='break_on_existing', default=False,
+        help="Stop the download process after attempting to download a file that's in the archive.")
+    selection.add_option(
         '--include-ads',
         dest='include_ads', action='store_true',
         help='Download advertisements as well (experimental)')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This adds an option --break-on-existing, which will stop the checking (and downloading) process when a file that exists in the download archive file was reached. There was an issue open regarding this but I can't locate it, apologies. This is meant for archivers of large channels, so that they could download the latest few videos without checking through thousands.