### PR TITLE
Handle Opus bitrate when quality is specified instead of bitrate

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -304,31 +304,19 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             extension = self._preferredcodec
             more_opts = []
             if self._preferredquality is not None:
+                preferredquality = int(self._preferredquality)
                 # The opus codec doesn't support the -aq option
-                if int(self._preferredquality) < 10 and extension != 'opus':
+                if preferredquality < 10 and extension != 'opus':
                     more_opts += ['-q:a', self._preferredquality]
-                elif int(self._preferredquality) < 10:
+                elif preferredquality < 10 and preferredquality >= 0:
                     # Handle opus quality/bitrate using Xiph.org's Recommended Settings
-                    if int(self._preferredquality) == 9:
-                        more_opts += ['-b:a', '450k']
-                    elif int(self._preferredquality) == 8:
-                        more_opts += ['-b:a', '256k']
-                    elif int(self._preferredquality) == 7:
-                        more_opts += ['-b:a', '128k']
-                    elif int(self._preferredquality) == 6:
-                        more_opts += ['-b:a', '96k']
-                    elif int(self._preferredquality) == 5:
-                        more_opts += ['-b:a', '64k']
-                    elif int(self._preferredquality) == 4:
-                        more_opts += ['-b:a', '32k']
-                    elif int(self._preferredquality) == 3:
-                        more_opts += ['-b:a', '24k']
-                    elif int(self._preferredquality) == 2:
-                        more_opts += ['-b:a', '10k']
-                    else:
-                        more_opts += ['-b:a', '6k']
+                    opus_bitrate_list = [
+                        '6k', '6k', '10k', '24k', '32k', '64k', '96k', '128k', '256k', '450k'
+                    ]
+                    more_opts += ['-b:a', opus_bitrate_list[preferredquality]]
                 else:
                     more_opts += ['-b:a', self._preferredquality + 'k']
+
             if self._preferredcodec == 'aac':
                 more_opts += ['-f', 'adts']
             if self._preferredcodec == 'm4a':

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -307,6 +307,26 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 # The opus codec doesn't support the -aq option
                 if int(self._preferredquality) < 10 and extension != 'opus':
                     more_opts += ['-q:a', self._preferredquality]
+                else if int(self._preferredquality) < 10:
+                    # Handle opus quality/bitrate using Xiph.org's Recommended Settings
+                    if      int(self._preferredquality) == 9:
+                        more_opts += ['-b:a', '450k']
+                    else if int(self._preferredquality) == 8:
+                        more_opts += ['-b:a', '256k']
+                    else if int(self._preferredquality) == 7:
+                        more_opts += ['-b:a', '128k']
+                    else if int(self._preferredquality) == 6:
+                        more_opts += ['-b:a', '96k']
+                    else if int(self._preferredquality) == 5:
+                        more_opts += ['-b:a', '64k']
+                    else if int(self._preferredquality) == 4:
+                        more_opts += ['-b:a', '32k']
+                    else if int(self._preferredquality) == 3:
+                        more_opts += ['-b:a', '24k']
+                    else if int(self._preferredquality) == 2:
+                        more_opts += ['-b:a', '10k']
+                    else:
+                        more_opts += ['-b:a', '6k']
                 else:
                     more_opts += ['-b:a', self._preferredquality + 'k']
             if self._preferredcodec == 'aac':

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -311,7 +311,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 elif preferredquality < 10 and preferredquality >= 0:
                     # Handle opus quality/bitrate using Xiph.org's Recommended Settings
                     opus_bitrate_list = [
-                        '6k', '6k', '10k', '24k', '32k', '64k', '96k', '128k', '256k', '450k'
+                        '450k', '256k', '160k', '128k', '96k', '64k', '32k', '24k', '10k', '6k'
                     ]
                     more_opts += ['-b:a', opus_bitrate_list[preferredquality]]
                 else:

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -307,23 +307,23 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 # The opus codec doesn't support the -aq option
                 if int(self._preferredquality) < 10 and extension != 'opus':
                     more_opts += ['-q:a', self._preferredquality]
-                else if int(self._preferredquality) < 10:
+                elif int(self._preferredquality) < 10:
                     # Handle opus quality/bitrate using Xiph.org's Recommended Settings
-                    if      int(self._preferredquality) == 9:
+                    if int(self._preferredquality) == 9:
                         more_opts += ['-b:a', '450k']
-                    else if int(self._preferredquality) == 8:
+                    elif int(self._preferredquality) == 8:
                         more_opts += ['-b:a', '256k']
-                    else if int(self._preferredquality) == 7:
+                    elif int(self._preferredquality) == 7:
                         more_opts += ['-b:a', '128k']
-                    else if int(self._preferredquality) == 6:
+                    elif int(self._preferredquality) == 6:
                         more_opts += ['-b:a', '96k']
-                    else if int(self._preferredquality) == 5:
+                    elif int(self._preferredquality) == 5:
                         more_opts += ['-b:a', '64k']
-                    else if int(self._preferredquality) == 4:
+                    elif int(self._preferredquality) == 4:
                         more_opts += ['-b:a', '32k']
-                    else if int(self._preferredquality) == 3:
+                    elif int(self._preferredquality) == 3:
                         more_opts += ['-b:a', '24k']
-                    else if int(self._preferredquality) == 2:
+                    elif int(self._preferredquality) == 2:
                         more_opts += ['-b:a', '10k']
                     else:
                         more_opts += ['-b:a', '6k']


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/rg3/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/rg3/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/rg3/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- ~~I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)~~

### What is the purpose of your *pull request*?
- ~~Bug fix~~
- [x] Improvement
- ~~New extractor~~
- ~~New feature~~

---

### Description of your *pull request* and other information

When converting formats the user would expect that with the default options the resulting file has at least a "normal quality", however when extracting audio from a source not in Opus, and specifying it as the resulting file format on youtube-dl without any other tuning, it produces a low quality file.

Here I used the [Xiph's Recomended Opus Bitrates](https://wiki.xiph.org/Opus_Recommended_Settings#Recommended_Bitrates) to emulate the mising -aq option on the opus codec.