### PR TITLE
[vrtnu] Rewrite remix.aka to remix-aka for VRT.nu

### DIFF
--- a/youtube_dl/extractor/canvas.py
+++ b/youtube_dl/extractor/canvas.py
@@ -50,6 +50,10 @@ class CanvasIE(InfoExtractor):
         formats = []
         for target in data['targetUrls']:
             format_url, format_type = target.get('url'), target.get('type')
+
+            # VRT seems to be providing invalid URLS
+            format_url = format_url.replace('https://remix.aka', 'https://remix-aka')
+
             if not format_url or not format_type:
                 continue
             if format_type == 'HLS':


### PR DESCRIPTION

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR fixes issue #17701, #18415 and #18414 and some more. VRT is providing invalid urls, that need to be rewritten.
