### PR TITLE
Implement C-SPAN Live information extractor

### DIFF
--- a/youtube_dl/extractor/cspanlive.py
+++ b/youtube_dl/extractor/cspanlive.py
@@ -1,0 +1,26 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .brightcove import BrightcoveNewIE
+from .common import InfoExtractor
+from ..utils import smuggle_url
+
+
+class CSpanLiveIE(InfoExtractor):
+    IE_NAME = 'cspanlive'
+    BRIGHTCOVE_URL_TEMPLATE = 'http://players.brightcove.net/3162030207001/2B2qWQJYYM_default/index.html?videoId=%s'
+
+    _VALID_URL = r'^https?://(?:www\.)?c-span\.org/networks'
+
+    def _real_extract(self, url):
+        webpage = self._download_webpage(url, 'stream')
+
+        akamai_token = self._html_search_regex(r'data-akamaitoken="([^"]+)"', webpage, 'akamai_token')
+        video_id = self._html_search_regex(r'data-bcid="([^"]+)"', webpage, 'video_id')
+
+        brightcove_url = smuggle_url(self.BRIGHTCOVE_URL_TEMPLATE % video_id, {
+            'akamai_token': akamai_token,
+            'source_url': url
+        })
+
+        return self.url_result(brightcove_url, ie=BrightcoveNewIE.ie_key(), video_id=video_id)

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -238,6 +238,7 @@ from .crunchyroll import (
     CrunchyrollShowPlaylistIE
 )
 from .cspan import CSpanIE
+from .cspanlive import CSpanLiveIE
 from .ctsnews import CtsNewsIE
 from .ctvnews import CTVNewsIE
 from .cultureunplugged import CultureUnpluggedIE


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This commit introduces the `CSpanLiveIE` class to add support for C-SPAN
live streams. These streams are based on the `BrightcoveNewIE` class
which requires Adobe Pass MSO authentication.

In order to support this new information extractor, `BrightcoveNewIE`
had to be updated to support an optional Akamai token ('hdnts' query
parameter) in the final m3u8 URL used by Brightcove.