### PR TITLE
Added --skip-empty-annotations to be used with write annotations. Wil…

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 # coding: utf-8
 
@@ -314,7 +315,8 @@ class YoutubeDL(object):
     The following options are used by the Youtube extractor:
     youtube_include_dash_manifest: If True (default), DASH manifests and related
                         data will be downloaded and processed by extractor.
-                        You can reduce network I/O by disabling it if you don't
+
+                       You can reduce network I/O by disabling it if you don't
                         care about DASH.
     """
 
@@ -1777,6 +1779,8 @@ class YoutubeDL(object):
             annofn = replace_extension(filename, 'annotations.xml', info_dict.get('ext'))
             if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(annofn)):
                 self.to_screen('[info] Video annotations are already present')
+            elif not '<annotation id=' in info_dict['annotations'] and self.params.get('writefullannotations', False):
+                    self.to_screen('[info] Annotation file is empty. Skipping')
             else:
                 try:
                     self.to_screen('[info] Writing video annotations to: ' + annofn)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -365,6 +365,7 @@ def _real_main(argv=None):
         'nopart': opts.nopart,
         'updatetime': opts.updatetime,
         'writedescription': opts.writedescription,
+        'writefullannotations': opts.writefullannotations,
         'writeannotations': opts.writeannotations,
         'writeinfojson': opts.writeinfojson,
         'writethumbnail': opts.writethumbnail,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -742,6 +742,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='writeinfojson', default=False,
         help='Write video metadata to a .info.json file')
     filesystem.add_option(
+        '--skip-empty-annotations',
+        action='store_true', dest='writefullannotations', default=False,
+        help='Used with --write-annotations. Will not save annotation file if there are no annotations')
+    filesystem.add_option(
         '--write-annotations',
         action='store_true', dest='writeannotations', default=False,
         help='Write video annotations to a .annotations.xml file')


### PR DESCRIPTION
…l not save annotation if none exist in video

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [] Bug fix
- [x ] Improvement
- [ ] New extractor
- [x ] New feature

---

### Description of your *pull request* and other information

https://github.com/rg3/youtube-dl/issues/18582

This is a fix to a current open issue. This allows the user to add the tag --skip-empty-annotations and if there are no annotations in the supplied youtube video instead of saving a barebones xml file it will skip it. Youtube provides a xml file regardless if there are annotations or not.
