### PR TITLE
[dbtv] Updated extractor according to site changes (was broken)

### DIFF
--- a/youtube_dl/extractor/dbtv.py
+++ b/youtube_dl/extractor/dbtv.py
@@ -7,50 +7,63 @@ from .common import InfoExtractor
 
 
 class DBTVIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?dbtv\.no/(?:[^/]+/)?(?P<id>[0-9]+)(?:#(?P<display_id>.+))?'
+    _VALID_URL = r'https://www\.dagbladet\.no/video/[^/]+/(?P<id>[^/]+)/?$'
     _TESTS = [{
-        'url': 'http://dbtv.no/3649835190001#Skulle_teste_ut_fornøyelsespark,_men_kollegaen_var_bare_opptatt_av_bikinikroppen',
-        'md5': '2e24f67936517b143a234b4cadf792ec',
+        'url': 'https://www.dagbladet.no/video/trailer-our-planet/hdECB3y6',
         'info_dict': {
-            'id': '3649835190001',
-            'display_id': 'Skulle_teste_ut_fornøyelsespark,_men_kollegaen_var_bare_opptatt_av_bikinikroppen',
+            'id': 'hdECB3y6',
             'ext': 'mp4',
-            'title': 'Skulle teste ut fornøyelsespark, men kollegaen var bare opptatt av bikinikroppen',
-            'description': 'md5:1504a54606c4dde3e4e61fc97aa857e0',
-            'thumbnail': r're:https?://.*\.jpg',
-            'timestamp': 1404039863,
-            'upload_date': '20140629',
-            'duration': 69.544,
-            'uploader_id': '1027729757001',
+            'title': 'Trailer: «Our Planet»',
         },
-        'add_ie': ['BrightcoveNew']
-    }, {
-        'url': 'http://dbtv.no/3649835190001',
-        'only_matching': True,
-    }, {
-        'url': 'http://www.dbtv.no/lazyplayer/4631135248001',
-        'only_matching': True,
-    }, {
-        'url': 'http://dbtv.no/vice/5000634109001',
-        'only_matching': True,
-    }, {
-        'url': 'http://dbtv.no/filmtrailer/3359293614001',
-        'only_matching': True,
+        'params': {
+            'skip_download': True,
+        },
     }]
 
-    @staticmethod
-    def _extract_urls(webpage):
-        return [url for _, url in re.findall(
-            r'<iframe[^>]+src=(["\'])((?:https?:)?//(?:www\.)?dbtv\.no/(?:lazy)?player/\d+.*?)\1',
-            webpage)]
+    def _real_extract(self, url):
+        mobj = re.search(self._VALID_URL, url)
+        video_id = mobj.group("id")
+        webpage = self._download_webpage(url, video_id)
+        title = self._og_search_title(webpage)
+        video_url = 'https://content.jwplatform.com/manifests/%s.m3u8' % video_id
+        formats = self._extract_m3u8_formats(video_url, video_id, 'mp4')
+        self._sort_formats(formats)
+
+        return {
+            'url': video_url,
+            'id': video_id,
+            'title': title,
+            'formats': formats,
+        }
+
+
+class DBYTIE(InfoExtractor):
+    _VALID_URL = r'https://www\.dagbladet\.no/video/(?P<id>[^/]+)/?$'
+    _TESTS = [{
+        'url': 'https://www.dagbladet.no/video/-VPqpBpkwDk/',
+        'info_dict': {
+            'id': '-VPqpBpkwDk',
+            'ext': 'mp4',
+            'upload_date': '20160916',
+            'uploader': 'Dagbladet',
+            'description': 'Video originally published on dagbladet.no/dbtv.no on 19.03.2014\n\nTrailer - Børning',
+            'uploader_id': 'UCk5pvsyZJoYJBd7_oFPTlRQ',
+            'title': 'Børning',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
 
     def _real_extract(self, url):
-        video_id, display_id = re.match(self._VALID_URL, url).groups()
+        mobj = re.search(self._VALID_URL, url)
+        video_id = mobj.group("id")
+        webpage = self._download_webpage(url, video_id)
+        title = self._og_search_title(webpage)
 
         return {
             '_type': 'url_transparent',
-            'url': 'http://players.brightcove.net/1027729757001/default_default/index.html?videoId=%s' % video_id,
+            'url': 'https://www.youtube.com/watch?v=%s' % video_id,
             'id': video_id,
-            'display_id': display_id,
-            'ie_key': 'BrightcoveNew',
+            'title': title,
         }

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -271,7 +271,10 @@ from .daum import (
     DaumPlaylistIE,
     DaumUserIE,
 )
-from .dbtv import DBTVIE
+from .dbtv import (
+    DBTVIE,
+    DBYTIE,
+)
 from .dctp import DctpTvIE
 from .deezer import DeezerPlaylistIE
 from .democracynow import DemocracynowIE


### PR DESCRIPTION
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] Bug fix

The site now has both their own videos and YouTube embeds. This patch aims to support both, the latter by delegating extraction to the YouTube extractor.
