### PR TITLE
[jamendo] parsing of duration (closes #18565)

### DIFF
--- a/youtube_dl/extractor/jamendo.py
+++ b/youtube_dl/extractor/jamendo.py
@@ -35,6 +35,19 @@ class JamendoIE(JamendoBaseIE):
                         /track/(?P<id>[0-9]+)/(?P<display_id>[^/?#&]+)
                     '''
     _TESTS = [{
+        'url': 'https://www.jamendo.com/track/1311140/221',
+        'md5': '9a73cd099a5453244bf73044442c8330',
+        'info_dict': {
+            'id': '1311140',
+            'display_id': '221',
+            'ext': 'flac',
+            'title': 'Duration of life - 221',
+            'artist': 'Duration of life',
+            'track': '221',
+            'duration': 141,
+            'thumbnail': r're:^https?://.*\.jpg'
+        }
+    }, {
         'url': 'https://www.jamendo.com/track/196219/stories-from-emona-i',
         'md5': '6e9e82ed6db98678f171c25a8ed09ffd',
         'info_dict': {
@@ -80,7 +93,7 @@ class JamendoIE(JamendoBaseIE):
         thumbnail = self._html_search_meta(
             'image', webpage, 'thumbnail', fatal=False)
         duration = parse_duration(self._search_regex(
-            r'<span[^>]+itemprop=["\']duration["\'][^>]+content=["\'](.+?)["\']',
+            r'data-bundled-models=["\']{[^}]+{[^{*}]+duration&quot;:(.+?),',
             webpage, 'duration', fatal=False))
 
         return {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Youtube-dl hasn't been able to fetch jamendo song duration for a while (#18565). This should fix it. I'm not totally happy with my fix, as I've encountered trouble fetching it from a json, and had to use it in another place in the page (see my comment on the issue. However, tests work fine (I've added a new one by the way).