### PR TITLE
Fix ruleporn, fixes #15344

### DIFF
--- a/youtube_dl/extractor/ruleporn.py
+++ b/youtube_dl/extractor/ruleporn.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
-from .nuevo import NuevoBaseIE
+from .common import InfoExtractor
 
 
-class RulePornIE(NuevoBaseIE):
+class RulePornIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?ruleporn\.com/(?:[^/?#&]+/)*(?P<id>[^/?#&]+)'
     _TEST = {
         'url': 'http://ruleporn.com/brunette-nympho-chick-takes-her-boyfriend-in-every-angle/',
@@ -24,21 +24,19 @@ class RulePornIE(NuevoBaseIE):
 
         webpage = self._download_webpage(url, display_id)
 
-        video_id = self._search_regex(
-            r'lovehomeporn\.com/embed/(\d+)', webpage, 'video id')
+        url = self._search_regex(
+            r'<source[^>]+src="(https?://media.ruleporn.com/media/videos/[a-zA-Z0-9/]+\.mp4)[^>]+>',
+            webpage, 'url')
 
         title = self._search_regex(
-            r'<h2[^>]+title=(["\'])(?P<url>.+?)\1',
-            webpage, 'title', group='url')
+            r'<h1>(.+?)</h1>',
+            webpage, 'title')
         description = self._html_search_meta('description', webpage)
 
-        info = self._extract_nuevo(
-            'http://lovehomeporn.com/media/nuevo/econfig.php?key=%s&rp=true' % video_id,
-            video_id)
-        info.update({
-            'display_id': display_id,
+        return {
+            'id': display_id,
             'title': title,
             'description': description,
-            'age_limit': 18
-        })
-        return info
+            'age_limit': 18,
+            'url': url
+        }


### PR DESCRIPTION
Fix ruleporn, fixes #15344

The videofile is in the html now. Simplifies the extractor a lot. Might
be part of solution for #20323.

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As mentioned in the commit message, this fixes downloads from ruleporn. 
