### PR TITLE
[Ruutu] Fix extractor by attempting to authenticate video url

### DIFF
--- a/youtube_dl/extractor/ruutu.py
+++ b/youtube_dl/extractor/ruutu.py
@@ -92,11 +92,10 @@ class RuutuIE(InfoExtractor):
             Returns original video url with authentication token
             appended. Required for most videos since early 2019.
             """
-            authenticated_url = self._download_webpage(
+            return self._download_webpage(
                 'https://gatling.nelonenmedia.fi/auth/access/v2',
                 video_id, query={'stream': url},
                 note='Authenticating video url', fatal=False)
-            return authenticated_url
 
         def extract_formats(node):
             for child in node:
@@ -112,8 +111,7 @@ class RuutuIE(InfoExtractor):
                     if not self._request_webpage(
                             video_url, video_id,
                             note='Checking if video is available without authentication',
-                            errnote='Authentication required',
-                            fatal=False):
+                            errnote='Authentication required', fatal=False):
                         video_url = authenticate_video_url(video_url)
                         if not video_url:
                             continue
@@ -177,8 +175,7 @@ class RuutuIE(InfoExtractor):
                 raise ExtractorError(
                     ("Probably a Ruutu+ video, authentication required. "
                      "Consider sending PR for proper handling of Ruutu+ "
-                     "videos with credentials."),
-                    expected=True)
+                     "videos with credentials."), expected=True)
 
         self._sort_formats(formats)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Since spring 2019, most ruutu.fi videos require an authenticated video url. This pr attempts to authenticate the video url if the old unauthenticated method fails. Related issue: #21031 
