### PR TITLE
Stops FFmpeg from flooding youtube-dl progress with excess download info

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -229,10 +229,12 @@ class FFmpegFD(ExternalFD):
 
         args = [ffpp.executable, '-y']
 
-        for log_level in ('quiet', 'verbose'):
-            if self.params.get(log_level, False):
-                args += ['-loglevel', log_level]
-                break
+        if self.params.get('quiet', False):
+            args += ['-loglevel', 'quiet']
+        elif self.params.get('verbose', False):
+            args += ['-loglevel', 'verbose']
+        else:
+            args += ['-loglevel', 'warning', '-stats']
 
         seekable = info_dict.get('_seekable')
         if seekable is not None:


### PR DESCRIPTION
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] Bug fix

### Description of your *pull request* and other information

A while ago, FFmpeg started echoing every opened URL by default, thereby flooding the terminal and making the youtube-dl progress line unreadable when FFmpeg is used for getting HLS videos.

```
[http @ 0x7f825281b400] Opening 'http://...' for reading
frame=  258 fps=0.0 q=-1.0 size=    2816kB time=00:00:10.32 bitrate=2234.2kbits
frame=  474 fps=449 q=-1.0 size=    5376kB time=00:00:18.98 bitrate=2319.6kbits
[http @ 0x7f8252824e00] Opening 'http://...' for reading
frame=  732 fps=468 q=-1.0 size=    8192kB time=00:00:29.29 bitrate=2291.1kbits
[http @ 0x7f825281b400] Opening 'http://...' for reading
```

The commit makes youtube-dl call FFmpeg in a way that prevents the progress line from being flooded.
