### PR TITLE
[twitter] Allow single dash to be used as username

### DIFF
--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -105,9 +105,6 @@ class TwitterCardIE(TwitterBaseIE):
         }, {
             'url': 'https://twitter.com/i/videos/752274308186120192',
             'only_matching': True,
-        }, {
-            'url': 'https://twitter.com/-/status/1087791357756956680',
-            'only_matching': True,
         },
     ]
 
@@ -431,6 +428,9 @@ class TwitterIE(InfoExtractor):
         'params': {
             'skip_download': True,  # requires ffmpeg
         },
+    }, {
+        'url': 'https://twitter.com/-/status/1087791357756956680',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -280,7 +280,7 @@ class TwitterCardIE(TwitterBaseIE):
 
 class TwitterIE(InfoExtractor):
     IE_NAME = 'twitter'
-    _VALID_URL = r'https?://(?:www\.|m\.|mobile\.)?twitter\.com/(?:i/web|-|(?P<user_id>[^/]+))/status/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|m\.|mobile\.)?twitter\.com/(?:i/web|(?P<user_id>[^/]+))/status/(?P<id>\d+)'
     _TEMPLATE_URL = 'https://twitter.com/%s/status/%s'
     _TEMPLATE_STATUSES_URL = 'https://twitter.com/statuses/%s'
 
@@ -444,7 +444,7 @@ class TwitterIE(InfoExtractor):
         if 'twitter.com/account/suspended' in urlh.geturl():
             raise ExtractorError('Account suspended by Twitter.', expected=True)
 
-        if user_id is None:
+        if user_id is None or user_id == '-':
             mobj = re.match(self._VALID_URL, urlh.geturl())
             user_id = mobj.group('user_id')
 

--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -105,6 +105,9 @@ class TwitterCardIE(TwitterBaseIE):
         }, {
             'url': 'https://twitter.com/i/videos/752274308186120192',
             'only_matching': True,
+        }, {
+            'url': 'https://twitter.com/-/status/1087791357756956680',
+            'only_matching': True,
         },
     ]
 
@@ -280,7 +283,7 @@ class TwitterCardIE(TwitterBaseIE):
 
 class TwitterIE(InfoExtractor):
     IE_NAME = 'twitter'
-    _VALID_URL = r'https?://(?:www\.|m\.|mobile\.)?twitter\.com/(?:i/web|(?P<user_id>[^/]+))/status/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.|m\.|mobile\.)?twitter\.com/(?:i/web|-|(?P<user_id>[^/]+))/status/(?P<id>\d+)'
     _TEMPLATE_URL = 'https://twitter.com/%s/status/%s'
     _TEMPLATE_STATUSES_URL = 'https://twitter.com/statuses/%s'
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR allows to use single dash for username part in video tweet urls.    
Taking follwing command as an example,

```
youtube-dl --output="%(uploader_id).%(ext)" https://twitter.com/-/status/1087791357756956680?s=19
```

youtube-dl used to save this video in a file named `-.mp4`, with this PR saved video will be named like `twitter.mp4`.