### PR TITLE
[soundcloud] Use api-v2 to support AAC streams

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -227,10 +227,13 @@ class SoundcloudIE(InfoExtractor):
                 acodec = 'opus'
                 ext = 'ogg'
                 abr = 64
-            elif stream['preset'] == 'aac_1_0':
+            elif stream['preset'] in ('aac_1_0', 'aac_hq'):
                 acodec = 'aac'
                 ext = 'm4a'
                 abr = 256
+            else:
+                self.to_screen('Stream type %s not recognised' % stream['preset'])
+                continue
 
             format_id = ('%s-%s-%s' % (stream['format']['protocol'], acodec, abr))
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Soundcloud Go+ provides AAC streams at 256kbps. These are only available from the api-v2 endpoint as progressive https or hls. This change addresses adds support for these and retains support for existing https/hls mp3 from the same v2 endpoint, and downloads (when available) from the v1 endpoint.

The 256k streams are only available if a Go+ account is provided by way of an OAuth token:
```
--add-header "Authorization: OAuth <token>"
```
If an OAuth token is not supplied, only MP3 128kbps and Opus 64kbps streams are available. Incidentally, this change also adds support for downloading the low rate Opus streams.

The main downside to this change is a delay whilst all the of the stream URLs are retrieved and validated.

I have tested this with a Go+ account and 256kbps AAC streams are retrieved correctly. I did have to use ffmpeg on the HLS streams (```--hls-prefer-ffmpeg```) for a valid seek table to be present but I have not investigated the precise cause of this.

