### PR TITLE
fix metadata extraction for xtube

### DIFF
--- a/youtube_dl/extractor/xtube.py
+++ b/youtube_dl/extractor/xtube.py
@@ -106,16 +106,17 @@ class XTubeIE(InfoExtractor):
             (r'<h1>\s*(?P<title>[^<]+?)\s*</h1>', r'videoTitle\s*:\s*(["\'])(?P<title>.+?)\1'),
             webpage, 'title', group='title')
         description = self._search_regex(
-            r'</h1>\s*<p>([^<]+)', webpage, 'description', fatal=False)
+            r'<span class="fullDescription[^"]+">\s*(?P<description>[^<]+)\s*</span>',
+            webpage, 'description', fatal=False)
         uploader = self._search_regex(
             (r'<input[^>]+name="contentOwnerId"[^>]+value="([^"]+)"',
              r'<span[^>]+class="nickname"[^>]*>([^<]+)'),
             webpage, 'uploader', fatal=False)
         duration = parse_duration(self._search_regex(
-            r'<dt>Runtime:?</dt>\s*<dd>([^<]+)</dd>',
+            r',"duration":(?P<duration>\d+)(,|})',
             webpage, 'duration', fatal=False))
         view_count = str_to_int(self._search_regex(
-            r'<dt>Views:?</dt>\s*<dd>([\d,\.]+)</dd>',
+            (r'<div class="viewsWrapper">\s*<span class="viewsCount">\s*(\d+)\s*views'),
             webpage, 'view count', fatal=False))
         comment_count = str_to_int(self._html_search_regex(
             r'>Comments? \(([\d,\.]+)\)<',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fix not working extraction of metadata from XTube.

#### Before:

```
$ python test/test_download.py TestDownload.test_XTube                                                                                                                                                                                                                                                                                    
[XTube] kVTUy_G222_: Downloading webpage
ERROR: unable to extract description; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/YoutubeDL.py", line 796, in extract_info
    ie_result = ie.extract(url)
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/extractor/common.py", line 529, in extract
    ie_result = self._real_extract(url)
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/extractor/xtube.py", line 109, in _real_extract
    r'</h1>\s*<p>([^<]+)', webpage, 'description', fatal=False)
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/extractor/common.py", line 1006, in _search_regex
    self._downloader.report_warning('unable to extract %s' % _name + bug_reports_message())
  File "/Users/duhlu/Projects/youtube-dl/test/helper.py", line 271, in _report_warning
    real_warning(w)
  File "test/test_download.py", line 52, in report_warning
    raise ExtractorError(message)
ExtractorError: unable to extract description; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

E
======================================================================
ERROR: test_XTube (__main__.TestDownload):
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test_download.py", line 159, in test_template
    force_generic_extractor=params.get('force_generic_extractor', False))
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/YoutubeDL.py", line 819, in extract_info
    self.report_error(compat_str(e), e.format_traceback())
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/YoutubeDL.py", line 624, in report_error
    self.trouble(error_message, tb)
  File "/Users/duhlu/Projects/youtube-dl/youtube_dl/YoutubeDL.py", line 594, in trouble
    raise DownloadError(message, exc_info)
DownloadError: ERROR: unable to extract description; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.

----------------------------------------------------------------------
Ran 1 test in 1.363s

FAILED (errors=1)
```

#### After:

```
$ python test/test_download.py TestDownload.test_XTube                                                                                                                                                                                                                                                                      
[XTube] kVTUy_G222_: Downloading webpage
[info] Writing video description metadata as JSON to: test_XTube_kVTUy_G222_.info.json
[debug] Invoking downloader on u'https://cdn1-l-ha-e7.xtube.com/videos/200810/18/kVTUy_G222_/480_99_5k3B5_G222_.mp4?validfrom=1557656142&validto=1557663342&rate=30&burst=100000&hash=2NWmJZPN7gE3sl2jnahJbIRh3Uk%3D'
[download] Destination: test_XTube_kVTUy_G222_.mp4
[download] 100% of 10.00KiB in 00:02
.
----------------------------------------------------------------------
Ran 1 test in 3.919s

OK
```