### PR TITLE
[tvplay] Extract subtitles for Viafree (closes #12685)

### DIFF
--- a/youtube_dl/extractor/tvplay.py
+++ b/youtube_dl/extractor/tvplay.py
@@ -310,7 +310,6 @@ class TVPlayIE(InfoExtractor):
 
         self._sort_formats(formats)
 
-        # TODO: webvtt in m3u8
         subtitles = {}
         sami_path = video.get('sami_path')
         if sami_path:
@@ -319,6 +318,24 @@ class TVPlayIE(InfoExtractor):
                 default=compat_urlparse.urlparse(url).netloc.rsplit('.', 1)[-1])
             subtitles[lang] = [{
                 'url': sami_path,
+            }]
+
+        subtitles_webvtt = video.get('subtitles_webvtt')
+        if subtitles_webvtt:
+            lang = self._search_regex(
+                r'_([a-z]{2})\.vtt', subtitles_webvtt, 'lang',
+                default=compat_urlparse.urlparse(url).netloc.rsplit('.', 1)[-1])
+            subtitles[lang] = [{
+                'url': subtitles_webvtt,
+            }]
+
+        subtitles_for_hearing_impaired = video.get('subtitles_for_hearing_impaired')
+        if subtitles_for_hearing_impaired:
+            lang = self._search_regex(
+                r'_([a-z]{2})_', subtitles_for_hearing_impaired, 'lang',
+                default=compat_urlparse.urlparse(url).netloc.rsplit('.', 1)[-1])
+            subtitles[lang + '_sdh'] = [{
+                'url': subtitles_for_hearing_impaired,
             }]
 
         series = video.get('format_title')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This will make it possible to extract subtitles for Viafree. Both regular subtitles and hearing impaired ones. I have tested this with multiple videos on viafree.se and it works as intended.

Regular subtitles are named with the two letter country code, like `sv`. I couldn't find any standard for naming hearing impaired subtitles, so I kept it's original filename, which is `sv_sdh`.

Running with `--list-subs` looks like this:
```
Language formats
sv       vtt
sv_sdh   vtt
```