### PR TITLE
[Soundcloud] Added -original quality thumbnail (Fixes #20554)

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -221,9 +221,9 @@ class SoundcloudIE(InfoExtractor):
         if isinstance(thumbnail, compat_str):
             thumbnail = thumbnail.replace('-large', '-original')
             thumbnails.append({
-                    'url': thumbnail.replace('-original', '-t500x500'),
-                    'width': 500,
-                    'height': 500
+                'url': thumbnail.replace('-original', '-t500x500'),
+                'width': 500,
+                'height': 500
             })
             thumbnails.append({'url': thumbnail})
         username = try_get(info, lambda x: x['user']['username'], compat_str)

--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -217,8 +217,15 @@ class SoundcloudIE(InfoExtractor):
         if quiet:
             self.report_extraction(name)
         thumbnail = info.get('artwork_url') or info.get('user', {}).get('avatar_url')
+        thumbnails = []
         if isinstance(thumbnail, compat_str):
-            thumbnail = thumbnail.replace('-large', '-t500x500')
+            thumbnail = thumbnail.replace('-large', '-original')
+            thumbnails.append({
+                    'url': thumbnail.replace('-original', '-t500x500'),
+                    'width': 500,
+                    'height': 500
+            })
+            thumbnails.append({'url': thumbnail})
         username = try_get(info, lambda x: x['user']['username'], compat_str)
 
         def extract_count(key):
@@ -231,6 +238,7 @@ class SoundcloudIE(InfoExtractor):
             'title': title,
             'description': info.get('description'),
             'thumbnail': thumbnail,
+            'thumbnails': thumbnails,
             'duration': int_or_none(info.get('duration'), 1000),
             'webpage_url': info.get('permalink_url'),
             'license': info.get('license'),


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes #20554

Added -original quality thumbnails to the soundcloud extractor

The —write-thumbnails and —list-thumbnails options will now give both -t500x500 and -original quality thumbnails

—write-thumbnail will still give -t500x500 thumbnails as it did before since the dimensions of the original quality thumbnail image is not fixed