### PR TITLE
remove ads embedded in json if any (closes #18430)

### DIFF
--- a/youtube_dl/extractor/rudo.py
+++ b/youtube_dl/extractor/rudo.py
@@ -38,8 +38,12 @@ class RudoIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id, encoding='iso-8859-1')
 
-        jwplayer_data = self._parse_json(re.sub('events: {(.|\n)*},\nabouttext', 'abouttext', 
-            self._search_regex(r'(?s)playerInstance\.setup\(({.+?})\)', webpage, 'jwplayer data')), video_id,
+        jwplayer_data = self._parse_json(
+            re.sub(
+                'events: {(.|\n)*},\nabouttext',
+                'abouttext',
+                self._search_regex(r'(?s)playerInstance\.setup\(({.+?})\)', webpage, 'jwplayer data')),
+            video_id,
             transform_source=lambda s: js_to_json(re.sub(r'encodeURI\([^)]+\)', '""', s)))
 
         info_dict = self._parse_jwplayer_data(

--- a/youtube_dl/extractor/rudo.py
+++ b/youtube_dl/extractor/rudo.py
@@ -38,8 +38,8 @@ class RudoIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id, encoding='iso-8859-1')
 
-        jwplayer_data = self._parse_json(self._search_regex(
-            r'(?s)playerInstance\.setup\(({.+?})\)', webpage, 'jwplayer data'), video_id,
+        jwplayer_data = self._parse_json(re.sub('events: {(.|\n)*},\nabouttext', 'abouttext', 
+            self._search_regex(r'(?s)playerInstance\.setup\(({.+?})\)', webpage, 'jwplayer data')), video_id,
             transform_source=lambda s: js_to_json(re.sub(r'encodeURI\([^)]+\)', '""', s)))
 
         info_dict = self._parse_jwplayer_data(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The issue on http://rudo.video is on some videos it has ads. When the program tries to parse the js with js_to_json it caused error because the 'events' key which was produced from ads has several js function as its value and program can't parse it as usual. I made a change to the code so when there's an 'events' key matched it will be removed. Hopefully, it won't cause any problem to the ad-free one because the ad-free videos does't have the 'events' key. CMIIW. Hope this solves #18430 .