### PR TITLE
[youtube]fix for token not in video infor 

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1679,7 +1679,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 'YouTube said: %s' % unavailable_message, expected=True, video_id=video_id)
         if 'token' not in video_info:
             if 'account_playback_token' in video_info:
-            video_info['token'] = video_info['account_playback_token']
+                video_info['token'] = video_info['account_playback_token']
             elif 'reason' in video_info:
                 if 'The uploader has not made this video available in your country.' in video_info['reason']:
                     regions_allowed = self._html_search_meta(

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1677,9 +1677,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 unavailable_message = 'Unable to extract video data'
             raise ExtractorError(
                 'YouTube said: %s' % unavailable_message, expected=True, video_id=video_id)
-
         if 'token' not in video_info:
-            if 'reason' in video_info:
+            if 'account_playback_token' in video_info:
+            video_info['token'] = video_info['account_playback_token']
+            elif 'reason' in video_info:
                 if 'The uploader has not made this video available in your country.' in video_info['reason']:
                     regions_allowed = self._html_search_meta(
                         'regionsAllowed', video_webpage, default=None)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

There is an urgent change of youtube that they change token parameter to account_playback_token, so youtube-dl can not parse the result correctly. There are some issues about this problem 
Fixes #20761 #20764 #20766 #20767 #20768 #20769 
