### PR TITLE
Add support for Google Fiber to adobepass.py

### DIFF
--- a/youtube_dl/extractor/adobepass.py
+++ b/youtube_dl/extractor/adobepass.py
@@ -1314,6 +1314,9 @@ MSO_INFO = {
     'cou060': {
         'name': 'Zito Media'
     },
+    'GoogleFiber': {
+        'name': 'Google Fiber Direct'
+    },
 }
 
 
@@ -1491,6 +1494,52 @@ class AdobePassIE(InfoExtractor):
                         }), headers={
                             'Content-Type': 'application/x-www-form-urlencoded'
                         })
+                elif mso_id == 'GoogleFiber':
+                    # Google Fiber uses a series of web calls and a click through
+                    # only valid if you are connecting from a Google Fiber IP address
+                    # TODO: handle username/password authentication if remote
+                    provider_redirect_page, urlh = provider_redirect_page_res
+                    if 'history_val' in provider_redirect_page:
+                        saml_firstbookend_url = urlh.geturl()
+                        saml_autoauth_page = self._download_webpage(
+                            saml_firstbookend_url, 'First Bookend Redirect', query={
+                                'history': '17',
+                            })
+                        if '$.ajax(' in saml_autoauth_page:
+                            saml_ajaxautoauth_url = self._html_search_regex(
+                                r'url\s*:\s*(["\'])(?P<url>.+?)\1',
+                                saml_autoauth_page,
+                                'SAML Redirect URL', group='url'
+                            )
+                            saml_login_url = self._html_search_regex(
+                                r'window.location.replace\((["\'])(?P<url>.+?login.php)\1',
+                                saml_autoauth_page,
+                                'Auth Redirect URL', group='url'
+                            )
+                            saml_ajaxcall_page = self._download_webpage(
+                                saml_ajaxautoauth_url, 'SAML Autoauth')
+                            saml_login_res = self._download_webpage_handle(
+                                saml_login_url + '?AuthState=%s' % saml_ajaxcall_page,
+                                'SAML Login')
+                            provider_postlogin_page_res = post_form(saml_login_res, 'SAML Accept Login')
+                            provider_postlogin_page, urlh = provider_postlogin_page_res
+                            saml_redirect_url = extract_redirect_url(
+                                provider_postlogin_page, fatal=True)
+                            provider_finallogin_page_res = self._download_webpage_handle(
+                                saml_redirect_url, video_id,
+                                'SAML Final Redirect')
+                            provider_page, urlh = provider_finallogin_page_res
+                            saml_lastbookend_url = urlh.geturl()
+                            saml_finalredirect_page_res = self._download_webpage_handle(
+                                saml_lastbookend_url, 'SAML Final', query={
+                                    'history': '19',
+                                }
+                            )
+                            post_form(saml_finalredirect_page_res, 'SAML Response')
+                        else:
+                            raise ExtractorError(
+                                'Unable to automatically login with GoogleFiber. Maybe not a Google Fiber IP?'
+                            )
                 else:
                     # Some providers (e.g. DIRECTV NOW) have another meta refresh
                     # based redirect that should be followed.


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Added support to adobepass.py to allow authentication when connecting from Google Fiber ISP. Adds GoogleFiber to the ap mso list, as well as handling the browser handshake used by Google Fiber.
