### PR TITLE
[update] Show also old version on update

### DIFF
--- a/youtube_dl/update.py
+++ b/youtube_dl/update.py
@@ -78,7 +78,7 @@ def update_self(to_screen, verbose, opener):
         to_screen('youtube-dl is up to date (%s)' % __version__)
         return
 
-    to_screen('Updating to version ' + version_id + ' ...')
+    to_screen('Updating to version ' + version_id + ' from version ' + __version__ + ' ...')
     version = versions_info['versions'][version_id]
 
     print_notes(to_screen, versions_info['versions'])


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This change shows also the old (= current) version when youtube-dl is updated. If the update introduces a regression i.e. breaks an extractor, the old version number can still be seen on console; it eases debugging.

Before:
```
Updating to version 2018.12.03 ...
```

After:
```
Updating to version 2018.12.03 from version 2000.01.01 ...
```