### PR TITLE
patch missing `token` on youtube

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1678,8 +1678,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             raise ExtractorError(
                 'YouTube said: %s' % unavailable_message, expected=True, video_id=video_id)
 
-        if 'token' not in video_info:
-            if 'reason' in video_info:
+        # patch in the token if it is elsewhere
+        if not video_info.get('token'):
+          video_info['token'] = video_info.get('account_playback_token')
+
+        if not video_info.get('token'):
+            if video_info.get('reason'):
                 if 'The uploader has not made this video available in your country.' in video_info['reason']:
                     regions_allowed = self._html_search_meta(
                         'regionsAllowed', video_webpage, default=None)
@@ -1687,7 +1691,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     self.raise_geo_restricted(
                         msg=video_info['reason'][0], countries=countries)
                 reason = video_info['reason'][0]
-                if 'Invalid parameters' in reason:
+                if reason.get('Invalid parameters'):
                     unavailable_message = extract_unavailable_message()
                     if unavailable_message:
                         reason = unavailable_message


### PR DESCRIPTION

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes #20758, building on @sandsmark 's patch.
