### PR TITLE
[mixer:vod] relax _VALID_URL (fixes #21531)

### DIFF
--- a/youtube_dl/extractor/beampro.py
+++ b/youtube_dl/extractor/beampro.py
@@ -99,27 +99,33 @@ class BeamProLiveIE(BeamProBaseIE):
 
 class BeamProVodIE(BeamProBaseIE):
     IE_NAME = 'Mixer:vod'
-    _VALID_URL = r'https?://(?:\w+\.)?(?:beam\.pro|mixer\.com)/[^/?#&]+\?.*?\bvod=(?P<id>\d+)'
-    _TEST = {
-        'url': 'https://mixer.com/willow8714?vod=2259830',
-        'md5': 'b2431e6e8347dc92ebafb565d368b76b',
-        'info_dict': {
-            'id': '2259830',
-            'ext': 'mp4',
-            'title': 'willow8714\'s Channel',
-            'duration': 6828.15,
-            'thumbnail': r're:https://.*source\.png$',
-            'timestamp': 1494046474,
-            'upload_date': '20170506',
-            'uploader': 'willow8714',
-            'uploader_id': '6085379',
-            'age_limit': 13,
-            'view_count': int,
+    _VALID_URL = r'https?://(?:\w+\.)?(?:beam\.pro|mixer\.com)/[^/?#&]+\?.*?\bvod=(?P<id>\w+)'
+    _TESTS = [
+        {
+            'url': 'https://mixer.com/willow8714?vod=2259830',
+            'md5': 'b2431e6e8347dc92ebafb565d368b76b',
+            'info_dict': {
+                'id': '2259830',
+                'ext': 'mp4',
+                'title': 'willow8714\'s Channel',
+                'duration': 6828.15,
+                'thumbnail': r're:https://.*source\.png$',
+                'timestamp': 1494046474,
+                'upload_date': '20170506',
+                'uploader': 'willow8714',
+                'uploader_id': '6085379',
+                'age_limit': 13,
+                'view_count': int,
+            },
+            'params': {
+                'skip_download': True,
+            },
         },
-        'params': {
-            'skip_download': True,
+        {
+            'url': 'https://mixer.com/streamer?vod=IxFno1rqC0S_XJ1a2yGgNw',
+            'only_matching': True,
         },
-    }
+    ]
 
     @staticmethod
     def _extract_format(vod, vod_type):

--- a/youtube_dl/extractor/beampro.py
+++ b/youtube_dl/extractor/beampro.py
@@ -100,32 +100,29 @@ class BeamProLiveIE(BeamProBaseIE):
 class BeamProVodIE(BeamProBaseIE):
     IE_NAME = 'Mixer:vod'
     _VALID_URL = r'https?://(?:\w+\.)?(?:beam\.pro|mixer\.com)/[^/?#&]+\?.*?\bvod=(?P<id>\w+)'
-    _TESTS = [
-        {
-            'url': 'https://mixer.com/willow8714?vod=2259830',
-            'md5': 'b2431e6e8347dc92ebafb565d368b76b',
-            'info_dict': {
-                'id': '2259830',
-                'ext': 'mp4',
-                'title': 'willow8714\'s Channel',
-                'duration': 6828.15,
-                'thumbnail': r're:https://.*source\.png$',
-                'timestamp': 1494046474,
-                'upload_date': '20170506',
-                'uploader': 'willow8714',
-                'uploader_id': '6085379',
-                'age_limit': 13,
-                'view_count': int,
-            },
-            'params': {
-                'skip_download': True,
-            },
+    _TESTS = [{
+        'url': 'https://mixer.com/willow8714?vod=2259830',
+        'md5': 'b2431e6e8347dc92ebafb565d368b76b',
+        'info_dict': {
+            'id': '2259830',
+            'ext': 'mp4',
+            'title': 'willow8714\'s Channel',
+            'duration': 6828.15,
+            'thumbnail': r're:https://.*source\.png$',
+            'timestamp': 1494046474,
+            'upload_date': '20170506',
+            'uploader': 'willow8714',
+            'uploader_id': '6085379',
+            'age_limit': 13,
+            'view_count': int,
         },
-        {
-            'url': 'https://mixer.com/streamer?vod=IxFno1rqC0S_XJ1a2yGgNw',
-            'only_matching': True,
+        'params': {
+            'skip_download': True,
         },
-    ]
+    }, {
+        'url': 'https://mixer.com/streamer?vod=IxFno1rqC0S_XJ1a2yGgNw',
+        'only_matching': True,
+    }]
 
     @staticmethod
     def _extract_format(vod, vod_type):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Changed the _VALID_URL regex pattern to match new VOD URLs as seen in #21531
e.g. https://mixer.com/Midgalicis?vod=IxFno1rqC0S_XJ1a2yGgNw