### PR TITLE
[nrk] Remove whitespace in XML subtitles causing problems for .srt files

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1237,7 +1237,7 @@ part 3</font></u>
 4
 00:00:09,560 --> 00:00:12,359
 <i><u><font color="yellow"><font color="lime">inner
- </font>style</font></u></i>
+</font>style</font></u></i>
 
 '''
         self.assertEqual(dfxp2srt(dfxp_data_with_style), srt_data)

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2831,7 +2831,7 @@ def dfxp2srt(dfxp_data):
                     self._applied_styles.pop()
 
         def data(self, data):
-            self._out += data
+            self._out += data.strip()
 
         def close(self):
             return self._out.strip()


### PR DESCRIPTION
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [X] Bug fix

XML subtitles on NRK sometimes have surrounding whitespace. When converted to srt, these subtitles don't display in video players like VLC. The fix simply trims the whitespace, thereby resolving the issue.

Closes #7908.
