### PR TITLE
Allow format to be specified by -f flag

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -294,7 +294,7 @@ class FFmpegFD(ExternalFD):
             if live:
                 args += ['-rtmp_live', 'live']
 
-        args += ['-i', url, '-c', 'copy']
+        args += ['-i', url]
 
         if self.params.get('test', False):
             args += ['-fs', compat_str(self._TEST_FILE_SIZE)]

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -305,7 +305,8 @@ class FFmpegFD(ExternalFD):
             else:
                 args += ['-f', 'mp4']
                 if tmpfilename == '-':
-                    args += ["-movflags", "frag_keyframe+empty_moov"]
+                    args += ['-movflags', 'frag_keyframe+empty_moov', '-c:v', 'libx264', '-c:a', 'aac', '-ac', '2', '-ab', '128000']
+                    args += ['-bsf:a', 'aac_adtstoasc', '-tune', 'zerolatency', '-preset', 'ultrafast', '-level', '31', '-pix_fmt', 'yuv420p']
                 if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._versions['ffmpeg'], '3.2', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
                     args += ['-bsf:a', 'aac_adtstoasc']
         elif protocol == 'rtmp':

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -300,10 +300,12 @@ class FFmpegFD(ExternalFD):
             args += ['-fs', compat_str(self._TEST_FILE_SIZE)]
 
         if protocol in ('m3u8', 'm3u8_native'):
-            if self.params.get('hls_use_mpegts', False) or tmpfilename == '-':
+            if self.params.get('hls_use_mpegts', False):
                 args += ['-f', 'mpegts']
             else:
                 args += ['-f', 'mp4']
+                if tmpfilename == '-':
+                    args += ["-movflags", "frag_keyframe+empty_moov"]
                 if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._versions['ffmpeg'], '3.2', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
                     args += ['-bsf:a', 'aac_adtstoasc']
         elif protocol == 'rtmp':


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

If input is mpegts, -c copy forces the output format to be mpegts even if -f specifies mp4. This PR will ensure both -f mpegts and -f mp4 are honored.
