### PR TITLE
[crunchyroll] Allow playlist urls specifying language

### DIFF
--- a/youtube_dl/extractor/crunchyroll.py
+++ b/youtube_dl/extractor/crunchyroll.py
@@ -631,10 +631,23 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 
 class CrunchyrollShowPlaylistIE(CrunchyrollBaseIE):
     IE_NAME = 'crunchyroll:playlist'
-    _VALID_URL = r'https?://(?:(?P<prefix>www|m)\.)?(?P<url>crunchyroll\.com/(?!(?:news|anime-news|library|forum|launchcalendar|lineup|store|comics|freetrial|login|media-\d+))(?P<id>[\w\-]+))/?(?:\?|$)'
+    _VALID_URL = r"""(?x)^
+        https?://(?:(?P<prefix>www|m)\.)?(?P<url>crunchyroll\.com/  # protocol, prefix, domain
+        (?:(?:en-gb|es|es-es|pt-br|pt-pt|fr|de|ar|it|ru)/)?         # optional language component
+        (?!(?:news|anime-news|library|forum|launchcalendar|lineup|store|comics|freetrial|login|media-\d+))  # exclude special pages
+        (?P<id>[\w\-]+))/?(?:\?|$)
+    """
 
     _TESTS = [{
         'url': 'http://www.crunchyroll.com/a-bridge-to-the-starry-skies-hoshizora-e-kakaru-hashi',
+        'info_dict': {
+            'id': 'a-bridge-to-the-starry-skies-hoshizora-e-kakaru-hashi',
+            'title': 'A Bridge to the Starry Skies - Hoshizora e Kakaru Hashi'
+        },
+        'playlist_count': 13,
+    }, {
+        # non-US language
+        'url': 'https://www.crunchyroll.com/en-gb/a-bridge-to-the-starry-skies-hoshizora-e-kakaru-hashi',
         'info_dict': {
             'id': 'a-bridge-to-the-starry-skies-hoshizora-e-kakaru-hashi',
             'title': 'A Bridge to the Starry Skies - Hoshizora e Kakaru Hashi'


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

Crunchyroll has the language in the url for languages other than `en-us`. The existing video extractor accepts these urls fine but the playlist extractor fails. I've fixed the playlist extractor.

Note I can't accept any arbitary language string because video urls in en-us have the same url format as playlist urls in other languages (`crunchyroll.com/language/show` looks a lot like `crunchyroll.com/show/episode`). This means that this'll have to be updated for any new languages :(. Then again it doesn't work for them atm anyway so this is still an improvement.

For my test I used the same example as the existing test but with a language specified so it should fail for other reasons at the same time as the other test. The tests to look rather similar though when run so maybe a different example would be a better choice?