### PR TITLE
[dlive] extend VALID_URL regex to support VID with hyphens

### DIFF
--- a/youtube_dl/extractor/dlive.py
+++ b/youtube_dl/extractor/dlive.py
@@ -9,7 +9,7 @@ from ..utils import int_or_none
 
 class DLiveVODIE(InfoExtractor):
     IE_NAME = 'dlive:vod'
-    _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[a-zA-Z0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[a-zA-Z0-9-]+)'
     _TEST = {
         'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
         'info_dict': {

--- a/youtube_dl/extractor/dlive.py
+++ b/youtube_dl/extractor/dlive.py
@@ -10,31 +10,20 @@ from ..utils import int_or_none
 class DLiveVODIE(InfoExtractor):
     IE_NAME = 'dlive:vod'
     _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[a-zA-Z0-9-]+)'
-    _TESTS = [
-        {
-            'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
-            'info_dict': {
-                'id': '3mTzOl4WR',
-                'ext': 'mp4',
-                'title': 'Minecraft with james charles epic',
-                'upload_date': '20190701',
-                'timestamp': 1562011015,
-                'uploader_id': 'pdp',
-            }
-        },
-        {
-            'url': 'https://dlive.tv/p/pdpreplay+D-RD-xSZg',
-            'info_dict': {
-                'id': 'D-RD-xSZg',
-                'title': 'Past Broadcast on July 1st, 2019 - Minecraft with james charles epic',
-                'uploader_id': 'pdpreplay',
-                'upload_date': '20190711',
-                'thumbnail': 'https://images.prd.dlivecdn.com/thumbnail/eceb2161-8984-11e9-9b13-f6d36f09ac29',
-                'timestamp': 1562826006,
-                'ext': 'mp4',
-            }
+    _TESTS = [{
+        'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
+        'info_dict': {
+            'id': '3mTzOl4WR',
+            'ext': 'mp4',
+            'title': 'Minecraft with james charles epic',
+            'upload_date': '20190701',
+            'timestamp': 1562011015,
+            'uploader_id': 'pdp',
         }
-    ]
+    }, {
+        'url': 'https://dlive.tv/p/pdpreplay+D-RD-xSZg',
+        'only_matching': True,
+    }]
 
     def _real_extract(self, url):
         uploader_id, vod_id = re.match(self._VALID_URL, url).groups()

--- a/youtube_dl/extractor/dlive.py
+++ b/youtube_dl/extractor/dlive.py
@@ -10,17 +10,31 @@ from ..utils import int_or_none
 class DLiveVODIE(InfoExtractor):
     IE_NAME = 'dlive:vod'
     _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[a-zA-Z0-9-]+)'
-    _TEST = {
-        'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
-        'info_dict': {
-            'id': '3mTzOl4WR',
-            'ext': 'mp4',
-            'title': 'Minecraft with james charles epic',
-            'upload_date': '20190701',
-            'timestamp': 1562011015,
-            'uploader_id': 'pdp',
+    _TESTS = [
+        {
+            'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
+            'info_dict': {
+                'id': '3mTzOl4WR',
+                'ext': 'mp4',
+                'title': 'Minecraft with james charles epic',
+                'upload_date': '20190701',
+                'timestamp': 1562011015,
+                'uploader_id': 'pdp',
+            }
+        },
+        {
+            'url': 'https://dlive.tv/p/pdpreplay+D-RD-xSZg',
+            'info_dict': {
+                'id': 'D-RD-xSZg',
+                'title': 'Past Broadcast on July 1st, 2019 - Minecraft with james charles epic',
+                'uploader_id': 'pdpreplay',
+                'upload_date': '20190711',
+                'thumbnail': 'https://images.prd.dlivecdn.com/thumbnail/eceb2161-8984-11e9-9b13-f6d36f09ac29',
+                'timestamp': 1562826006,
+                'ext': 'mp4',
+            }
         }
-    }
+    ]
 
     def _real_extract(self, url):
         uploader_id, vod_id = re.match(self._VALID_URL, url).groups()

--- a/youtube_dl/extractor/dlive.py
+++ b/youtube_dl/extractor/dlive.py
@@ -9,7 +9,7 @@ from ..utils import int_or_none
 
 class DLiveVODIE(InfoExtractor):
     IE_NAME = 'dlive:vod'
-    _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[a-zA-Z0-9-]+)'
+    _VALID_URL = r'https?://(?:www\.)?dlive\.tv/p/(?P<uploader_id>.+?)\+(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://dlive.tv/p/pdp+3mTzOl4WR',
         'info_dict': {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some dlive VIDs such as the one found in https://dlive.tv/p/pdpreplay+D-RD-xSZg contain hyphens, so modified _VALID_URL accordingly.