### PR TITLE
Add official docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,5 +47,5 @@ RUN apk update && \
     rm -rf /var/cache/apk/*
 # Copy init script, set workdir & entrypoint
 COPY init /init
-WORKDIR /home/dockeruser
+WORKDIR /workdir
 ENTRYPOINT ["/init"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# Builder container for pandoc, prerequisite for building youtube-dl
+# (so build environment isn't in final container, to save space)
 FROM alpine:3.9 as builder_pandoc
 RUN apk update && \
     apk add cabal \ 
@@ -8,6 +10,8 @@ RUN apk update && \
     cabal update && \
     cabal install --upgrade-dependencies --enable-per-component -j --force-reinstalls pandoc
 
+# Builder container for youtube-dl
+# (so build environment isn't in final container, to save space)
 FROM alpine:3.9 as builder_ytdl
 COPY --from=builder_pandoc /root/.cabal /root/.cabal
 RUN apk update && \
@@ -26,9 +30,12 @@ RUN apk update && \
     make -j && \
     make install
 
+# Final container
 FROM alpine:3.9 as final
+# Copy youtube-dl binary and manpage into container from builder container
 COPY --from=builder_ytdl /usr/local/bin/youtube-dl /usr/local/bin/youtube-dl
 COPY --from=builder_ytdl /usr/local/man/man1/youtube-dl.1 /usr/local/man/man1/youtube-dl.1
+# Install & configure prerequisites for youtube-dl
 RUN apk update && \
     apk add ffmpeg \
             rtmpdump \
@@ -38,8 +45,7 @@ RUN apk update && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     youtube-dl --version && \
     rm -rf /var/cache/apk/*
-
+# Copy init script, set workdir & entrypoint
 COPY init /init
 WORKDIR /home/dockeruser
 ENTRYPOINT ["/init"]
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,16 +35,17 @@ FROM alpine:3.9 as final
 # Copy youtube-dl binary and manpage into container from builder container
 COPY --from=builder_ytdl /usr/local/bin/youtube-dl /usr/local/bin/youtube-dl
 COPY --from=builder_ytdl /usr/local/man/man1/youtube-dl.1 /usr/local/man/man1/youtube-dl.1
-# Install & configure prerequisites for youtube-dl
+# Install & configure s6 overlay, then prerequisites for youtube-dl
 RUN apk update && \
     apk add ffmpeg \
             rtmpdump \
             mplayer \
             mpv \
-            python3 && \
+            python3 \
+            bash && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     youtube-dl --version && \
-    rm -rf /var/cache/apk/*
+    rm -rf /var/cache/apk/* /tmp/*
 # Copy init script, set workdir & entrypoint
 COPY init /init
 WORKDIR /workdir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:3.9 as builder_pandoc
+RUN apk update && \
+    apk add cabal \ 
+            zlib-dev \
+            wget \
+            ghc \
+            musl-dev && \
+    cabal update && \
+    cabal install --upgrade-dependencies --enable-per-component -j --force-reinstalls pandoc
+
+FROM alpine:3.9 as builder_ytdl
+COPY --from=builder_pandoc /root/.cabal /root/.cabal
+RUN apk update && \
+    apk add ffmpeg \
+            rtmpdump \
+            mplayer \
+            mpv \
+            python3 \
+            git \
+            make \
+            zip && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    ln -s /root/.cabal/bin/pandoc /usr/local/bin/pandoc && \
+    git clone https://github.com/ytdl-org/youtube-dl.git && \
+    cd /youtube-dl && \
+    make -j && \
+    make install
+
+FROM alpine:3.9 as final
+COPY --from=builder_ytdl /usr/local/bin/youtube-dl /usr/local/bin/youtube-dl
+COPY --from=builder_ytdl /usr/local/man/man1/youtube-dl.1 /usr/local/man/man1/youtube-dl.1
+RUN apk update && \
+    apk add ffmpeg \
+            rtmpdump \
+            mplayer \
+            mpv \
+            python3 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    youtube-dl --version && \
+    rm -rf /var/cache/apk/*
+
+COPY init /init
+WORKDIR /home/dockeruser
+ENTRYPOINT ["/init"]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,7 +104,7 @@ docker run \
     :ytsubscriptions \
     --dateafter now-5days \
     --download-archive /workdir/.youtube-dl-archive \
-    --cookies /workdir/cookiejar.dat \
+    --cookies /workdir/.youtube-dl-cookiejar \
     --netrc \
     --limit-rate 5000 2>> /path/to/logs/youtube-dl.err >> /path/to/logs/youtube-dl.log
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,186 @@
+## youtube-dl
+youtube-dl - download videos from youtube.com or other video platforms
+
+## Quick Start
+**NOTE**: The docker command provided in this quick start is given as an example, and parameters should be adjusted to your needs.
+
+It is suggested to configure an alias as follows (and place into your `.bash_aliases` file):
+
+```
+alias youtube-dl='docker run \
+                  --rm -i \
+                  -e PGID=$(id -g) \
+                  -e PUID=$(id -u) \
+                  -v $(pwd):/workdir:rw \
+                  ytdl-org/youtube-dl'
+```
+
+When run (eg: `youtube-dl https://www.youtube.com/watch?v=dQw4w9WgXcQ`), it will download the video to the current working directory, and take any command line arguments that the normal youtube-dl binary would.
+
+## Using a config file
+
+To prevent having to specify many command line arguments every time you run youtube-dl, you may wish to have an external configuation file.
+
+In order for the docker container to use the configuration file, it must be mapped through to the container.
+
+```
+docker run \
+    --rm -i \
+    -e PGID=$(id -g) \
+    -e PUID=$(id -u) \
+    -v /path/to/downloaded/videos:/workdir:rw \
+    -v /path/to/youtube-dl.conf:/etc/youtube-dl.conf:ro \
+    ytdl-org/youtube-dl
+```
+
+Where:
+* `/path/to/downloaded/videos` is where youtube-dl will download videos to (use `$(pwd)` to downloade to current working directory.
+* `/path/to/youtube-dl.conf` is the path to your youtube-dl.conf file.
+
+## Environment Variables
+
+To customize some properties of the container, the following environment variables can be passed via the `-e` parameter (one for each variable). This paramater has the format `<VARIABLE_NAME>=<VALUE>`.
+
+| Variable | Description | Recommended Setting |
+|----------|-------------|---------------------|
+| PGID     | The Group ID that the `youtube-dl` process will run as | `$(id -u)` for the current user's GID |
+| PUID     | The User ID that the `youtube-dl` process will run as | `$(id -g)` for the current user's UID |
+
+## Authentication using .netrc
+
+If you want to download videos that require authentication (or your youtube subscriptions for example, see below), it is recommended to use a .netrc file.
+
+You can create a file with the following syntax:
+
+```
+machine youtube login USERNAME password PASSWORD
+```
+
+Where:
+* `USERNAME` is replaced with your youtube account username
+* `PASSWORD` is replaced with your youtube account password
+
+You may need to disable some account security settings (such as '2-Step Verification' and 'Use your phone to sign in', so it is suggested to make a long, complex password (eg: 32 random characters).
+
+This file can then be mapped through to the container as a .netrc file, eg:
+
+```
+docker run \
+    --rm -i \
+    -e PGID=$(id -g) \
+    -e PUID=$(id -u) \
+    -v /path/to/downloaded/videos:/workdir:rw \
+    -v /path/to/youtube-dl.conf:/etc/youtube-dl.conf:ro \
+    -v /path/to/netrc_file:/home/dockeruser/.netrc:ro
+    ytdl-org/youtube-dl
+```
+
+## Data Volumes
+
+There are no data volumes explicity set in the Dockerfile, however:
+
+| Container Path | Permissions | Description |
+|----------------|-------------|-------------|
+| `/workdir` | rw | The `youtube-dl` process is executed with a working directory of `/workdir`. Thus, unless you override the output directory with the `--output` argument on the command line or via a configuration file, videos will end up in this directory. |
+| `/etc/youtube-dl.conf` | ro | The `youtube-dl` process will look in this location for a configuration file by default. |
+| `/home/dockeruser/.netrc` | ro | The `youtube-dl` process will look in this location for a .netrc file (if `--netrc` is specified on the command line or via a configuration file). |
+
+## Scheduled download of youtube subscriptions
+
+In order to perform a scheduled download of youtube subscriptions, it is recommended to use the following command to be executed via cron on a regular basis (eg: daily).
+
+```
+docker run \
+    --rm 
+    -i 
+    --name youtube-dl-cron 
+    -e PGID=GID 
+    -e PUID=UID
+    --cpus CPUS 
+    -v /path/to/netrc:/home/dockeruser/.netrc:ro 
+    -v /path/to/youtube/subscriptions:/workdir:rw
+    -v /path/to/youtube-dl.conf:/etc/youtube-dl.conf:ro 
+    mikenye/youtube-dl \
+    :ytsubscriptions \
+    --dateafter now-5days \
+    --download-archive /workdir/.youtube-dl-archive \
+    --cookies /workdir/cookiejar.dat \
+    --netrc \
+    --limit-rate 5000 2>> /path/to/logs/youtube-dl.err >> /path/to/logs/youtube-dl.log
+```
+
+Where:
+* `GID`: a group ID to run as (if in a normal user's crontab, use `$(id -g)`
+* `UID`: a user ID to run as (if in a normal user's crontab, use `$(id -u)`
+* `CPUS`: the number of CPUs to constrain the docker container to. This may be required to prevent impacting system performance if transcoding takes place. If not, the `--cpus` argument can be completely omitted.
+* `/path/to/netrc`: the path to the file containing your youtube credentials, see above.
+* `/path/to/youtube/subscriptions`: the path where videos will be saved.
+* `/path/to/youtube-dl.conf`: the path to your `youtube-dl.conf` file, where settings such as output file naming, quality, etc can be determined.
+* `/path/to/logs/youtube-dl.err`: the path to the error log, if desired
+* `/path/to/logs/youtube-dl.log`: the path to the application log, if desired
+
+Notes:
+* `--rm` is given so the container is destroyed when execution is finished. This will prevent your drive from slowly filling up with exited containers.
+* `--name youtube-dl-cron` is given so that multiple instances are not started by cron. In the event the previous container is still running, docker will simply exit with an error that the container name is already taken.
+* `--dateafter now-5days` is given to limit youtube-dl to only download recent videos. Feel free to adjust as required.
+* `--limit-rate` is given to prevent impacting your internet connection. Feel free to adjust as required.
+
+In the example above, a configuration file is used. This allows us to easily add commands to select a specific quality, and name the videos with a specific format. For example, to download the videos into a format recognised by Plex, you could use the following:
+
+```
+-v
+--ignore-errors
+--no-overwrites
+--continue
+--no-post-overwrites
+--add-metadata
+--write-thumbnail
+--playlist-reverse
+--write-description
+--write-info-json
+--write-annotations
+--format "best[height<=?1080]"
+--fixup fix
+--output '/workdir/%(uploader)s/%(uploader)s - %(upload_date)s - %(title)s - %(id)s.%(ext)s'
+```
+
+The above example config file will:
+* Ignore errors
+* Will not overwrite existing videos
+* Will continue downloading in the event a download is interrupted
+* Will download metadata and embed into the resulting video, so that Plex will be able to display this information
+* Will download oldest videos first, so videos can be sorted by "date added" in Plex
+* Will download the best quality up to a maximum of 1080p (prevent 4K downloads)
+* Will format videos with a separate folder for each uploader.
+
+## Ports
+
+No port mappings are required for this container.
+
+## Docker Image Update
+
+If the system on which the container runs doesn't provide a way to easily update the Docker image (eg: watchtower), simply pull the latest version of the container:
+
+```
+docker pull ytdl-org/youtube-dl
+````
+
+## Shell access
+
+To get shell access to a running container, execute the following command:
+
+```
+docker exec -ti CONTAINER sh 
+```
+
+Where `CONTAINER` is the name of the running container.
+
+To start a container with a shell (instead of `youtube-dl`), execute the following command:
+
+```
+docker run --rm -ti --entrypoint=/bin/sh ytdl-org/youtube-dl
+```
+
+## Support or Contact
+
+Having troubles with the container or have questions? Please create a new issue on our github.

--- a/docker/build_and_push.sh
+++ b/docker/build_and_push.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -x
+
+# Build "latest"
+docker build . -t ytdl-org/youtube-dl:latest 
+build_exit=$?
+
+
+# Get version of latest container
+# Repeat as running straight after the build can give a 'bad interpreter: Text file busy' error
+n=0
+until [ $n -ge 5 ]
+do
+    build_version=$(docker run --rm -ti ytdl-org/youtube-dl --version) 
+    if [ $? -eq 0 ]; then
+        build_version=$(echo $build_version | sed 's/\r$//')
+        break
+    fi
+    n=$[$n+1]
+    sleep 15
+done
+if [ $n -ge 5 ]; then
+    echo "Failed when trying to get youtube-dl version in latest container :("
+    exit 1
+fi
+
+# If the build was successful, then we can tag with current version
+if [ $build_exit -eq 0 ]; then
+    docker tag ytdl-org/youtube-dl:latest ytdl-org/youtube-dl:$build_version
+    tag_exit=$?
+fi
+
+if [ $build_exit -eq 0 ]; then
+    if [ $tag_exit -eq 0 ]; then
+        # If building and tagging was successful, then push
+        docker push ytdl-org/youtube-dl:latest
+        docker push ytdl-org/youtube-dl:$build_version
+        exit 0
+    fi
+fi
+
+echo "Something went wrong..."
+exit 1

--- a/docker/init
+++ b/docker/init
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Create dockeruser user/group
+addgroup -g $PGID dockeruser
+adduser -D -u $PUID -G dockeruser -h /home/dockeruser dockeruser
+chown $PUID:$PGID /home/dockeruser
+
+# Change ownership of youtube-dl and set sticky bit so youtube-dl runs as dockeruser (rootless operation)
+chown $PUID:$PGID `which youtube-dl`
+chmod u+s,g+s `which youtube-dl`
+
+# Ensure .netrc has correct permissions (if present)
+chown root:root /root/.netrc
+
+# Run youtube-dl with remainder of command line arguments
+youtube-dl $@

--- a/docker/init
+++ b/docker/init
@@ -1,16 +1,17 @@
-#!/bin/sh
+#!/bin/bash
+
+export YOUTUBEDLARGS=$@
+
+YOUTUBEDLPGID=${PGID:-1000}
+YOUTUBEDLPUID=${PUID:-1000}
 
 # Create dockeruser user/group
-addgroup -g $PGID dockeruser
-adduser -D -u $PUID -G dockeruser -h /home/dockeruser dockeruser
-chown $PUID:$PGID /home/dockeruser
-
-# Change ownership of youtube-dl and set sticky bit so youtube-dl runs as dockeruser (rootless operation)
-chown $PUID:$PGID `which youtube-dl`
-chmod u+s,g+s `which youtube-dl`
-
-# Ensure .netrc has correct permissions (if present)
-chown root:root /root/.netrc
+addgroup -g $YOUTUBEDLPGID dockeruser
+adduser -D -u $YOUTUBEDLPUID -G dockeruser -h /home/dockeruser dockeruser
+chown $YOUTUBEDLPUID:$YOUTUBEDLPGID /home/dockeruser
+export HOME=/home/dockeruser
 
 # Run youtube-dl with remainder of command line arguments
-youtube-dl $@
+su -m dockeruser <<'EOF'
+youtube-dl $YOUTUBEDLARGS
+EOF


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X] New feature

---

### Description of your *pull request* and other information

Add an official docker image. This has been discussed in several existing pull requests, most notably #11632. The comments before closure of the previous pull request indicate that the Dockerfile should live in this repository. Accordingly, I have added this, plus documentation on how best to utilise the the container.

Furthermore, there is a simple shell script that can be used to build, tag and push the docker image up to hub.docker.com. Alternatively, hub.docker's automated build process can be configured to automatically re-build the "latest" tagged container when this repository is updated. However, the script allows past versions of youtube-dl to be pushed to hub.docker with the youtube-dl version as the tag (which is likely worth doing). There is probably a way to automate this, however without access as a contributor I can't do much more than this.

The docker container attempts to ahere to good practices:

- youtube-dl is not run as root. The user can specify the UID/GID that youtube-dl is run as, or if omitted it will run as 1000:1000.

- It  allows the user to supply a youtube-dl.conf file, a .netrc file, work with cookies and a download-archive.

- User can set up an alias for youtube-dl that instantiates the container and see no functional difference in operation.

During the build process, the docker container builds youtube-dl from scratch - pre-built binaries are not used. If the build script is used, the following is performed:

1. Image is built with the :latest tag
2. Upon successful build, the version of youtube-dl is obtained from the freshly built image. This version is used to create a version of the image that is tagged with youtube-dl's version instead of the :latest tag.
3. Upon success of the above two items, the script will attempt to push both the :latest and :version tagged images to hub.docker (which fails if the user has no access, but the built images will still reside on the local system)

Container is based on Alpine Linux version 3.9 and uses a multi-build process to keep the final image size as low as possible (142MB).

I've been using youtube-dl for years and am delighted that I might be able to contribute to this project.

Thanks for your time and consideration.
