### PR TITLE
Add support for websites with multiple LD-JSON objects

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2101,6 +2101,19 @@ class GenericIE(InfoExtractor):
             },
             'expected_warnings': ['Failed to download MPD manifest'],
         },
+        {
+            # page with multiple LD-JSON objects
+            'url': 'https://www.antena3.com/noticias/sociedad/grupo-personas-descuelga-pancarta-lazo-amarillo-ayuntamiento-barcelona-video_201903145c8a02c70cf2b779bc2dca9b.html',
+            'md5': '5a9a0d6c788f0a4cee05d2c077b3637c',
+            'info_dict': {
+                'id': 'grupo-personas-descuelga-pancarta-lazo-amarillo-ayuntamiento-barcelona-video_201903145c8a02c70cf2b779bc2dca9b',
+                'ext': 'mp4',
+                'title': 'Un grupo de personas descuelga una pancarta con un lazo amarillo del Ayuntamiento de Barcelona y operarios la vuelven a colocar',
+                'timestamp': 1552548539,
+                'description': 'La retirada de la pancarta con el lazo amarillo en la fachada del Ayuntamiento de Barcelona ha durado poco. Tras su retirada por parte de un grupo de personas esta madrugada un grupo de operarios ha vuelto a colocarla. ',
+                'upload_date': '20190314',
+            },
+        },
         # {
         #     # TODO: find another test
         #     # http://schema.org/VideoObject


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-d#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some websites contain multiple LD-JSON objects. `youtube-dl` only looked at the first one of them, which means video downloads would fail for websites whose first LD-JSON object wasn't a `VideoObject`. This PR makes `youtube-dl` find the first `VideoObject` in the page.

Example site: https://www.antena3.com/noticias/sociedad/grupo-personas-descuelga-pancarta-lazo-amarillo-ayuntamiento-barcelona-video_201903145c8a02c70cf2b779bc2dca9b.html