### PR TITLE
Fix issue #20264 Lrt.lt site redesign

### DIFF
--- a/youtube_dl/extractor/lrt.py
+++ b/youtube_dl/extractor/lrt.py
@@ -6,8 +6,6 @@ import re
 from .common import InfoExtractor
 from ..utils import (
     determine_ext,
-    int_or_none,
-    parse_duration,
     remove_end,
 )
 
@@ -17,70 +15,67 @@ class LRTIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?lrt\.lt/mediateka/irasas/(?P<id>[0-9]+)'
     _TESTS = [{
         # m3u8 download
-        'url': 'http://www.lrt.lt/mediateka/irasas/54391/',
-        'md5': 'fe44cf7e4ab3198055f2c598fc175cb0',
+        'url': 'https://www.lrt.lt/mediateka/irasas/54391/septynios-kauno-dienos',
+        'md5': '50c84b875e930784daa66fa8c2617664',
         'info_dict': {
             'id': '54391',
             'ext': 'mp4',
             'title': 'Septynios Kauno dienos',
             'description': 'md5:24d84534c7dc76581e59f5689462411a',
-            'duration': 1783,
-            'view_count': int,
-            'like_count': int,
         },
     }, {
-        # direct mp3 download
-        'url': 'http://www.lrt.lt/mediateka/irasas/1013074524/',
-        'md5': '389da8ca3cad0f51d12bed0c844f6a0a',
+        # after the redesign - everything is mp4 file (some of the shows used to be mp3)
+        'url': 'https://www.lrt.lt/mediateka/irasas/1013074524/kita-tema-2016-09-05-15-05',
+        'md5': 'e286cd475ad2839ab90c2ec0be57930b',
         'info_dict': {
             'id': '1013074524',
-            'ext': 'mp3',
+            'ext': 'mp4',
             'title': 'Kita tema 2016-09-05 15:05',
             'description': 'md5:1b295a8fc7219ed0d543fc228c931fb5',
-            'duration': 3008,
-            'view_count': int,
-            'like_count': int,
         },
     }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
         webpage = self._download_webpage(url, video_id)
-
         title = remove_end(self._og_search_title(webpage), ' - LRT')
+
+        file_url1 = ""
+        urlinfo = ""
 
         formats = []
         for _, file_url in re.findall(
-                r'file\s*:\s*(["\'])(?P<url>(?:(?!\1).)+)\1', webpage):
-            ext = determine_ext(file_url)
+                r'(main_url) = "(.*)";', webpage):
+            urlinfo = self._download_json("https://www.lrt.lt/servisai/stream_url/vod/media_info/?url=" + file_url, video_id)
+
+            file_url1 = urlinfo.get("playlist_item").get("file")
+
+            release_date_string_temp = urlinfo.get("date")
+            release_date = release_date_string_temp[0:4] + release_date_string_temp[5:7] + release_date_string_temp[8:10]
+
+            ext = determine_ext(file_url1)
             if ext not in ('m3u8', 'mp3'):
                 continue
             # mp3 served as m3u8 produces stuttered media file
-            if ext == 'm3u8' and '.mp3' in file_url:
+            if ext == 'm3u8' and '.mp3' in file_url1:
                 continue
             if ext == 'm3u8':
                 formats.extend(self._extract_m3u8_formats(
-                    file_url, video_id, 'mp4', entry_protocol='m3u8_native',
+                    file_url1, video_id, 'mp4', entry_protocol='m3u8_native',
                     fatal=False))
             elif ext == 'mp3':
                 formats.append({
-                    'url': file_url,
+                    'url': file_url1,
                     'vcodec': 'none',
                 })
         self._sort_formats(formats)
 
-        thumbnail = self._og_search_thumbnail(webpage)
-        description = self._og_search_description(webpage)
-        duration = parse_duration(self._search_regex(
-            r'var\s+record_len\s*=\s*(["\'])(?P<duration>[0-9]+:[0-9]+:[0-9]+)\1',
-            webpage, 'duration', default=None, group='duration'))
+        try:
+            thumbnail = self._og_search_thumbnail(webpage)
+        except:
+            thumbnail = 0
 
-        view_count = int_or_none(self._html_search_regex(
-            r'<div[^>]+class=(["\']).*?record-desc-seen.*?\1[^>]*>(?P<count>.+?)</div>',
-            webpage, 'view count', fatal=False, group='count'))
-        like_count = int_or_none(self._search_regex(
-            r'<span[^>]+id=(["\'])flikesCount.*?\1>(?P<count>\d+)<',
-            webpage, 'like count', fatal=False, group='count'))
+        description = urlinfo.get("content")
 
         return {
             'id': video_id,
@@ -88,7 +83,5 @@ class LRTIE(InfoExtractor):
             'formats': formats,
             'thumbnail': thumbnail,
             'description': description,
-            'duration': duration,
-            'view_count': view_count,
-            'like_count': like_count,
+            'release_date': release_date
         }


### PR DESCRIPTION
Fixes the issue ytdl-org/youtube-dl#20264

As part of the fix the following changes were made to video attributes:
* duration - removed
* view_count - removed
* like_count - removed
* release_date - added

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/) - 
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix - updated existing extractor after the site redesign
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

LRT.lt had an existing extractor. The site has been redesigned (approximately in Feb 2019) which broke the extractor. The website lrt.lt now has a JSON API to get the details about the media file and the reference to the m3u8 file.

The existing extractor has been updated.