### PR TITLE
Attempt to fix Twitch extractors for new URLs

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1235,10 +1235,10 @@ from .twitch import (
     TwitchChapterIE,
     TwitchVodIE,
     TwitchProfileIE,
+    TwitchAllVideosIE,
     TwitchUploadsIE,
     TwitchPastBroadcastsIE,
     TwitchHighlightsIE,
-    TwitchAllVideosIE,
     TwitchStreamIE,
     TwitchClipsIE,
 )

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1231,6 +1231,8 @@ from .twentymin import TwentyMinutenIE
 from .twentythreevideo import TwentyThreeVideoIE
 from .twitcasting import TwitCastingIE
 from .twitch import (
+    TwitchVideoIE,
+    TwitchChapterIE,
     TwitchVodIE,
     TwitchProfileIE,
     TwitchAllVideosIE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1231,8 +1231,6 @@ from .twentymin import TwentyMinutenIE
 from .twentythreevideo import TwentyThreeVideoIE
 from .twitcasting import TwitCastingIE
 from .twitch import (
-    TwitchVideoIE,
-    TwitchChapterIE,
     TwitchVodIE,
     TwitchProfileIE,
     TwitchAllVideosIE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1235,10 +1235,10 @@ from .twitch import (
     TwitchChapterIE,
     TwitchVodIE,
     TwitchProfileIE,
-    TwitchAllVideosIE,
     TwitchUploadsIE,
     TwitchPastBroadcastsIE,
     TwitchHighlightsIE,
+    TwitchAllVideosIE,
     TwitchStreamIE,
     TwitchClipsIE,
 )

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -205,6 +205,43 @@ class TwitchItemBaseIE(TwitchBaseIE):
         return self._extract_media(self._match_id(url))
 
 
+class TwitchVideoIE(TwitchItemBaseIE):
+    IE_NAME = 'twitch:video'
+    _VALID_URL = r'%s/[^/]+/b/(?P<id>\d+)' % TwitchBaseIE._VALID_URL_BASE
+    _ITEM_TYPE = 'video'
+    _ITEM_SHORTCUT = 'a'
+
+    _TEST = {
+        'url': 'http://www.twitch.tv/riotgames/b/577357806',
+        'info_dict': {
+            'id': 'a577357806',
+            'title': 'Worlds Semifinals - Star Horn Royal Club vs. OMG',
+        },
+        'playlist_mincount': 12,
+        'skip': 'HTTP Error 404: Not Found',
+    }
+
+
+class TwitchChapterIE(TwitchItemBaseIE):
+    IE_NAME = 'twitch:chapter'
+    _VALID_URL = r'%s/[^/]+/c/(?P<id>\d+)' % TwitchBaseIE._VALID_URL_BASE
+    _ITEM_TYPE = 'chapter'
+    _ITEM_SHORTCUT = 'c'
+
+    _TESTS = [{
+        'url': 'http://www.twitch.tv/acracingleague/c/5285812',
+        'info_dict': {
+            'id': 'c5285812',
+            'title': 'ACRL Off Season - Sports Cars @ Nordschleife',
+        },
+        'playlist_mincount': 3,
+        'skip': 'HTTP Error 404: Not Found',
+    }, {
+        'url': 'http://www.twitch.tv/tsm_theoddone/c/2349361',
+        'only_matching': True,
+    }]
+
+
 class TwitchVodIE(TwitchItemBaseIE):
     IE_NAME = 'twitch:vod'
     _VALID_URL = r'''(?x)
@@ -510,6 +547,8 @@ class TwitchStreamIE(TwitchBaseIE):
     def suitable(cls, url):
         return (False
                 if any(ie.suitable(url) for ie in (
+                    TwitchVideoIE,
+                    TwitchChapterIE,
                     TwitchVodIE,
                     TwitchProfileIE,
                     TwitchAllVideosIE,

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -456,58 +456,49 @@ class TwitchAllVideosIE(TwitchVideosBaseIE):
 
 class TwitchUploadsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:uploads'
-    _VALID_URL = r'%s/uploads' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\/?\?.*filter=uploads.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'upload'
     _PLAYLIST_TYPE = 'uploads'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/uploads',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=uploads',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
         'playlist_mincount': 0,
-    }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/uploads',
-        'only_matching': True,
     }]
 
 
 class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:past-broadcasts'
-    _VALID_URL = r'%s/past-broadcasts' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\/?\?.*filter=archives.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive'
     _PLAYLIST_TYPE = 'past broadcasts'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/past-broadcasts',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=archives',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
         'playlist_mincount': 0,
-    }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/past-broadcasts',
-        'only_matching': True,
     }]
 
 
 class TwitchHighlightsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:highlights'
-    _VALID_URL = r'%s/highlights' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\/?\?.*filter=highlights.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'highlight'
     _PLAYLIST_TYPE = 'highlights'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/highlights',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=highlights',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
         'playlist_mincount': 805,
-    }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/highlights',
-        'only_matching': True,
     }]
 
 

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -394,37 +394,34 @@ class TwitchProfileIE(TwitchPlaylistBaseIE):
 
 
 class TwitchVideosBaseIE(TwitchPlaylistBaseIE):
-    _VALID_URL_VIDEOS_BASE = r'%s/(?P<id>[^/]+)/videos' % TwitchBaseIE._VALID_URL_BASE
+    _VALID_URL_VIDEOS_BASE = r'%s/(?P<id>[^/]+)/videos/?\?(?:.*?[&;])??filter=%%s' % TwitchBaseIE._VALID_URL_BASE
     _PLAYLIST_PATH = TwitchPlaylistBaseIE._PLAYLIST_PATH + '&broadcast_type='
 
 
 class TwitchAllVideosIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:all'
-    _VALID_URL = r'%s/all' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'all'
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive,upload,highlight'
     _PLAYLIST_TYPE = 'all videos'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/all',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=all&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
         'playlist_mincount': 869,
-    }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/all',
-        'only_matching': True,
     }]
 
 
 class TwitchUploadsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:uploads'
-    _VALID_URL = r'%s\/?\?.*filter=uploads.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'uploads'
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'upload'
     _PLAYLIST_TYPE = 'uploads'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos?filter=uploads',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=uploads&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
@@ -435,12 +432,12 @@ class TwitchUploadsIE(TwitchVideosBaseIE):
 
 class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:past-broadcasts'
-    _VALID_URL = r'%s\/?\?.*filter=archives.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'archives'
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive'
     _PLAYLIST_TYPE = 'past broadcasts'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos?filter=archives',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=archives&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
@@ -451,12 +448,12 @@ class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
 
 class TwitchHighlightsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:highlights'
-    _VALID_URL = r'%s\/?\?.*filter=highlights.*' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'highlights'
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'highlight'
     _PLAYLIST_TYPE = 'highlights'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos?filter=highlights',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=highlights&sort=views',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
@@ -513,8 +510,6 @@ class TwitchStreamIE(TwitchBaseIE):
     def suitable(cls, url):
         return (False
                 if any(ie.suitable(url) for ie in (
-                    TwitchVideoIE,
-                    TwitchChapterIE,
                     TwitchVodIE,
                     TwitchProfileIE,
                     TwitchAllVideosIE,

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -205,43 +205,6 @@ class TwitchItemBaseIE(TwitchBaseIE):
         return self._extract_media(self._match_id(url))
 
 
-class TwitchVideoIE(TwitchItemBaseIE):
-    IE_NAME = 'twitch:video'
-    _VALID_URL = r'%s/[^/]+/b/(?P<id>\d+)' % TwitchBaseIE._VALID_URL_BASE
-    _ITEM_TYPE = 'video'
-    _ITEM_SHORTCUT = 'a'
-
-    _TEST = {
-        'url': 'http://www.twitch.tv/riotgames/b/577357806',
-        'info_dict': {
-            'id': 'a577357806',
-            'title': 'Worlds Semifinals - Star Horn Royal Club vs. OMG',
-        },
-        'playlist_mincount': 12,
-        'skip': 'HTTP Error 404: Not Found',
-    }
-
-
-class TwitchChapterIE(TwitchItemBaseIE):
-    IE_NAME = 'twitch:chapter'
-    _VALID_URL = r'%s/[^/]+/c/(?P<id>\d+)' % TwitchBaseIE._VALID_URL_BASE
-    _ITEM_TYPE = 'chapter'
-    _ITEM_SHORTCUT = 'c'
-
-    _TESTS = [{
-        'url': 'http://www.twitch.tv/acracingleague/c/5285812',
-        'info_dict': {
-            'id': 'c5285812',
-            'title': 'ACRL Off Season - Sports Cars @ Nordschleife',
-        },
-        'playlist_mincount': 3,
-        'skip': 'HTTP Error 404: Not Found',
-    }, {
-        'url': 'http://www.twitch.tv/tsm_theoddone/c/2349361',
-        'only_matching': True,
-    }]
-
-
 class TwitchVodIE(TwitchItemBaseIE):
     IE_NAME = 'twitch:vod'
     _VALID_URL = r'''(?x)

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -438,7 +438,7 @@ class TwitchVideosBaseIE(TwitchPlaylistBaseIE):
 
 class TwitchAllVideosIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:all'
-    _VALID_URL = '%s(?:/?(?:%s)|[^/?]+?/?)?' % (
+    _VALID_URL = '%s/?(?:(?:%s)|$)' % (
         TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE,
         TwitchVideosBaseIE._VALID_URL_VIDEOS_FILTERS % 'all'
     )

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -431,13 +431,17 @@ class TwitchProfileIE(TwitchPlaylistBaseIE):
 
 
 class TwitchVideosBaseIE(TwitchPlaylistBaseIE):
-    _VALID_URL_VIDEOS_BASE = r'%s/(?P<id>[^/]+)/videos/?\?(?:.*?[&;])??filter=%%s' % TwitchBaseIE._VALID_URL_BASE
+    _VALID_URL_VIDEOS_BASE = r'%s/(?P<id>[^/]+)/videos' % TwitchBaseIE._VALID_URL_BASE
+    _VALID_URL_VIDEOS_FILTERS = r'\?(?:.*?[&;])??filter=%s'
     _PLAYLIST_PATH = TwitchPlaylistBaseIE._PLAYLIST_PATH + '&broadcast_type='
 
 
 class TwitchAllVideosIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:all'
-    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'all'
+    _VALID_URL = '%s(?:/?(?:%s)|[^/?]+?/?)?' % (
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE,
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_FILTERS % 'all'
+    )
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive,upload,highlight'
     _PLAYLIST_TYPE = 'all videos'
 
@@ -448,12 +452,18 @@ class TwitchAllVideosIE(TwitchVideosBaseIE):
             'title': 'Spamfish',
         },
         'playlist_mincount': 869,
+    }, {
+        'url': 'https://m.twitch.tv/spamfish/videos/',
+        'only_matching': True,
     }]
 
 
 class TwitchUploadsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:uploads'
-    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'uploads'
+    _VALID_URL = '%s/?(?:%s)' % (
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE,
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_FILTERS % 'uploads'
+    )
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'upload'
     _PLAYLIST_TYPE = 'uploads'
 
@@ -469,7 +479,10 @@ class TwitchUploadsIE(TwitchVideosBaseIE):
 
 class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:past-broadcasts'
-    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'archives'
+    _VALID_URL = '%s/?(?:%s)' % (
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE,
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_FILTERS % 'archives'
+    )
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive'
     _PLAYLIST_TYPE = 'past broadcasts'
 
@@ -485,7 +498,10 @@ class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
 
 class TwitchHighlightsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:highlights'
-    _VALID_URL = TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE % 'highlights'
+    _VALID_URL = '%s/?(?:%s)' % (
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE,
+        TwitchVideosBaseIE._VALID_URL_VIDEOS_FILTERS % 'highlights'
+    )
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'highlight'
     _PLAYLIST_TYPE = 'highlights'
 


### PR DESCRIPTION
Twitch changed its URLs for user's videos lists recently. This commit includes
fixes for "past broadcasts", "hightlights" and "uploads".

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

See #21811