### PR TITLE
Handle multiple Content-Type headers

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2272,7 +2272,7 @@ class GenericIE(InfoExtractor):
 
         # Check for direct link to a video
         content_type = head_response.headers.get('Content-Type', '').lower()
-        m = re.match(r'^(?P<type>audio|video|application(?=/(?:ogg$|(?:vnd\.apple\.|x-)?mpegurl)))/(?P<format_id>[^;\s]+)', content_type)
+        m = re.match(r'^(?P<type>audio|video|application(?=/(?:ogg$|(?:vnd\.apple\.|x-)?mpegurl)))/(?P<format_id>[^;\s,]+)', content_type)
         if m:
             format_id = compat_str(m.group('format_id'))
             if format_id.endswith('mpegurl'):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Akami seems to add multiple Content-Type headers in a HEAD request, see below:

```bash
# curl -I "http://api.new.livestream.com/accounts/27755193/events/8462344/live.m3u8"
HTTP/1.1 302 Found
Server: openresty
Content-Type: text/plain; charset=utf-8
Content-Length: 25
X-Powered-By: Express
X-LS-Infinite-Cache: 1
Location: http://playback2.akamaized.net/streams/27755193_8462344_lsid2g8kf69x57y4jz3_1/master.m3u8?dw=32&hdnts=exp=1555236983~acl=/streams/27755193_8462344_lsid2g8kf69x57y4jz3_1/master.m3u8*~hmac=8daade1a9c06a41c1ffcdf5acfa72fa19cf91e2d2a6256c3bbe1f8bc97a00562
Cache-Control: max-age=0
Date: Sun, 14 Apr 2019 10:06:48 GMT
Connection: keep-alive
X-Served-By: cache-jfk8131-JFK, cache-ams21044-AMS
X-Cache: HIT, MISS, MISS
X-Cache-Hits: 0, 0
X-Timer: S1555236409.599329,VS0,VE96
Vary: Accept
Age: 0
Via: 1.1 varnish
Accept-Ranges: bytes

(follow redirect) 

# curl -I "http://playback2.akamaized.net/streams/27755193_8462344_lsid2g8kf69x57y4jz3_1/master.m3u8?dw=32&hdnts=exp=1555236983~acl=/streams/27755193_8462344_lsid2g8kf69x57y4jz3_1/master.m3u8*~hmac=8daade1a9c06a41c1ffcdf5acfa72fa19cf91e2d2a6256c3bbe1f8bc97a00562"
HTTP/1.1 200 OK
Cache-Control: max-age=30
Expires: Sun, 14 Apr 2019 10:07:36 GMT
Date: Sun, 14 Apr 2019 10:07:06 GMT
Connection: keep-alive
Content-Type: application/x-mpegURL # <- 1st Content-Type
X-VIM-CACHEBC: EP:H11,E:h,TD1:r
Aka-c-hit: cache-hit
Akamai-Mon-Iucid-Del: 823334
Content-Type: application/x-mpegURL # <- 2nd Content-Type
Set-Cookie: abcde=exp=1555322826~acl=%2f*~data=hdntl~hmac=94e25d5a2d5d1638b0a7cdfc7c3f3d9d4394c169b3798fa63bd93c9b11479e6d; Domain=playback2.akamaized.net; Path=/; Expires=Mon, 15-Apr-2019 10:07:03 GMT
Access-Control-Max-Age: 86400
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: Server,range,hdntl,hdnts,Akamai-Mon-Iucid-Ing,Akamai-Mon-Iucid-Del
Access-Control-Allow-Headers: origin,range,hdntl,hdnts
Access-Control-Allow-Methods: GET,POST,OPTIONS
Access-Control-Allow-Origin: https://livestream.com
```

Python requests causes a `headers.get('Content-Type')` to return it as `application/x-mpegURL, application/x-mpegURL`, and the header-regex uses a `\s` or a `;` as a seperator, but not a `,`, therefore the `format_id` is extracted as `x-mpegURL,` (note the comma). This causes it to skip the `_extract_m3u8_formats` function.

This PR fixes this and adds a comma as separator.