### PR TITLE
[NiconicoPlaylist] Add new extractor

### DIFF
--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -454,6 +454,7 @@ class NiconicoPlaylistIE(InfoExtractor):
             'title': 'Private_Mylist_Test',
         },
         'playlist_mincount': 2,
+        'skip': 'Requires an account',
     }]
 
     #  Add support for private mylist access by owner via log-in

--- a/youtube_dl/extractor/niconico.py
+++ b/youtube_dl/extractor/niconico.py
@@ -438,15 +438,27 @@ class NiconicoIE(InfoExtractor):
 
 class NiconicoPlaylistIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?nicovideo\.jp/mylist/(?P<id>\d+)'
+    _NETRC_MACHINE = 'niconico'
 
-    _TEST = {
+    _TESTS = [{
         'url': 'http://www.nicovideo.jp/mylist/27411728',
         'info_dict': {
             'id': '27411728',
             'title': 'AKB48のオールナイトニッポン',
         },
         'playlist_mincount': 225,
-    }
+    }, {
+        'url': 'https://www.nicovideo.jp/mylist/64988008',
+        'info_dict': {
+            'id': '64988008',
+            'title': 'Private_Mylist_Test',
+        },
+        'playlist_mincount': 2,
+    }]
+
+    #  Add support for private mylist access by owner via log-in
+    def _real_initialize(self):
+        NiconicoIE._login(self)
 
     def _real_extract(self, url):
         list_id = self._match_id(url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This improvement to the NiconicoPlaylist extractor allows for the extraction of private Niconico mylists (playlists) if they are owned by the account which is logged in. This commit only adds calls the preexisting login method in the NiconicoIE, the netrc association, and a test case (skipped due to login requirement). 

As this is my first pull request in GitHub, please highlight any mistakes which I have made, so that I may rectify them. 
