### PR TITLE
Dump video list only

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -925,6 +925,11 @@ class YoutubeDL(object):
 
             ie_entries = ie_result['entries']
 
+            if self.params.get("dump_video_list_only", False):
+                # ie_entries is a generator, so it depletes when we iterate through it and no videos remain for download
+                for entry in ie_entries:
+                    print(entry)
+
             def make_playlistitems_entries(list_ie_entries):
                 num_entries = len(list_ie_entries)
                 return [

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -335,6 +335,7 @@ def _real_main(argv=None):
         'forceformat': opts.getformat,
         'forcejson': opts.dumpjson or opts.print_json,
         'dump_single_json': opts.dump_single_json,
+        'dump_video_list_only': opts.dump_video_list_only,
         'simulate': opts.simulate or any_getting,
         'skip_download': opts.skip_download,
         'format': opts.format,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -603,6 +603,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='getid', default=False,
         help='Simulate, quiet but print id')
     verbosity.add_option(
+        '--dump-video-list-only',
+        action='store_true', dest='dump_video_list_only', default=False,
+        help='Just dump the list of videos in a channel/playlist and do not perform other requests. Use together with -i and -q to obtain parseable JSON Lines format.')
+    verbosity.add_option(
         '--get-thumbnail',
         action='store_true', dest='getthumbnail', default=False,
         help='Simulate, quiet but print thumbnail URL')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Youtube-dl's capabilities of retrieving all the videos from a YouTube channel or playlist are excellent, but for very large channels (15k videos), scraping the channel with full downloads on one machine leads to problems, so we would like to distribute the download across multiple machines at various sites. For this, we simply need a list of all the videos in a channel or a playlist. Superficially, the current feature --get-id does this, but in fact it runs the full simulation with lots of requests, which makes it slow and again bears the risk of having the machine banned.
The new option --dump-video-list-only dumps the video list and is best used with -i and -q so the output is a parseable JSON Lines file. To this end, it simply goes through the ie_entries generator and prints every item from it. This has the effect of emptying the generator so that no further requests are done because the video list for processing is 0 elements long. 
