### PR TITLE
[youtube] fix 403 forbidden error

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1886,7 +1886,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
 
                     signature = self._decrypt_signature(
                         encrypted_sig, video_id, player_url, age_gate)
-                    url += '&signature=' + signature
+                    if 'sp' in url_data:
+                        url += '&' + url_data['sp'][0] + '=' + signature
+                    else:
+                        url += '&signature=' + signature
                 if 'ratebypass' not in url:
                     url += '&ratebypass=yes'
 


### PR DESCRIPTION
youtube has new 'sp' paramter in url_data which gives signature param name that
server is expecting for the signature param value in url

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [ x [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

YouTube seems to have new parameter 'sp' in [url_data](https://github.com/rg3/youtube-dl/blob/fa4ac365f69cbd51e4c9801984ebea49a12825b7/youtube_dl/extractor/youtube.py#L1828) (data which has format information, itag, url etc), whose value can be 'signature' or 'sig'.
This parameter 'sp' (guessing it means 'signature parameter') tells the server the name of the signature parameter in the url. youtube-dl, prior to this pull request, always [append](https://github.com/rg3/youtube-dl/blob/fa4ac365f69cbd51e4c9801984ebea49a12825b7/youtube_dl/extractor/youtube.py#L1889) '&signature=SIG' to the url, resulting in HTTP 403 errors for encrypted signature videos.

This 'sp' parameter is found in 'url_data' only for encrypted signature videos. For anonymous page downloading and for most accounts, its value is 'signature', which is why youtube-dl works most of the time (with or without login). But for one of my accounts, this 'sp' parameter's value is 'sig', for which it always give 403 on encrypted signature videos.  Only thing different for this account is that I've recently used up YouTube premium trial (about a month ago).
The issue seems replicable #18841 

Video, without logging in, has no issue:
```
$ python -m youtube_dl https://www.youtube.com/watch?v=D4hAVemuQXY -v
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://www.youtube.com/watch?v=D4hAVemuQXY', u'-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.01.17
[debug] Git HEAD: 379306ef5
[debug] Python version 2.7.15 (CPython) - Darwin-18.2.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1, ffprobe 4.1
[debug] Proxy map: {}
[youtube] D4hAVemuQXY: Downloading webpage
[youtube] D4hAVemuQXY: Downloading video info webpage
[youtube] {18} signature length 42.44, html5 player vfl-jbnrr
[youtube] {36} signature length 40.44, html5 player vfl-jbnrr
[youtube] D4hAVemuQXY: Downloading player https://www.youtube.com/yts/jsbin/player_ias-vfl-jbnrr/en_US/base.js
[youtube] {17} signature length 42.44, html5 player vfl-jbnrr
[youtube] {135} signature length 42.44, html5 player vfl-jbnrr
[youtube] {244} signature length 42.44, html5 player vfl-jbnrr
[youtube] {397} signature length 42.44, html5 player vfl-jbnrr
[youtube] {134} signature length 42.44, html5 player vfl-jbnrr
[youtube] {243} signature length 42.44, html5 player vfl-jbnrr
[youtube] {396} signature length 42.44, html5 player vfl-jbnrr
[youtube] {133} signature length 42.44, html5 player vfl-jbnrr
[youtube] {242} signature length 42.44, html5 player vfl-jbnrr
[youtube] {395} signature length 42.44, html5 player vfl-jbnrr
[youtube] {160} signature length 42.44, html5 player vfl-jbnrr
[youtube] {278} signature length 42.44, html5 player vfl-jbnrr
[youtube] {394} signature length 42.44, html5 player vfl-jbnrr
[youtube] {140} signature length 42.44, html5 player vfl-jbnrr
[youtube] {171} signature length 42.44, html5 player vfl-jbnrr
[youtube] {249} signature length 42.44, html5 player vfl-jbnrr
[youtube] {250} signature length 42.44, html5 player vfl-jbnrr
[youtube] {251} signature length 42.44, html5 player vfl-jbnrr
[debug] Default format spec: bestvideo+bestaudio/best
WARNING: Requested formats are incompatible for merge and will be merged into mkv.
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?lmt=1540547722115265&fvip=3&ei=QctDXL_dOJeE1gKwhZ_oDg&txp=5532432&gir=yes&requiressl=yes&key=yt6&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&ms=au%2Crdu&mv=m&mt=1547946664&id=o-AGHiTZAVN8GKqIT7Dle5BjKZIOh_AfTPXy0Xydq7zvfn&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&mm=31%2C29&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&sparams=aitags%2Cclen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Ckeepalive%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Crequiressl%2Csource%2Cexpire&ipbits=0&clen=27800113&initcwndbps=908750&pl=29&itag=135&dur=327.627&keepalive=yes&source=youtube&expire=1547968418&c=WEB&mime=video%2Fmp4&signature=6A9FE04AB82A2167AD7829F54E298242BD69DF7C.157C870FAC2E13C95A6454B267DD3D76754056F1&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4
[download] 100% of 26.51MiB in 00:02
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?lmt=1540554828851893&fvip=3&ei=QctDXL_dOJeE1gKwhZ_oDg&txp=5511222&gir=yes&requiressl=yes&key=yt6&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&ms=au%2Crdu&mv=m&mt=1547946664&id=o-AGHiTZAVN8GKqIT7Dle5BjKZIOh_AfTPXy0Xydq7zvfn&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&mm=31%2C29&sparams=clen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Ckeepalive%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Crequiressl%2Csource%2Cexpire&ipbits=0&clen=4638867&initcwndbps=908750&pl=29&itag=251&dur=327.661&keepalive=yes&source=youtube&expire=1547968418&c=WEB&mime=audio%2Fwebm&signature=C69D126F860D1CAA6A309E0838092E4F7C1C504B.5ADA507197F8A5886BC8F5A14F6849F70C32C3D3&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm
[download] 100% of 4.42MiB in 00:00
[ffmpeg] Merging formats into "Eminem - Sing For The Moment-D4hAVemuQXY.mkv"
[debug] ffmpeg command line: ffmpeg -y -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4' -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm' -c copy -map '0:v:0' -map '1:a:0' 'file:Eminem - Sing For The Moment-D4hAVemuQXY.temp.mkv'
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4 (pass -k to keep)
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm (pass -k to keep)
```

Issue, with logging in, using mentioned account:
```
$ python -m youtube_dl https://www.youtube.com/watch?v=D4hAVemuQXY -u 'PRIVATE' -v
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://www.youtube.com/watch?v=D4hAVemuQXY', u'-u', u'PRIVATE', u'-v']
Type account password and press [Return]: 
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.01.17
[debug] Git HEAD: 379306ef5
[debug] Python version 2.7.15 (CPython) - Darwin-18.2.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1, ffprobe 4.1
[debug] Proxy map: {}
[youtube] Downloading login page
[youtube] Looking up account info
[youtube] Logging in
[youtube] Checking cookie
[youtube] D4hAVemuQXY: Downloading webpage
[youtube] D4hAVemuQXY: Downloading video info webpage
[youtube] {18} signature length 110, html5 player vfl-jbnrr
[youtube] {36} signature length 110, html5 player vfl-jbnrr
[youtube] {17} signature length 110, html5 player vfl-jbnrr
[youtube] {135} signature length 110, html5 player vfl-jbnrr
[youtube] {244} signature length 106, html5 player vfl-jbnrr
[youtube] {397} signature length 110, html5 player vfl-jbnrr
[youtube] {134} signature length 110, html5 player vfl-jbnrr
[youtube] {243} signature length 110, html5 player vfl-jbnrr
[youtube] {396} signature length 110, html5 player vfl-jbnrr
[youtube] {133} signature length 110, html5 player vfl-jbnrr
[youtube] {242} signature length 110, html5 player vfl-jbnrr
[youtube] {395} signature length 106, html5 player vfl-jbnrr
[youtube] {160} signature length 106, html5 player vfl-jbnrr
[youtube] {278} signature length 110, html5 player vfl-jbnrr
[youtube] {394} signature length 110, html5 player vfl-jbnrr
[youtube] {140} signature length 110, html5 player vfl-jbnrr
[youtube] {171} signature length 106, html5 player vfl-jbnrr
[youtube] {249} signature length 110, html5 player vfl-jbnrr
[youtube] {250} signature length 110, html5 player vfl-jbnrr
[youtube] {251} signature length 106, html5 player vfl-jbnrr
[debug] Default format spec: bestvideo+bestaudio/best
WARNING: Requested formats are incompatible for merge and will be merged into mkv.
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?mm=31%2C29&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&id=o-AGjpRnghBdIXZHBqPfCTdgIwlwTgYr32hfC4GS72KFMM&dur=327.627&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&c=WEB&initcwndbps=942500&lsparams=initcwndbps%2Cmn%2Cmm%2Cmv%2Cms%2Cpl&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&mt=1547946168&lmt=1540547722115265&lsig=ANVabiowRQIgSLR4LY9eW6p_OH0O6KC9NpowgDY8eWIxP7zr-_G4NCACIQCrnEMv_xYzlyYuSsqTvENNBNyYLQVdlA_VShfVM6VHQQ%3D%3D&source=youtube&mv=m&fvip=3&mime=video%2Fmp4&pl=29&sparams=expire%2Cei%2Cip%2Cid%2Cipbits%2Citag%2Csource%2Cclen%2Cgir%2Cmime%2Cdur%2Caitags%2Ckeepalive%2Crequiressl%2Clmt&ipbits=0&ei=IclDXP2BEcWGgQfB7Yh4&txp=5532432&clen=27800113&requiressl=yes&keepalive=yes&itag=135&gir=yes&ms=au%2Crdu&expire=1547967873&signature=AMao4c4wRgIhAOd-LJneOFUHIGDTNM0AEWH47qSH1RZiDGlx31WiCe07AiEAzqHol6weAGIQVbdNfrEE0Kx-335rp4h-mOar32pM37U=&ratebypass=yes'
ERROR: unable to download video data: HTTP Error 403: Forbidden
Traceback (most recent call last):
  File "youtube_dl/YoutubeDL.py", line 1903, in process_info
    partial_success = dl(fname, new_info)
  File "youtube_dl/YoutubeDL.py", line 1848, in dl
    return fd.download(name, info)
  File "youtube_dl/downloader/common.py", line 364, in download
    return self.real_download(filename, info_dict)
  File "youtube_dl/downloader/http.py", line 341, in real_download
    establish_connection()
  File "youtube_dl/downloader/http.py", line 109, in establish_connection
    ctx.data = self.ydl.urlopen(request)
  File "youtube_dl/YoutubeDL.py", line 2212, in urlopen
    return self._opener.open(req, timeout=self._socket_timeout)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 556, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
HTTPError: HTTP Error 403: Forbidden
```

Same download link from above output, but with parameter name 'signature' replaced with 'sig', fixes the issue:
```
wget -O test.file "https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?mm=31%2C29&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&id=o-AGjpRnghBdIXZHBqPfCTdgIwlwTgYr32hfC4GS72KFMM&dur=327.627&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&c=WEB&initcwndbps=942500&lsparams=initcwndbps%2Cmn%2Cmm%2Cmv%2Cms%2Cpl&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&mt=1547946168&lmt=1540547722115265&lsig=ANVabiowRQIgSLR4LY9eW6p_OH0O6KC9NpowgDY8eWIxP7zr-_G4NCACIQCrnEMv_xYzlyYuSsqTvENNBNyYLQVdlA_VShfVM6VHQQ%3D%3D&source=youtube&mv=m&fvip=3&mime=video%2Fmp4&pl=29&sparams=expire%2Cei%2Cip%2Cid%2Cipbits%2Citag%2Csource%2Cclen%2Cgir%2Cmime%2Cdur%2Caitags%2Ckeepalive%2Crequiressl%2Clmt&ipbits=0&ei=IclDXP2BEcWGgQfB7Yh4&txp=5532432&clen=27800113&requiressl=yes&keepalive=yes&itag=135&gir=yes&ms=au%2Crdu&expire=1547967873&sig=AMao4c4wRgIhAOd-LJneOFUHIGDTNM0AEWH47qSH1RZiDGlx31WiCe07AiEAzqHol6weAGIQVbdNfrEE0Kx-335rp4h-mOar32pM37U=&ratebypass=yes"
--2019-01-20 01:12:02--  https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?mm=31%2C29&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&id=o-AGjpRnghBdIXZHBqPfCTdgIwlwTgYr32hfC4GS72KFMM&dur=327.627&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&c=WEB&initcwndbps=942500&lsparams=initcwndbps%2Cmn%2Cmm%2Cmv%2Cms%2Cpl&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&mt=1547946168&lmt=1540547722115265&lsig=ANVabiowRQIgSLR4LY9eW6p_OH0O6KC9NpowgDY8eWIxP7zr-_G4NCACIQCrnEMv_xYzlyYuSsqTvENNBNyYLQVdlA_VShfVM6VHQQ%3D%3D&source=youtube&mv=m&fvip=3&mime=video%2Fmp4&pl=29&sparams=expire%2Cei%2Cip%2Cid%2Cipbits%2Citag%2Csource%2Cclen%2Cgir%2Cmime%2Cdur%2Caitags%2Ckeepalive%2Crequiressl%2Clmt&ipbits=0&ei=IclDXP2BEcWGgQfB7Yh4&txp=5532432&clen=27800113&requiressl=yes&keepalive=yes&itag=135&gir=yes&ms=au%2Crdu&expire=1547967873&sig=AMao4c4wRgIhAOd-LJneOFUHIGDTNM0AEWH47qSH1RZiDGlx31WiCe07AiEAzqHol6weAGIQVbdNfrEE0Kx-335rp4h-mOar32pM37U=&ratebypass=yes
Resolving r7---sn-xpgjvh-q0cd.googlevideo.com (r7---sn-xpgjvh-q0cd.googlevideo.com)... 2001:bb0:100:1b::12, 159.134.171.210
Connecting to r7---sn-xpgjvh-q0cd.googlevideo.com (r7---sn-xpgjvh-q0cd.googlevideo.com)|2001:bb0:100:1b::12|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 27800113 (27M) [video/mp4]
Saving to: ‘test.file’

test.file                                      13%[===========>                                                                                   ]   3.52M   513KB/s    eta 44s    ^C
```

Output, after fixing, with login, works fine:
```
$ python -m youtube_dl https://www.youtube.com/watch?v=D4hAVemuQXY -u 'PRIVATE' -v
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://www.youtube.com/watch?v=D4hAVemuQXY', u'-u', u'PRIVATE', u'-v']
Type account password and press [Return]: 
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.01.17
[debug] Git HEAD: 379306ef5
[debug] Python version 2.7.15 (CPython) - Darwin-18.2.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1, ffprobe 4.1
[debug] Proxy map: {}
[youtube] Downloading login page
[youtube] Looking up account info
[youtube] Logging in
[youtube] Checking cookie
[youtube] D4hAVemuQXY: Downloading webpage
[youtube] D4hAVemuQXY: Downloading video info webpage
[youtube] {18} signature length 106, html5 player vfl-jbnrr
[youtube] {36} signature length 110, html5 player vfl-jbnrr
[youtube] {17} signature length 110, html5 player vfl-jbnrr
[youtube] {135} signature length 106, html5 player vfl-jbnrr
[youtube] {244} signature length 110, html5 player vfl-jbnrr
[youtube] {397} signature length 106, html5 player vfl-jbnrr
[youtube] {134} signature length 110, html5 player vfl-jbnrr
[youtube] {243} signature length 110, html5 player vfl-jbnrr
[youtube] {396} signature length 106, html5 player vfl-jbnrr
[youtube] {133} signature length 110, html5 player vfl-jbnrr
[youtube] {242} signature length 110, html5 player vfl-jbnrr
[youtube] {395} signature length 106, html5 player vfl-jbnrr
[youtube] {160} signature length 110, html5 player vfl-jbnrr
[youtube] {278} signature length 110, html5 player vfl-jbnrr
[youtube] {394} signature length 106, html5 player vfl-jbnrr
[youtube] {140} signature length 106, html5 player vfl-jbnrr
[youtube] {171} signature length 110, html5 player vfl-jbnrr
[youtube] {249} signature length 110, html5 player vfl-jbnrr
[youtube] {250} signature length 106, html5 player vfl-jbnrr
[youtube] {251} signature length 110, html5 player vfl-jbnrr
[debug] Default format spec: bestvideo+bestaudio/best
WARNING: Requested formats are incompatible for merge and will be merged into mkv.
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?ipbits=0&dur=327.627&expire=1547969564&beids=9466586&txp=5532432&ei=vM9DXJLQIIWegQfIkLXgDw&c=WEB&itag=135&keepalive=yes&requiressl=yes&lmt=1540547722115265&fvip=3&ms=au%2Crdu&lsparams=ms%2Cmn%2Cmv%2Cmm%2Cinitcwndbps%2Cpl&mv=m&initcwndbps=950000&source=youtube&sparams=expire%2Cei%2Cip%2Csource%2Caitags%2Cclen%2Clmt%2Cdur%2Cid%2Cgir%2Cmime%2Cipbits%2Crequiressl%2Citag%2Ckeepalive&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&pl=29&id=o-ACWXpw5FivEhUFt34u2EKbaRBGM6V-frKklIuzoyr4ym&mime=video%2Fmp4&clen=27800113&lsig=ANVabiowRAIgFFON2AQBSI8Fn2gGEJpjp6cQs0YsLUIjtTzWa-W-XmICIGW2beM_L-ZC5G0bfgUl4grLbVxSZ0ioujV-ydepzjZo&mt=1547947881&gir=yes&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&mm=31%2C29&sig=AMao4c4wRAIgfxBN-HMej6-gKaFM3Rc4CRLoKkHyqwA09xEABRh-mpcCIAS8Sw_WBW_7NArzBOlAjSrVuF_0nu6D5hnVNTvaH0Qh&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4
[download] 100% of 26.51MiB in 00:03
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?ipbits=0&dur=327.661&expire=1547969564&beids=9466586&txp=5511222&ei=vM9DXJLQIIWegQfIkLXgDw&c=WEB&itag=251&keepalive=yes&requiressl=yes&lmt=1540554828851893&fvip=3&ms=au%2Crdu&lsparams=ms%2Cmn%2Cmv%2Cmm%2Cinitcwndbps%2Cpl&mv=m&initcwndbps=950000&source=youtube&sparams=expire%2Cei%2Cip%2Csource%2Cclen%2Clmt%2Cdur%2Cid%2Cgir%2Cmime%2Cipbits%2Crequiressl%2Citag%2Ckeepalive&lsig=ANVabiowRgIhAJzIP42gQlMpUDsks1bJn-Mdk1JBqEyTre8Jjey_s3MxAiEA89fdYgEiD1PokmyZPyoHa--PHsCiSv-xYlWs6mlJPyE%3D&pl=29&id=o-ACWXpw5FivEhUFt34u2EKbaRBGM6V-frKklIuzoyr4ym&mime=audio%2Fwebm&clen=4638867&mt=1547947881&gir=yes&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&mm=31%2C29&sig=AMao4c4wRQIhAI3eeVSl4bW-GNRcwuoZI6SyAcAwUWmnZsYsIaU1de89AiA_VA21Cjoeeaif9BnTdKjyrnfqL_j_snwS_sZv80KWbA==&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm
[download] 100% of 4.42MiB in 00:00
[ffmpeg] Merging formats into "Eminem - Sing For The Moment-D4hAVemuQXY.mkv"
[debug] ffmpeg command line: ffmpeg -y -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4' -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm' -c copy -map '0:v:0' -map '1:a:0' 'file:Eminem - Sing For The Moment-D4hAVemuQXY.temp.mkv'
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4 (pass -k to keep)
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm (pass -k to keep)
```

Output, after fixing, no login, works fine:
```
$ python -m youtube_dl https://www.youtube.com/watch?v=D4hAVemuQXY -v
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'https://www.youtube.com/watch?v=D4hAVemuQXY', u'-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.01.17
[debug] Git HEAD: 379306ef5
[debug] Python version 2.7.15 (CPython) - Darwin-18.2.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1, ffprobe 4.1
[debug] Proxy map: {}
[youtube] D4hAVemuQXY: Downloading webpage
[youtube] D4hAVemuQXY: Downloading video info webpage
[youtube] {18} signature length 42.44, html5 player vfl-jbnrr
[youtube] {36} signature length 42.44, html5 player vfl-jbnrr
[youtube] {17} signature length 42.44, html5 player vfl-jbnrr
[youtube] {135} signature length 42.44, html5 player vfl-jbnrr
[youtube] {244} signature length 42.44, html5 player vfl-jbnrr
[youtube] {397} signature length 42.44, html5 player vfl-jbnrr
[youtube] {134} signature length 42.44, html5 player vfl-jbnrr
[youtube] {243} signature length 42.44, html5 player vfl-jbnrr
[youtube] {396} signature length 42.44, html5 player vfl-jbnrr
[youtube] {133} signature length 42.44, html5 player vfl-jbnrr
[youtube] {242} signature length 42.44, html5 player vfl-jbnrr
[youtube] {395} signature length 42.44, html5 player vfl-jbnrr
[youtube] {160} signature length 42.44, html5 player vfl-jbnrr
[youtube] {278} signature length 42.44, html5 player vfl-jbnrr
[youtube] {394} signature length 42.44, html5 player vfl-jbnrr
[youtube] {140} signature length 42.44, html5 player vfl-jbnrr
[youtube] {171} signature length 42.44, html5 player vfl-jbnrr
[youtube] {249} signature length 42.44, html5 player vfl-jbnrr
[youtube] {250} signature length 42.44, html5 player vfl-jbnrr
[youtube] {251} signature length 42.44, html5 player vfl-jbnrr
[debug] Default format spec: bestvideo+bestaudio/best
WARNING: Requested formats are incompatible for merge and will be merged into mkv.
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?mt=1547947818&itag=135&pl=29&ei=eM9DXOfnAcSh8gOqnpH4Cw&ms=au%2Crdu&mv=m&mm=31%2C29&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&expire=1547969496&requiressl=yes&mime=video%2Fmp4&aitags=133%2C134%2C135%2C160%2C242%2C243%2C244%2C278%2C394%2C395%2C396%2C397&source=youtube&lmt=1540547722115265&key=yt6&dur=327.627&ipbits=0&initcwndbps=957500&keepalive=yes&c=WEB&id=o-AJxk1VHCk7VcKI9AZPRPcwCLJQ0h4kbwm3OBhXYmEPMO&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&txp=5532432&clen=27800113&gir=yes&fvip=3&sparams=aitags%2Cclen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Ckeepalive%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Crequiressl%2Csource%2Cexpire&signature=C7AC0ACDA99B474E9D9451D2D8FAD48F27009694.82C06B95314814BB4986F2BDB94811A4138390F3&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4
[download] 100% of 26.51MiB in 00:02
[debug] Invoking downloader on u'https://r7---sn-xpgjvh-q0cd.googlevideo.com/videoplayback?mt=1547947818&itag=251&pl=29&ei=eM9DXOfnAcSh8gOqnpH4Cw&ms=au%2Crdu&mv=m&mm=31%2C29&mn=sn-xpgjvh-q0cd%2Csn-q0c7rn76&expire=1547969496&requiressl=yes&mime=audio%2Fwebm&source=youtube&lmt=1540554828851893&key=yt6&dur=327.661&ipbits=0&initcwndbps=957500&keepalive=yes&c=WEB&id=o-AJxk1VHCk7VcKI9AZPRPcwCLJQ0h4kbwm3OBhXYmEPMO&ip=2001%3Abb6%3A5e09%3Afb58%3Ab4f7%3Ad8d7%3A762d%3A9cce&txp=5511222&clen=4638867&gir=yes&fvip=3&sparams=clen%2Cdur%2Cei%2Cgir%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Ckeepalive%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Crequiressl%2Csource%2Cexpire&signature=1BB5413A9CBE93FCEA6A07F6170C64D4D3139571.177E4B23EE9F6AC8B26C75A8F5B00BA1476066B3&ratebypass=yes'
[download] Destination: Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm
[download] 100% of 4.42MiB in 00:00
[ffmpeg] Merging formats into "Eminem - Sing For The Moment-D4hAVemuQXY.mkv"
[debug] ffmpeg command line: ffmpeg -y -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4' -i 'file:Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm' -c copy -map '0:v:0' -map '1:a:0' 'file:Eminem - Sing For The Moment-D4hAVemuQXY.temp.mkv'
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f135.mp4 (pass -k to keep)
Deleting original file Eminem - Sing For The Moment-D4hAVemuQXY.f251.webm (pass -k to keep)
```