### PR TITLE
[utils] Configurable SSL cipher list

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -354,6 +354,7 @@ class YoutubeDL(object):
         self.params = {
             # Default parameters
             'nocheckcertificate': False,
+            'ciphers': None,
         }
         self.params.update(params)
         self.cache = Cache(self)

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -397,6 +397,7 @@ def _real_main(argv=None):
         'download_archive': download_archive_fn,
         'cookiefile': opts.cookiefile,
         'nocheckcertificate': opts.no_check_certificate,
+        'ciphers': opts.ciphers,
         'prefer_insecure': opts.prefer_insecure,
         'proxy': opts.proxy,
         'socket_timeout': opts.socket_timeout,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -536,6 +536,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='no_check_certificate', default=False,
         help='Suppress HTTPS certificate validation')
     workarounds.add_option(
+        '--ciphers',
+        metavar='CIPHERS', dest='ciphers',
+        help='Set SSL cipher list')
+    workarounds.add_option(
         '--prefer-insecure',
         '--prefer-unsecure', action='store_true', dest='prefer_insecure',
         help='Use an unencrypted connection to retrieve information about the video. (Currently supported only for YouTube)')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -696,8 +696,11 @@ def formatSeconds(secs):
 
 def make_HTTPS_handler(params, **kwargs):
     opts_no_check_certificate = params.get('nocheckcertificate', False)
+    opts_ciphers = params.get('ciphers')
     if hasattr(ssl, 'create_default_context'):  # Python >= 3.4 or 2.7.9
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+        if opts_ciphers:
+            context.set_ciphers(opts_ciphers)
         if opts_no_check_certificate:
             context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
@@ -716,6 +719,8 @@ def make_HTTPS_handler(params, **kwargs):
                                if opts_no_check_certificate
                                else ssl.CERT_REQUIRED)
         context.set_default_verify_paths()
+        if opts_ciphers:
+            context.set_ciphers(opts_ciphers)
         return YoutubeDLHTTPSHandler(params, context=context, **kwargs)
 
 


### PR DESCRIPTION
Allows working around the weak ciphers by setting to DEFAULT@SECLEVEL=1

Needed for ceskatelevize.cz with recent Linux distros.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

In latest Debian Linux (unstable), SSL library does not accept small Diffie-Hellman keys by default. Because of this, downloading from ceskatelevize.cz fails with the following error:

ERROR: Unable to download webpage: <urlopen error [SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1056)> (caused by URLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1056)')))

This patch allows to work around this by specifying the cipher list manually, eg. `youtube-dl --no-check-certificate --ciphers DEFAULT@SECLEVEL=1 https://www.ceskatelevize.cz/porady/11784224641-king-skate/`