### PR TITLE
[iprima] Enables HD quality when CookieFile is provided

### DIFF
--- a/youtube_dl/extractor/iprima.py
+++ b/youtube_dl/extractor/iprima.py
@@ -74,11 +74,12 @@ class IPrimaIE(InfoExtractor):
             webpage, 'real id')
 
         playerpage = self._download_webpage(
-            'http://play.iprima.cz/prehravac/init',
+            'https://api.play-backend.iprima.cz/prehravac/init-embed',
             video_id, note='Downloading player', query={
                 '_infuse': 1,
                 '_ts': round(time.time()),
                 'productId': video_id,
+                'embed': True,
             }, headers={'Referer': url})
 
         formats = []


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This changes will allow download of streams in HD quality which is normally available only to signed-in users. 
A cookie file needs to be provided with `--cookies` flag for this improvement to work, if cookie file is not provided only SD streams are available.

