### PR TITLE
[postprocessor/ffmpeg] Support for DCSubtitle (XML) format

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -19,6 +19,7 @@ from ..utils import (
     shell_quote,
     subtitles_filename,
     dfxp2srt,
+    dc2srt,
     ISO639Utils,
     replace_extension,
 )
@@ -610,7 +611,7 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
             sub_filenames.append(old_file)
             new_file = subtitles_filename(filename, lang, new_ext)
 
-            if ext in ('dfxp', 'ttml', 'tt'):
+            if ext in ('dfxp', 'ttml', 'tt', 'xml'):
                 self._downloader.report_warning(
                     'You have requested to convert dfxp (TTML) subtitles into another format, '
                     'which results in style information loss')
@@ -619,7 +620,12 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
                 srt_file = subtitles_filename(filename, lang, 'srt')
 
                 with open(dfxp_file, 'rb') as f:
-                    srt_data = dfxp2srt(f.read())
+                    file = f.read()
+
+                if ext == 'xml':
+                    srt_data = dc2srt(file)
+                else:
+                    srt_data = dfxp2srt(file)
 
                 with io.open(srt_file, 'wt', encoding='utf-8') as f:
                     f.write(srt_data)

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2721,6 +2721,35 @@ def match_filter_func(filter_str):
     return _match_func
 
 
+def dc_time_to_srt_time(dc_time):
+    return '{0:}:{1:}:{2:},{3:}'.format(*dc_time.split(':'))
+
+
+def parse_dc_subtitles(dc):
+    subs = []
+    root = xml.etree.ElementTree.fromstring(dc)
+    font = root.find('Font')
+    for subtitle in font.findall('Subtitle'):
+        subs.append({
+            'number': subtitle.attrib['SpotNumber'],
+            'start': subtitle.attrib['TimeIn'],
+            'end': subtitle.attrib['TimeOut'],
+            'text': '\n'.join([text.text for text in subtitle.findall('Text')]),
+        })
+    return subs
+
+
+def dc2srt(dc):
+    subs = parse_dc_subtitles(dc)
+    srt = []
+    for sub in subs:
+        srt.append(sub['number'])
+        srt.append(dc_time_to_srt_time(sub['start']) + ' --> ' + dc_time_to_srt_time(sub['end']))
+        srt.append(sub['text'])
+        srt.append('')
+    return '\n'.join(srt)
+
+
 def parse_dfxp_time_expr(time_expr):
     if not time_expr:
         return


### PR DESCRIPTION
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) [1]
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/) [2]
- [X] Bug fix / New feature

[1] The `flake8` warnings are unrelated to this patch.

[2] The code is modified from a [snippet](https://gist.github.com/naglis/ee95a03d8f84d36fe2c3). I don't know if a permission from the original author is relevant.

The patch introduces support for converting the "DCSubtitle" format (used at least on Viafree) to srt. This prevents FFmpeg from choking on subtitle conversion, since it doesn't support the format.

Closes #20352.
