### PR TITLE
[thisav] Fix video extraction, uploader extraction and tests.

### DIFF
--- a/youtube_dl/extractor/thisav.py
+++ b/youtube_dl/extractor/thisav.py
@@ -61,11 +61,12 @@ class ThisAVIE(InfoExtractor):
             else:
                 info_dict = self._extract_jwplayer_data(
                     webpage, video_id, require_title=False)
+
         uploader = self._html_search_regex(
-            r': <a href="http://www\.thisav\.com/user/[0-9]+/(?:[^"]+)">([^<]+)</a>',
+            r': <a href="https?://www\.thisav\.com/user/[0-9]+/(?:[^"]+)">([^<]+)</a>',
             webpage, 'uploader name', fatal=False)
         uploader_id = self._html_search_regex(
-            r': <a href="http://www\.thisav\.com/user/[0-9]+/([^"]+)">(?:[^<]+)</a>',
+            r': <a href="https?://www\.thisav\.com/user/[0-9]+/([^"]+)">(?:[^<]+)</a>',
             webpage, 'uploader id', fatal=False)
 
         info_dict.update({

--- a/youtube_dl/extractor/thisav.py
+++ b/youtube_dl/extractor/thisav.py
@@ -9,20 +9,20 @@ from ..utils import urljoin, xpath_text
 
 class ThisAVIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?thisav\.com/video/(?P<id>[0-9]+)/.*'
+
+    # all videos are now html5 videos
     _TESTS = [{
-        # jwplayer
-        'url': 'http://www.thisav.com/video/47734/%98%26sup1%3B%83%9E%83%82---just-fit.html',
-        'md5': '0480f1ef3932d901f0e0e719f188f19b',
+        'url': 'https://www.thisav.com/video/47734/%98%26sup1%3B%83%9E%83%82---just-fit.html',
+        'md5': 'adad2d2e989b4524698b4fb856d6719f',
         'info_dict': {
             'id': '47734',
-            'ext': 'flv',
+            'ext': 'mp4',
             'title': '高樹マリア - Just fit',
             'uploader': 'dj7970',
             'uploader_id': 'dj7970'
         }
     }, {
-        # html5 media
-        'url': 'http://www.thisav.com/video/242352/nerdy-18yo-big-ass-tattoos-and-glasses.html',
+        'url': 'https://www.thisav.com/video/242352/nerdy-18yo-big-ass-tattoos-and-glasses.html',
         'md5': 'ba90c076bd0f80203679e5b60bf523ee',
         'info_dict': {
             'id': '242352',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The thisav extractor has been broken for almost 2 years, this PR attempts to
fix it. I've seen PRs being turned down because they made untested changes to
`common.py`, while other PRs only changed the regex slightly and hoped for the
best. This PR avoids as much mpd parsing business as possible and extracts only
the relevant bits robustly.
