### PR TITLE
[lynda] Fix for invalid json response when no transcript is available

### DIFF
--- a/youtube_dl/extractor/lynda.py
+++ b/youtube_dl/extractor/lynda.py
@@ -247,7 +247,9 @@ class LyndaIE(LyndaBaseIE):
 
     def _get_subtitles(self, video_id):
         url = 'https://www.lynda.com/ajax/player?videoId=%s&type=transcript' % video_id
-        subs = self._download_json(url, None, False)
+        subs = self._download_json(url, None, False, fatal=False)
+        if not subs:
+            return {}
         fixed_subs = self._fix_subtitles(subs)
         if fixed_subs:
             return {'en': [{'ext': 'srt', 'data': fixed_subs}]}


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When no transcript is available, the ``https://www.lynda.com/ajax/player?videoId=%s&type=transcript`` endpoint returns an invalid json response

[Example](https://www.lynda.com/ajax/player?videoId=780636&type=transcript)
```
{ Status="NotFound", Message="Command not found" }
```
which raises a json parsing error ``ValueError('Expecting property name enclosed in double quotes: line 1 column 3 (char 2)',)``

Example:

```
$> youtube-dl --config-location lynda_config 'https://www.lynda.com/Data-Science-tutorials/Data-Science-Tools-Trade-First-Steps/664826-2.html' --playlist-items 36 -v

[debug] System config: []
[debug] User config: []
[debug] Custom config: [u'--cookies', u'lynda_cookies.txt', u'--sub-format', u'srt', u'--sub-lang', u'en', u'--no-mtime', u'--write-sub', u'--add-metadata', u'--xattrs', u'--embed-subs', u'--retries', u'2', u'-o', u'./%(playlist)s/%(chapter_number)s - %(chapter)s/%(playlist_index)s_%(title)s_%(id)s.%(ext)s']
[debug] Command-line args: [u'--config-location', u'lynda_config', u'https://www.lynda.com/Data-Science-tutorials/Data-Science-Tools-Trade-First-Steps/664826-2.html', u'--playlist-items', u'36', u'-v']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.03.18
[debug] Python version 2.7.15 (CPython) - Darwin-17.7.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 3.2.2-tessus, ffprobe 3.2.2-tessus, rtmpdump 2.4
[debug] Proxy map: {}
[lynda:course] 664826: Downloading course JSON
[download] Downloading playlist: Data Science Tools of the Trade: First Steps
[lynda:course] playlist Data Science Tools of the Trade: First Steps: Collected 43 video ids (downloading 1 of them)
[download] Downloading video 1 of 1
[lynda] 780636: Downloading video JSON
[lynda] 780636: Checking 1-540 video format URL
[lynda] 780636: Checking 1-360 video format URL
[lynda] 780636: Checking 1-720 video format URL
[lynda] 780636: Checking 0-540 video format URL
[lynda] 780636: Checking 0-360 video format URL
[lynda] 780636: Checking 0-720 video format URL
ERROR: None: Failed to parse JSON  (caused by ValueError('Expecting property name enclosed in double quotes: line 1 column 3 (char 2)',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 898, in _parse_json
    return json.loads(json_string)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/json/decoder.py", line 380, in raw_decode
    obj, end = self.scan_once(s, idx)
ValueError: Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
Traceback (most recent call last):
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 794, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 529, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/lynda.py", line 217, in _real_extract
    subtitles = self.extract_subtitles(video_id)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 2850, in extract_subtitles
    return self._get_subtitles(*args, **kwargs)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/lynda.py", line 250, in _get_subtitles
    subs = self._download_json(url, None, False)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 891, in _download_json
    expected_status=expected_status)
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 875, in _download_json_handle
    fatal=fatal), urlh
  File "/usr/local/bin/youtube-dl/youtube_dl/extractor/common.py", line 902, in _parse_json
    raise ExtractorError(errmsg, cause=ve)
ExtractorError: None: Failed to parse JSON  (caused by ValueError('Expecting property name enclosed in double quotes: line 1 column 3 (char 2)',)); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```
