### PR TITLE
[facebook] extract better titles (fixes #14156)

### DIFF
--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -412,6 +412,10 @@ class FacebookIE(InfoExtractor):
             'title', default=None)
         if not video_title:
             video_title = self._html_search_regex(
+                r'(?s)<title id="pageTitle"[^>]*>([^<]*)(?: \| Facebook)</title>',
+                webpage, 'title', default=None)
+        if not video_title:
+            video_title = self._html_search_regex(
                 r'(?s)<span class="fbPhotosPhotoCaption".*?id="fbPhotoPageCaption"><span class="hasCaption">(.*?)</span>',
                 webpage, 'alternative title', default=None)
         if not video_title:


### PR DESCRIPTION
This now tries to find the primary title, which is displayed in bold
above the previously extracted full text. This is the title which is
also displayed - if given by the uploader - to the top left when
displaying a video fullscreen.

For videos posted to groups, the extractor still doesn't use the
given comment text as a title, and now extracts e.g. "[group name]
Public Group" instead of "[group name] has 481 members", which may
or may not be better.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This now tries to find the primary title, which is displayed in bold
above the previously extracted full text. This is the title which is
also displayed - if given by the uploader - to the top left when
displaying a video fullscreen.

For videos posted to groups, the extractor still doesn't use the
given comment text as a title, and now extracts e.g. "[group name]
Public Group" instead of "[group name] has 481 members", which may
or may not be better.

Examples are given in #14156:
The title of the URL
https://www.facebook.com/markberubemusic/videos/vb.350276931674911/315046592680474/?type=2&theater

which has an accompanying text of:

> **This week in Switzerland...**
>
> 13.12.18 - Basel - Kaserne / 15.12.18 - Bern - Dachstock * opening for Sophie Hunger

changes from:
> 13.12.18 - Basel - Kaserne / 15.12.18 - Bern - Dachstock * opening for Sophie...

to

> This week in Switzerland...

Please note that almost all tests checking the titles are invalidated. Some which previously did not have a title now even have one (and a nice one, sometimes).