### PR TITLE
Don't display messsage about confirmation code when file isn't downloadble

### DIFF
--- a/youtube_dl/extractor/googledrive.py
+++ b/youtube_dl/extractor/googledrive.py
@@ -60,6 +60,10 @@ class GoogleDriveIE(InfoExtractor):
     }, {
         'url': 'https://drive.google.com/uc?id=0B2fjwgkl1A_CX083Tkowdmt6d28',
         'only_matching': True,
+    }, {
+        # no downloadable video
+        'url': 'https://drive.google.com/file/d/1L_ao48RH6DoHXGhBYdXo4UjfEkTDyReY/view',
+        'only_matching': True,
     }]
     _FORMATS_EXT = {
         '5': 'flv',
@@ -238,13 +242,14 @@ class GoogleDriveIE(InfoExtractor):
                     urlh, url, video_id, note='Downloading confirmation page',
                     errnote='Unable to confirm download', fatal=False)
                 if confirmation_webpage:
-                    confirm = self._search_regex(
-                        r'confirm=([^&"\']+)', confirmation_webpage,
-                        'confirmation code', fatal=False)
-                    if confirm:
-                        add_source_format(update_url_query(source_url, {
-                            'confirm': confirm,
-                        }))
+                    if 'uc-error-caption' not in confirmation_webpage:
+                        confirm = self._search_regex(
+                            r'confirm=([^&"\']+)', confirmation_webpage,
+                            'confirmation code', fatal=False)
+                        if confirm:
+                            add_source_format(update_url_query(source_url, {
+                                'confirm': confirm,
+                            }))
 
         if not formats:
             reason = self._search_regex(


### PR DESCRIPTION

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Handling the situation when the file can not be downloaded:
> Sorry, the owner hasn't given you permission to download this file.
