### PR TITLE
[YahooJapanNews] Add extractor.

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1448,6 +1448,7 @@ from .yahoo import (
     YahooSearchIE,
     YahooGyaOPlayerIE,
     YahooGyaOIE,
+    YahooJapanNewsIE,
 )
 from .yandexdisk import YandexDiskIE
 from .yandexmusic import (

--- a/youtube_dl/extractor/yahoo.py
+++ b/youtube_dl/extractor/yahoo.py
@@ -688,7 +688,7 @@ class YahooJapanNewsIE(InfoExtractor):
         content_id = self._search_regex(
             r'<script[^>]+class=["\']yvpub-player["\'][^>]+contentid=(?P<contentid>[^&"\']+)',
             webpage, 'contentid', group='contentid')
-        # md5 hash of space_id + '_headlines.yahoo.co.jp'
+        # md5 hash of space_id + '_' + host
         ak = hashlib.md5('_'.join((space_id, host)).encode()).hexdigest()
 
         json_data = self._download_json(

--- a/youtube_dl/extractor/yahoo.py
+++ b/youtube_dl/extractor/yahoo.py
@@ -577,12 +577,12 @@ class YahooJapanNewsIE(InfoExtractor):
             'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
         }, 'params': {'skip_download': True}
         }, {
-        'url': 'https://news.yahoo.co.jp/pickup/6330725',
+        'url': 'https://headlines.yahoo.co.jp/hl?a=20190721-00000001-oxv-l04',
         'info_dict': {
             'id': '1750855',
             'ext': 'mp4',
-            'title': 'ひき逃げか 200m引きずった痕 | 2019/7/21(日) - Yahoo!ニュース',
-            'description': '21日午前4時40分ごろ、仙台市泉区で、倒れていた女性（39）が見つかり、病院で死亡が確認された。路上に女…',
+            'title': '200ｍ引きずられたか\u3000路上で女性死亡\u3000ひき逃げ事件として捜査\u3000仙台（仙台放送） - Yahoo!ニュース',
+            'description': '倒れている女性が見つかったのは、仙台市泉区松陵１丁目の路上です。21日午前4時40分 - Yahoo!ニュース(仙台放送)',
             'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
         }, 'params': {'skip_download': True}
         }, {

--- a/youtube_dl/extractor/yahoo.py
+++ b/youtube_dl/extractor/yahoo.py
@@ -640,34 +640,11 @@ class YahooJapanNewsIE(InfoExtractor):
         ) or self._html_search_regex('<title>([^<]+)</title>', webpage, 'title')
 
         if display_id == host:
-            # Headline page (w/ multiple BC playlists)
-            stream_urls_plists = re.findall(
-                r'YJNEWS\.LIVESTREAM\.SRC.+=(?:\s+)?["\'](?P<streamurl>[^"\']+plist=(?P<plist>\d+)[^"\']+)',
-                webpage)
-            if not stream_urls_plists:
-                # Manually build ('news.yahoo.co.jp', ...)
-                sbase_url = 'https://s.yimg.jp/images/media/video/player/html/embed_1.2.5.html?service=news&service_type=video&plist=%s&poster=%s&sp=%s&country=JP'
-
-                params = re.findall(
-                    r'["\']plist["\']:\s*["\'](?P<plist>[^"\']+)[^;]+?["\']poster["\']:\s*["\'](?P<poster>[^"\']+)[^;]+?["\']spaceId["\']:\s*["\'](?P<spaceid>[^"\']+)',
-                    webpage)
-                for p in params:
-                    stream_urls_plists.append((sbase_url % p, p[0]))
+            # Headline page (w/ multiple BC playlists) ('news.yahoo.co.jp', 'headlines.yahoo.co.jp/videonews/', ...)
+            stream_plists = re.findall(r'plist=(\d+)', webpage) or re.findall(r'plist["\']:\s*["\']([^"\']+)', webpage)
 
             bc_url = 'http://players.brightcove.net/5690807595001/HyZNerRl7_default/index.html?playlistId=%s'
-            entries = []
-            for url, plist_id in stream_urls_plists:
-                embed_page = self._download_webpage(
-                    'https://s.yimg.jp/images/media/video/player/js/embed_1.0.9.min.js',
-                    plist_id,
-                    headers={
-                        'Authority': 's.yimg.jp',
-                        'Path': '/images/media/video/player/js/embed_1.0.9.min.js',
-                        'Referer': url,
-                    }, fatal=False)
-                if not embed_page:
-                    continue
-                entries.append(bc_url % plist_id)
+            entries = [bc_url % plist_id for plist_id in stream_plists]
 
             return self.playlist_from_matches(entries, playlist_title=title, ie='BrightcoveNew')
 

--- a/youtube_dl/extractor/yahoo.py
+++ b/youtube_dl/extractor/yahoo.py
@@ -566,15 +566,25 @@ class YahooJapanNewsIE(InfoExtractor):
     IE_NAME = 'yahoo:japannews'
     IE_DESC = 'Yahoo! Japan News'
     _VALID_URL = r'https?://(?P<host>(?:news|headlines)\.yahoo\.co\.jp)[^\d]*(?P<id>\d[\d-]*\d)?'
+    _GEO_COUNTRIES = ['JP']
     _TESTS = [{
-            'url': 'https://headlines.yahoo.co.jp/videonews/ann?a=20190716-00000071-ann-int',
-            'info_dict': {
-                'id': '1736242',
-                'ext': 'mp4',
-                'title': 'ムン大統領が対日批判を強化“現金化”効果は？（テレビ朝日系（ANN）） - Yahoo!ニュース',
-                'description': '韓国の元徴用工らを巡る裁判の原告が弁護士が差し押さえた三菱重工業の資産を売却して - Yahoo!ニュース(テレビ朝日系（ANN）)',
-                'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
-            }, 'params': {'skip_download': True},
+        'url': 'https://headlines.yahoo.co.jp/videonews/ann?a=20190716-00000071-ann-int',
+        'info_dict': {
+            'id': '1736242',
+            'ext': 'mp4',
+            'title': 'ムン大統領が対日批判を強化“現金化”効果は？（テレビ朝日系（ANN）） - Yahoo!ニュース',
+            'description': '韓国の元徴用工らを巡る裁判の原告が弁護士が差し押さえた三菱重工業の資産を売却して - Yahoo!ニュース(テレビ朝日系（ANN）)',
+            'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
+        }, 'params': {'skip_download': True}
+        }, {
+        'url': 'https://news.yahoo.co.jp/pickup/6330725',
+        'info_dict': {
+            'id': '1750855',
+            'ext': 'mp4',
+            'title': 'ひき逃げか 200m引きずった痕 | 2019/7/21(日) - Yahoo!ニュース',
+            'description': '21日午前4時40分ごろ、仙台市泉区で、倒れていた女性（39）が見つかり、病院で死亡が確認された。路上に女…',
+            'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
+        }, 'params': {'skip_download': True}
         }, {
             'url': 'https://headlines.yahoo.co.jp/videonews/',
             'only_matching': True,
@@ -644,7 +654,7 @@ class YahooJapanNewsIE(InfoExtractor):
                 for p in params:
                     stream_urls_plists.append((sbase_url % p, p[0]))
 
-            bc_url = 'http://players.brightcove.net/%s/%s_%s/index.html?playlistId=%s'
+            bc_url = 'http://players.brightcove.net/5690807595001/HyZNerRl7_default/index.html?playlistId=%s'
             entries = []
             for url, plist_id in stream_urls_plists:
                 embed_page = self._download_webpage(
@@ -655,18 +665,9 @@ class YahooJapanNewsIE(InfoExtractor):
                         'Path': '/images/media/video/player/js/embed_1.0.9.min.js',
                         'Referer': url,
                     }, fatal=False)
-                account = self._search_regex(
-                    r'\w+\.video_attr\[(["\'])data-account\1\]\s*=\s*\1(?P<accountid>[\d]+)',
-                    embed_page, 'account id', group='accountid', fatal=False)
-                player = self._search_regex(
-                    r'\w+\.video_attr\[(["\'])data-player\1\]\s*=\s*\1(?P<playerid>[^"\']+)',
-                    embed_page, 'player id', group='playerid', fatal=False)
-                embed = self._search_regex(
-                    r'(["\'])data-embed\1\s*:\s*\1(?P<embed>[^"\']+)',
-                    embed_page, 'embed', group='embed', fatal=False)
-                if not all([embed_page, account, player, embed]):
+                if not embed_page:
                     continue
-                entries.append(bc_url % (account, player, embed, plist_id))
+                entries.append(bc_url % plist_id)
 
             return self.playlist_from_matches(entries, playlist_title=title, ie='BrightcoveNew')
 

--- a/youtube_dl/extractor/yahoo.py
+++ b/youtube_dl/extractor/yahoo.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import hashlib
 import itertools
 import json
 import re
 
 from .common import InfoExtractor, SearchInfoExtractor
 from ..compat import (
+    compat_str,
     compat_urllib_parse,
     compat_urlparse,
 )
@@ -18,7 +20,9 @@ from ..utils import (
     int_or_none,
     mimetype2ext,
     smuggle_url,
+    try_get,
     unescapeHTML,
+    url_or_none,
 )
 
 from .brightcove import (
@@ -556,3 +560,285 @@ class YahooGyaOIE(InfoExtractor):
                 'https://gyao.yahoo.co.jp/player/%s/' % video_id.replace(':', '/'),
                 YahooGyaOPlayerIE.ie_key(), video_id))
         return self.playlist_result(entries, program_id)
+
+
+class YahooJapanNewsIE(InfoExtractor):
+    IE_NAME = 'yahoo:japannews'
+    IE_DESC = 'Yahoo! Japan News'
+    _VALID_URL = r'https?://(?P<host>(?:news|headlines)\.yahoo\.co\.jp)(/[^\d]*(?P<id>\d[\d-]*\d))?'
+    _TESTS = [
+        {
+            'url': 'https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int',
+            'info_dict': {
+                'id': '20190531-00000180',
+                'ext': 'mp4',
+                'title': '北“対米担当特別代表を銃殺”韓国紙報じる（日本テレビ系（NNN）） - Yahoo!ニュース',
+                'description': '韓国の主要紙である朝鮮日報は、２回目の米朝首脳会談が決裂した責任を問われ、北朝鮮 - Yahoo!ニュース(日本テレビ系（NNN）)',
+                'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
+            },
+            'params': {'skip_download': True},
+        },
+        {
+            'url': 'https://headlines.yahoo.co.jp/hl?a=20190529-00010015-houdoukvq-soci',
+            'info_dict': {
+                'id': '20190529-00010015',
+                'ext': 'mp4',
+                'title': '高校屋上から男子高校生 転落\u3000目撃 女子生徒パニックで搬送（FNN.jpプライムオンライン） - Yahoo!ニュース',
+                'description': '29日午後、宮崎市の高校の屋上から男子高校生が転落し、重傷となっている。29日午後2 - Yahoo!ニュース(FNN.jpプライムオンライン)',
+                'thumbnail': r're:^https?://.*\.[a-zA-Z\d]{3,4}$',
+            },
+            'params': {'skip_download': True},
+        },
+        {
+            'url': 'https://headlines.yahoo.co.jp/videonews/',
+            'info_dict': {
+                'id': 'headlines.yahoo.co.jp',
+                'ext': 'mp4',
+                'title': '映像ニュース - Yahoo!ニュース',
+                'description': 'テレビ局などが配信する映像ニュースを掲載。',
+            },
+            'params': {'skip_download': True},
+        },
+        {
+            'url': 'https://news.yahoo.co.jp',
+            'info_dict': {
+                'id': 'news.yahoo.co.jp',
+                'ext': 'mp4',
+                'title': 'Yahoo!ニュース',
+                'description': 'Yahoo!ニュースは、新聞・通信社が配信するニュースのほか、映像、雑誌や個人の書き手が執筆する記事など多種多様なニュースを掲載しています。',
+            },
+            'params': {'skip_download': True},
+        },
+        {
+            'url': 'https://news.yahoo.co.jp/byline/fujitatakanori/20190528-00127666/',
+            'only_matching': True,
+        },
+        {'url': 'https://news.yahoo.co.jp/pickup/6325141', 'only_matching': True},
+    ]
+    _USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
+    _ORIGIN = 'https://s.yimg.jp'
+
+    def _extract_formats(self, json_data, content_id):
+        formats = []
+
+        video_data = try_get(
+            json_data,
+            lambda x: x['ResultSet']['Result'][0]['VideoUrlSet']['VideoUrl'],
+            list,
+        )
+        if video_data:
+            # Article page
+            for vid in video_data:
+                delivery = vid.get('delivery')
+                url = url_or_none(vid.get('Url'))
+                if not delivery or not url:
+                    continue
+                elif delivery == 'hls':
+                    formats.extend(
+                        self._extract_m3u8_formats(
+                            url,
+                            content_id,
+                            'mp4',
+                            entry_protocol='m3u8_native',
+                            m3u8_id='hls',
+                            fatal=False,
+                        )
+                    )
+                elif delivery == 'progressive':
+                    formats.append(
+                        {
+                            'url': url,
+                            'format_id': 'http-%s' % compat_str(vid.get('bitrate', '')),
+                            'ext': determine_ext(url),
+                            'height': int_or_none(vid.get('height')),
+                            'width': int_or_none(vid.get('width')),
+                            'btr': int_or_none(vid.get('bitrate')),
+                        }
+                    )
+        else:
+            # Headline page with multiple videos
+            for vid in json_data.get('videos', []):
+                for src in vid.get('sources', []):
+                    url = url_or_none(src.get('src'))
+                    ext = determine_ext(url)
+                    if not url:
+                        continue
+                    if ext == 'm3u8':
+                        formats.extend(
+                            self._extract_m3u8_formats(
+                                url,
+                                content_id,
+                                'mp4',
+                                entry_protocol='m3u8_native',
+                                m3u8_id='hls',
+                                fatal=False,
+                            )
+                        )
+                    else:
+                        formats.append({'url': url, 'ext': ext})
+
+        self._remove_duplicate_formats(formats)
+        self._sort_formats(formats)
+
+        return formats
+
+    @staticmethod
+    def _get_md5(s):
+        return hashlib.md5(s.encode()).hexdigest()
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        host = mobj.group('host')
+        # Headline page without `displayid` defaults to `host`.
+        display_id = mobj.group('id') or host
+        webpage = self._download_webpage(url, display_id)
+
+        title = (
+            self._og_search_title(webpage, default=None)
+            or self._html_search_meta('twitter:title', webpage, default=None)
+            or self._html_search_regex('<title>([^<]+)</title>', webpage, 'title')
+        )
+        description = (
+            self._og_search_description(webpage, default=None)
+            or self._html_search_meta('description', webpage, default=None)
+            or self._html_search_meta('twitter:description', webpage, default=None)
+        )
+        thumbnail = self._og_search_thumbnail(
+            webpage, default=None
+        ) or self._html_search_meta('twitter:image', webpage, default=None)
+
+        if display_id == host:
+            # Headline page with playlist of videos
+            formats = []
+
+            # No single useful `contentid` on page
+            content_id = display_id
+
+            stream_urls_plists = re.findall(
+                r'YJNEWS\.LIVESTREAM\.SRC.+=(?:\s+)?["\'](?P<streamurl>[^"\']+plist=(?P<plist>\d+)[^"\']+)',
+                webpage,
+            )
+            if not stream_urls_plists:
+                # Manually build stream urls ('news.yahoo.co.jp', ...)
+                sbase_url = 'https://s.yimg.jp/images/media/video/player/html/embed_1.2.5.html?service=news&service_type=video&plist=%s&poster=%s&sp=%s&country=JP'
+
+                params = re.findall(
+                    r'["\']plist["\']:\s*["\'](?P<plist>[^"\']+)[^;]+?["\']poster["\']:\s*["\'](?P<poster>[^"\']+)[^;]+?["\']spaceId["\']:\s*["\'](?P<spaceid>[^"\']+)',
+                    webpage,
+                )
+                for p in params:
+                    stream_urls_plists.append((sbase_url % p, p[0]))
+
+            for url, plist_id in stream_urls_plists:
+                embed_page = self._download_webpage(
+                    'https://s.yimg.jp/images/media/video/player/js/embed_1.0.9.min.js',
+                    plist_id,
+                    headers={
+                        'Authority': 's.yimg.jp',
+                        'Path': '/images/media/video/player/js/embed_1.0.9.min.js',
+                        'Referer': url,
+                        'User-Agent': self._USER_AGENT,
+                    },
+                )
+                account = self._search_regex(
+                    r'\w+\.video_attr\[(["\'])data-account\1\]\s*=\s*\1(?P<accountid>[\d]+)',
+                    embed_page,
+                    'account id',
+                    group='accountid',
+                )
+                player = self._search_regex(
+                    r'\w+\.video_attr\[(["\'])data-player\1\]\s*=\s*\1(?P<playerid>[^"\']+)',
+                    embed_page,
+                    'player id',
+                    group='playerid',
+                )
+                embed = self._search_regex(
+                    r'(["\'])data-embed\1\s*:\s*\1(?P<embed>[^"\']+)',
+                    embed_page,
+                    'embed',
+                    group='embed',
+                )
+                indexjs_page = self._download_webpage(
+                    'https://players.brightcove.net/%s/%s_%s/index.min.js'
+                    % (account, player, embed),
+                    plist_id,
+                    headers={'Referer': url, 'User-Agent': self._USER_AGENT},
+                )
+                policy_key = self._search_regex(
+                    r'policyKey:\s*["\']([^"\']+)', indexjs_page, 'policy key'
+                )
+
+                json_data = self._download_json(
+                    'https://edge.api.brightcove.com/playback/v1/accounts/%s/playlists/%s'
+                    % (account, plist_id),
+                    plist_id,
+                    headers={
+                        'Accept': 'application/json;pk=%s' % policy_key,
+                        'Origin': self._ORIGIN,
+                        'Referer': url,
+                        'User-Agent': self._USER_AGENT,
+                    },
+                    fatal=False,
+                )
+
+                formats.extend(self._extract_formats(json_data, content_id))
+
+        else:
+            # Article page
+            app_id = 'dj0zaiZpPVZMTVFJR0FwZWpiMyZzPWNvbnN1bWVyc2VjcmV0Jng9YjU-'
+            space_id = (
+                self._search_regex(
+                    r'<script[^>]+class=(["\'])yvpub-player\1[^>]+spaceid=(?P<spaceid>[^&"\']+)',
+                    webpage,
+                    'spaceid',
+                    group='spaceid',
+                    default=None,
+                )
+                or self._search_regex(
+                    r'YAHOO\.JP\.srch\.\w+link\.onLoad[^;]+spaceID["\' ]*:["\' ]+([^"\']+)',
+                    webpage,
+                    'spaceid',
+                    default=None,
+                )
+                or self._search_regex(r'<!--\s+SpaceID=(\d+)', webpage, 'spaceid')
+            )
+            content_id = self._search_regex(
+                r'<script[^>]+class=(["\'])yvpub-player\1[^>]+contentid=(?P<contentid>[^&"\']+)',
+                webpage,
+                'contentid',
+                group='contentid',
+                default=space_id,
+            )
+            # md5 hash of space_id + '_headlines.yahoo.co.jp'
+            ak = YahooJapanNewsIE._get_md5('_'.join((space_id, host)))
+
+            json_data = self._download_json(
+                'https://feapi-yvpub.yahooapis.jp/v1/content/%s' % content_id,
+                content_id,
+                headers={
+                    'Accept': 'application/json, text/javascript, */*; q=0.01',
+                    'Origin': self._ORIGIN,
+                    'Host': 'feapi-yvpub.yahooapis.jp',
+                    'User-Agent': self._USER_AGENT,
+                    'Referer': 'https://s.yimg.jp/images/yvpub/player/vamos/pc/latest/player.html',
+                },
+                query={
+                    'appid': app_id,
+                    'output': 'json',
+                    'space_id': space_id,
+                    'domain': host,
+                    'ak': ak,
+                    'device_type': '1100',
+                },
+                fatal=False,
+            )
+
+            formats = self._extract_formats(json_data, content_id)
+
+        return {
+            'id': display_id,
+            'title': title,
+            'description': description,
+            'thumbnail': thumbnail,
+            'formats': formats,
+        }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I added an extractor that supports Yahoo Japan News pages which aren't extractable via generic or Yahoo extractors. This extractor specifically supports pages on news.yahoo.co.jp and headlines.yahoo.co.jp. 

Current output:
```
$ youtube-dl -v https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', 'https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.05.20
[debug] Python version 3.7.3 (CPython) - Darwin-18.6.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1.3, ffprobe 4.1.3, phantomjs 4, rtmpdump 2.4
[debug] Proxy map: {}
[generic] nnn?a=20190531-00000180-nnn-int: Requesting header
WARNING: Falling back on generic information extractor.
[generic] nnn?a=20190531-00000180-nnn-int: Downloading webpage
[generic] nnn?a=20190531-00000180-nnn-int: Extracting information
ERROR: Unsupported URL: https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/YoutubeDL.py", line 796, in extract_info
    ie_result = ie.extract(url)
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/extractor/common.py", line 529, in extract
    ie_result = self._real_extract(url)
  File "/usr/local/lib/python3.7/site-packages/youtube_dl/extractor/generic.py", line 3329, in _real_extract
    raise UnsupportedError(url)
youtube_dl.utils.UnsupportedError: Unsupported URL: https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
```
After adding extractor:
```
python -m youtube_dl -v https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-v', 'https://headlines.yahoo.co.jp/videonews/nnn?a=20190531-00000180-nnn-int']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2019.05.20
[debug] Git HEAD: 569a27f63
[debug] Python version 3.7.3 (CPython) - Darwin-18.6.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.1.3, ffprobe 4.1.3, phantomjs 4, rtmpdump 2.4
[debug] Proxy map: {}
[yahoo:japannews] 20190531-00000180: Downloading webpage
[yahoo:japannews] 1593640: Downloading JSON metadata
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[yahoo:japannews] 1593640: Downloading m3u8 information
[debug] Default format spec: bestvideo+bestaudio/best
[debug] Invoking downloader on 'https://gw-yvpub.c.yimg.jp/v1/hls/4K5p1TOO2WN94pPv/video.m3u8?bw=5000&session_token=1mDCAc8xMSbcnfiY.Yztd4Eeo30kitTsiHlxPUg-&https=1'
[hlsnative] Downloading m3u8 manifest
...
```