### PR TITLE
[flake8] Ignore W504 (line break after binary operator)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal = True
 
 [flake8]
 exclude = youtube_dl/extractor/__init__.py,devscripts/buildserver.py,devscripts/lazy_load_template.py,devscripts/make_issue_template.py,setup.py,build,.git,venv
-ignore = E402,E501,E731,E741
+ignore = E402,E501,W504,E731,E741


### PR DESCRIPTION
Both W504 (line break after binary operator) and W503 (line break before binary operator) were implicitly enabled, even though conceptually they are mutually exclusive.

W504 had over 100 hits, while W503 had none, so let's disable the former.