### PR TITLE
[Twitch] Add support for collections as per #20414

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1241,6 +1241,7 @@ from .twitch import (
     TwitchChapterIE,
     TwitchVodIE,
     TwitchProfileIE,
+    TwitchCollectionsIE,
     TwitchAllVideosIE,
     TwitchUploadsIE,
     TwitchPastBroadcastsIE,

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -453,6 +453,9 @@ class TwitchCollectionsIE(TwitchBaseIE):
             'title': 'CORSAIR DreamLeague Season 11 - The Stockholm Major - Studio'
         },
         'playlist_mincount': 57,
+    }, {
+        'url': 'https://www.twitch.tv/collections/HgTD8zFrghUb-Q',
+        'only_matching': True,
     }]
 
     def _extract_collection(self, collection_id):

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -575,6 +575,7 @@ class TwitchStreamIE(TwitchBaseIE):
                             (?:(?:www|go|m)\.)?twitch\.tv/|
                             player\.twitch\.tv/\?.*?\bchannel=
                         )
+                        (?!collections)
                         (?P<id>[^/#?]+)
                     '''
 

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -437,7 +437,7 @@ class TwitchVideosBaseIE(TwitchPlaylistBaseIE):
 
 class TwitchCollectionsIE(TwitchBaseIE):
     IE_NAME = 'twitch:collections'
-    _VALID_URL = r'%s/collections/(?P<id>[\w\d]+)' % TwitchBaseIE._VALID_URL_BASE
+    _VALID_URL = r'%s/collections/(?P<id>[\w\d\-]+)' % TwitchBaseIE._VALID_URL_BASE
 
     _TESTS = [{
         'url': 'https://www.twitch.tv/collections/myIbIFkZphQSbQ',

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -575,7 +575,7 @@ class TwitchStreamIE(TwitchBaseIE):
                             (?:(?:www|go|m)\.)?twitch\.tv/|
                             player\.twitch\.tv/\?.*?\bchannel=
                         )
-                        (?!collections)
+                        (?!collections/[\w\d\-]+)
                         (?P<id>[^/#?]+)
                     '''
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Trying to download a Twitch collection [(example)](https://www.twitch.tv/collections/myIbIFkZphQSbQ) would result in an error: the url would fall to the TwitchStream regex and it would report that 'collections' is offline as if it were a streamer. I created `TwitchCollectionsIE`, a new extractor to retrieve the collection items as a playlist. Information on the Collections API can be found [here.](https://dev.twitch.tv/docs/v5/reference/collections)  
