### PR TITLE
skip-http-head flag feature

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -403,7 +403,7 @@ def _real_main(argv=None):
         'prefer_ffmpeg': opts.prefer_ffmpeg,
         'include_ads': opts.include_ads,
         'default_search': opts.default_search,
-        'skip_http_head': opts.skip_http_head,
+        'skip_http_head': opts.generic_skip_http_head,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,
         'encoding': opts.encoding,
         'extract_flat': opts.extract_flat,

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -403,6 +403,7 @@ def _real_main(argv=None):
         'prefer_ffmpeg': opts.prefer_ffmpeg,
         'include_ads': opts.include_ads,
         'default_search': opts.default_search,
+        'skip_http_head': opts.skip_http_head,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,
         'encoding': opts.encoding,
         'extract_flat': opts.extract_flat,

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2226,13 +2226,15 @@ class GenericIE(InfoExtractor):
         else:
             video_id = self._generic_id(url)
 
-        self.to_screen('%s: Requesting header' % video_id)
-
-        head_req = HEADRequest(url)
-        head_response = self._request_webpage(
-            head_req, video_id,
-            note=False, errnote='Could not send HEAD request to %s' % url,
-            fatal=False)
+        if self._downloader.params.get('skip_http_head') == None:
+            head_response = False
+        else:
+            self.to_screen('%s: Requesting header' % video_id)
+            head_req = HEADRequest(url)
+            head_response = self._request_webpage(
+                head_req, video_id,
+                note=False, errnote='Could not send HEAD request to %s' % url,
+                fatal=False)
 
         if head_response is not False:
             # Check for redirect

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -226,6 +226,13 @@ def parseOpts(overrideArguments=None):
         action='store_const', const='::', dest='source_address',
         help='Make all connections via IPv6',
     )
+    network.add_option(
+        '--skip-http-head',
+        action='store_const', default=False, dest='skip_http_head',
+        help='Skip the initial HTTP head request',
+    )
+
+
 
     geo = optparse.OptionGroup(parser, 'Geo Restriction')
     geo.add_option(

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -232,7 +232,6 @@ def parseOpts(overrideArguments=None):
         help='Make all connections via IPv6',
     )
 
-
     geo = optparse.OptionGroup(parser, 'Geo Restriction')
     geo.add_option(
         '--geo-verification-proxy',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -198,6 +198,11 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='no_color',
         default=False,
         help='Do not emit color codes in output')
+    general.add_option(
+        '--skip-http-head',
+        action='store_const', default=False, dest='generic_skip_http_head',
+        help='Skip the initial HTTP head request',
+    )
 
     network = optparse.OptionGroup(parser, 'Network Options')
     network.add_option(
@@ -226,12 +231,6 @@ def parseOpts(overrideArguments=None):
         action='store_const', const='::', dest='source_address',
         help='Make all connections via IPv6',
     )
-    network.add_option(
-        '--skip-http-head',
-        action='store_const', default=False, dest='skip_http_head',
-        help='Skip the initial HTTP head request',
-    )
-
 
 
     geo = optparse.OptionGroup(parser, 'Geo Restriction')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Today I wanted to download mdp file. so i have a sepcific URL refer to this mdp file, this URL is one time URL, and its expires after 1 request.
youtube-dl is sending HEAD request before the GET one, cause that my URL is always expires and I wasn't able to download it.
By skipping the head request you can actually make it work and download the requested resource.
