### PR TITLE
Update format example with parenthesis in readme.md, to prevent "audio not downloaded and merged" behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,9 @@ $ youtube-dl -f 'bestvideo[height<=480]+bestaudio/best[height<=480]'
 # Download best video only format but no bigger than 50 MB
 $ youtube-dl -f 'best[filesize<50M]'
 
+# Utilizing parenthesis for the + sign, in order to prevent audio from not being downloaded and merged
+$ youtube-dl -f ((248/247/137/136)+(251/140/171))
+
 # Download best format available via direct link over HTTP/HTTPS protocol
 $ youtube-dl -f '(bestvideo+bestaudio/best)[protocol^=http]'
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

When downloading with the intent of merging video+audio together, the lack of parehthesis would make the script fail to download the audio part.

Example:
```
youtube-dl -f 248/137/136+251/140
```
Whenever 248 and 251 do not exist, youtube-dl will only download 137, completely ignores 140, thus generated a file with video only.

Change it to (  (248/137/136)+(251/140)  ) solved the issue. A file with 137+140 can be downloaded and merged correctly.

Not so sure if I should change the code directly, so I changed readme.md first.