### PR TITLE
[YahooJapanNews] Add extractor.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1453,6 +1453,7 @@ from .yahoo import (
     YahooSearchIE,
     YahooGyaOPlayerIE,
     YahooGyaOIE,
+    YahooJapanNewsIE,
 )
 from .yandexdisk import YandexDiskIE
 from .yandexmusic import (


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I added an extractor that supports Yahoo Japan News pages which weren't extractable using generic or Yahoo extractors. This extractor specifically supports pages on news.yahoo.co.jp and headlines.yahoo.co.jp. 

Current output:
```
$ youtube-dl -v https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', 'https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.05.20
[debug] Python version 3.7.3 (CPython) - Darwin-18.6.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1.3, ffprobe 4.1.3, phantomjs 4, rtmpdump 2.4
[debug] Proxy map: {}
[generic] nnn?a=20190531-00000180-nnn-int: Requesting header
WARNING: Falling back on generic information extractor.
[generic] nnn?a=20190531-00000180-nnn-int: Downloading webpage
[generic] nnn?a=20190531-00000180-nnn-int: Extracting information
ERROR: Unsupported URL: https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/YoutubeDL.py", line 796, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/extractor/common.py", line 529, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/extractor/generic.py", line 3329, in _real_extract
    raise UnsupportedError(url)
youtube_dl.utils.UnsupportedError: Unsupported URL: https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
```
After fix:
```
python -m youtube_dl -v https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', 'https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.05.20
[debug] Git HEAD: 569a27f63
[debug] Python version 3.7.3 (CPython) - Darwin-18.6.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1.3, ffprobe 4.1.3, phantomjs 4, rtmpdump 2.4
[debug] Proxy map: {}
[yahoo:japannews] 20190531-00000180: Downloading webpage
[yahoo:japannews] 1593640: Downloading JSON metadata
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[debug] Default format spec: bestvideo+bestaudio/best
[debug] Invoking downloader on 'https://gw-yvpub.c.yimg.jp/v1/hls/4K5p1TOO2WN94pPv/video.m3u8?bw=5000&session_token=1mDCAc8xMSbcnfiY.Yztd4Eeo30kitTsiHlxPUg-&https=1'
[hlsnative] Downloading m3u8 manifest
...
```