### PR TITLE
[niconico] Fixing swf support

### DIFF
--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -299,7 +299,7 @@ class NiconicoIE(InfoExtractor):
             #    'http://flapi.nicovideo.jp/api/getflv/' + video_id + '?as3=1',
             #    video_id, 'Downloading flv info')
             # Nov 2018: the method above no longer returns the correct swf address; use below instead
-            flv_info_webpage = watch_api_data.get('flashvars', {}).get(u'flvInfo')
+            flv_info_webpage = watch_api_data.get('flashvars', {}).get('flvInfo')
             flv_info_webpage = compat_urllib_parse.unquote(flv_info_webpage)
             flv_info = compat_urlparse.parse_qs(flv_info_webpage)
             if 'url' not in flv_info:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As of Nov 30, 2018, the current method for extracting URLs for legacy swf videos for niconico (nicovideo.jp) no longer works (the method will return an URL, but GET requests are met with 403s). The correct swf URL needs to be extracted from "watchAPIDataContainer" instead.
