### PR TITLE
[BYUtv] Add support for akamai VODs (addresses #20574)

### DIFF
--- a/youtube_dl/extractor/byutv.py
+++ b/youtube_dl/extractor/byutv.py
@@ -4,7 +4,6 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
-    ExtractorError,
     url_basename,
     parse_duration,
 )
@@ -75,7 +74,6 @@ class BYUtvIE(InfoExtractor):
                 'thumbnail': ep.get('imageThumbnail'),
             }
         else:
-            info = {}
             ep = info['dvr']
             formats = self._extract_m3u8_formats(
                 ep['videoUrl'], video_id, 'mp4', entry_protocol='m3u8_native'
@@ -88,5 +86,5 @@ class BYUtvIE(InfoExtractor):
                 'title': ep['title'],
                 'description': ep.get('description'),
                 'thumbnail': ep.get('imageThumbnail'),
-                'duration': parse_duration(ep.get('length'))
+                'duration': parse_duration(ep.get('length')),
             }

--- a/youtube_dl/extractor/byutv.py
+++ b/youtube_dl/extractor/byutv.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
+from ..utils import url_basename
 
 
 class BYUtvIE(InfoExtractor):
@@ -23,6 +24,27 @@ class BYUtvIE(InfoExtractor):
         },
         'add_ie': ['Ooyala'],
     }, {
+        'url': 'https://www.byutv.org/player/a5467e14-c7f2-46f9-b3c2-cb31a56749c6/byu-soccer-w-argentina-vs-byu-4419',
+        'info_dict': {
+            'id': 'a5467e14-c7f2-46f9-b3c2-cb31a56749c6',
+            'display_id': 'byu-soccer-w-argentina-vs-byu-4419',
+            'ext': 'mp4',
+            'title': 'Argentina vs. BYU (4/4/19)',
+            'length': '02:05:43',
+        },
+    }, {
+        'url': 'https://www.byutv.org/player/a5467e14-c7f2-46f9-b3c2-cb31a56749c6/byu-soccer-w-argentina-vs-byu-4419',
+        'info_dict': {
+            'id': 'a5467e14-c7f2-46f9-b3c2-cb31a56749c6',
+            'display_id': 'byu-soccer-w-argentina-vs-byu-4419',
+            'ext': 'mp4',
+            'title': 'Argentina vs. BYU (4/4/19)',
+            'length': '02:05:43',
+        },
+        'params': {
+            'skip_download': True
+        },
+    }, {
         'url': 'http://www.byutv.org/watch/6587b9a3-89d2-42a6-a7f7-fd2f81840a7d',
         'only_matching': True,
     }, {
@@ -33,9 +55,8 @@ class BYUtvIE(InfoExtractor):
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
         video_id = mobj.group('id')
-        display_id = mobj.group('display_id') or video_id
 
-        ep = self._download_json(
+        info = self._download_json(
             'https://api.byutv.org/api3/catalog/getvideosforcontent', video_id,
             query={
                 'contentid': video_id,
@@ -44,15 +65,31 @@ class BYUtvIE(InfoExtractor):
             }, headers={
                 'x-byutv-context': 'web$US',
                 'x-byutv-platformkey': 'xsaaw9c7y5',
-            })['ooyalaVOD']
+            })
 
-        return {
-            '_type': 'url_transparent',
-            'ie_key': 'Ooyala',
-            'url': 'ooyala:%s' % ep['providerId'],
-            'id': video_id,
-            'display_id': display_id,
-            'title': ep.get('title'),
-            'description': ep.get('description'),
-            'thumbnail': ep.get('imageThumbnail'),
-        }
+        if 'ooyalaVOD' in info:
+            ep = info['ooyalaVOD']
+            return {
+                '_type': 'url_transparent',
+                'ie_key': 'Ooyala',
+                'url': 'ooyala:%s' % ep['providerId'],
+                'id': video_id,
+                'display_id': mobj.group('display_id') or video_id,
+                'title': ep.get('title'),
+                'description': ep.get('description'),
+                'thumbnail': ep.get('imageThumbnail'),
+            }
+        elif 'dvr' in info:
+            ep = info['dvr']
+            formats = self._extract_m3u8_formats(
+                ep['videoUrl'], video_id, 'mp4', entry_protocol='m3u8_native'
+            )
+            return {
+                'formats': formats,
+                'id': video_id,
+                'display_id': url_basename(url),
+                'title': ep.get('title'),
+                'description': ep.get('description'),
+                'thumbnail': ep.get('imageThumbnail'),
+                'length': ep.get('length'),
+            }

--- a/youtube_dl/extractor/byutv.py
+++ b/youtube_dl/extractor/byutv.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
-from ..utils import url_basename
+from ..utils import (
+    ExtractorError,
+    url_basename,
+)
 
 
 class BYUtvIE(InfoExtractor):
@@ -30,16 +33,6 @@ class BYUtvIE(InfoExtractor):
             'display_id': 'byu-soccer-w-argentina-vs-byu-4419',
             'ext': 'mp4',
             'title': 'Argentina vs. BYU (4/4/19)',
-            'length': '02:05:43',
-        },
-    }, {
-        'url': 'https://www.byutv.org/player/a5467e14-c7f2-46f9-b3c2-cb31a56749c6/byu-soccer-w-argentina-vs-byu-4419',
-        'info_dict': {
-            'id': 'a5467e14-c7f2-46f9-b3c2-cb31a56749c6',
-            'display_id': 'byu-soccer-w-argentina-vs-byu-4419',
-            'ext': 'mp4',
-            'title': 'Argentina vs. BYU (4/4/19)',
-            'length': '02:05:43',
         },
         'params': {
             'skip_download': True
@@ -67,7 +60,7 @@ class BYUtvIE(InfoExtractor):
                 'x-byutv-platformkey': 'xsaaw9c7y5',
             })
 
-        if 'ooyalaVOD' in info:
+        if info.get('ooyalaVOD'):
             ep = info['ooyalaVOD']
             return {
                 '_type': 'url_transparent',
@@ -75,11 +68,11 @@ class BYUtvIE(InfoExtractor):
                 'url': 'ooyala:%s' % ep['providerId'],
                 'id': video_id,
                 'display_id': mobj.group('display_id') or video_id,
-                'title': ep.get('title'),
+                'title': ep['title'],
                 'description': ep.get('description'),
                 'thumbnail': ep.get('imageThumbnail'),
             }
-        elif 'dvr' in info:
+        elif info.get('dvr'):
             ep = info['dvr']
             formats = self._extract_m3u8_formats(
                 ep['videoUrl'], video_id, 'mp4', entry_protocol='m3u8_native'
@@ -88,8 +81,9 @@ class BYUtvIE(InfoExtractor):
                 'formats': formats,
                 'id': video_id,
                 'display_id': url_basename(url),
-                'title': ep.get('title'),
+                'title': ep['title'],
                 'description': ep.get('description'),
                 'thumbnail': ep.get('imageThumbnail'),
-                'length': ep.get('length'),
             }
+        else:
+            raise ExtractorError('Unrecognized VOD type.')

--- a/youtube_dl/extractor/byutv.py
+++ b/youtube_dl/extractor/byutv.py
@@ -6,6 +6,7 @@ from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
     url_basename,
+    parse_duration,
 )
 
 
@@ -33,6 +34,7 @@ class BYUtvIE(InfoExtractor):
             'display_id': 'byu-soccer-w-argentina-vs-byu-4419',
             'ext': 'mp4',
             'title': 'Argentina vs. BYU (4/4/19)',
+            'duration': 7543.0,
         },
         'params': {
             'skip_download': True
@@ -60,23 +62,25 @@ class BYUtvIE(InfoExtractor):
                 'x-byutv-platformkey': 'xsaaw9c7y5',
             })
 
-        if info.get('ooyalaVOD'):
-            ep = info['ooyalaVOD']
+        ep = info.get('ooyalaVOD')
+        if ep:
             return {
                 '_type': 'url_transparent',
                 'ie_key': 'Ooyala',
                 'url': 'ooyala:%s' % ep['providerId'],
                 'id': video_id,
                 'display_id': mobj.group('display_id') or video_id,
-                'title': ep['title'],
+                'title': ep.get('title'),
                 'description': ep.get('description'),
                 'thumbnail': ep.get('imageThumbnail'),
             }
-        elif info.get('dvr'):
+        else:
+            info = {}
             ep = info['dvr']
             formats = self._extract_m3u8_formats(
                 ep['videoUrl'], video_id, 'mp4', entry_protocol='m3u8_native'
             )
+            self._sort_formats(formats)
             return {
                 'formats': formats,
                 'id': video_id,
@@ -84,6 +88,5 @@ class BYUtvIE(InfoExtractor):
                 'title': ep['title'],
                 'description': ep.get('description'),
                 'thumbnail': ep.get('imageThumbnail'),
+                'duration': parse_duration(ep.get('length'))
             }
-        else:
-            raise ExtractorError('Unrecognized VOD type.')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some byutv URLs [(example)](https://www.byutv.org/player/a5467e14-c7f2-46f9-b3c2-cb31a56749c6/byu-soccer-w-argentina-vs-byu-4419) were throwing an extractor/key error. Previously, the byutv extractor would use the ooyala extractor, but it seems like some newer videos on the site are using akamai. For ooyala videos, the API reponse looks like `{'ooyalaVOD': {...}}`, while for akamai videos, the format is `{'dvr':{...}}`. I didn't want to mess with the current functionality, so videos using ooyala still use the extractor as before, but for akamai dvr VODs I used the m3u8 URL for extraction. 
