### PR TITLE
Update link to GitHub issues page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <table border="0" id="rgb">
 	<tr><td><a class="button" id="r" href="https://github.com/ytdl-org/youtube-dl/blob/master/README.md#readme">Documentation</a></td></tr>
 	<tr><td><a class="button" id="g" href="download.html">Download</a></td></tr>
-	<tr><td><a class="button" id="main-support" href="https://github.com/ytdl-org/youtube-dl/issues/new">Support</a></td></tr>
+	<tr><td><a class="button" id="main-support" href="https://github.com/ytdl-org/youtube-dl/issues/new/choose">Support</a></td></tr>
 	<tr><td><a class="button" id="y" href="https://github.com/ytdl-org/youtube-dl/">Develop</a></td></tr>
 	<tr><td><a class="button" id="b" href="about.html">About</a></td></tr>
 </table>


### PR DESCRIPTION
### Description of your *pull request* and other information

(this isn't a code change) This changes the Support link from https://github.com/ytdl-org/youtube-dl/issues/new to https://github.com/ytdl-org/youtube-dl/issues/new/choose, prompting users to pick a template instead of giving them an empty textbox.