### PR TITLE
Strip surrounding whitespace in filenames

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -509,7 +509,7 @@ def sanitize_filename(s, restricted=False, is_id=False):
     if not is_id:
         while '__' in result:
             result = result.replace('__', '_')
-        result = result.strip('_')
+        result = result.strip(' _')
         # Common case of "Foreign band name - English song title"
         if restricted and result.startswith('-_'):
             result = result[2:]


### PR DESCRIPTION
Such spaces are annoying enough to deal with, and break external downloaders trying to be smart (such as aria2c).
Fixes #20312.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As explained in #20312, `aria2c` tries to be smart and strips surrounding spaces from filenames.
Moreover, having leading spaces in filenames isn't great in general, so it would fit the general
theme of `sanitize_filename` to add it to the list of banned characters.

Creating this pull request to make fixing this bug as easy to solve as possible, since it seems this
bothers no one else.
