### PR TITLE
[vine] Fixed the extraction of newer Vines

### DIFF
--- a/youtube_dl/extractor/vine.py
+++ b/youtube_dl/extractor/vine.py
@@ -6,7 +6,6 @@ import re
 from .common import InfoExtractor
 from ..compat import compat_str
 from ..utils import (
-    determine_ext,
     int_or_none,
     unified_timestamp,
 )
@@ -74,15 +73,9 @@ class VineIE(InfoExtractor):
                     return format_url
 
         formats = []
-        for quality, format_id in enumerate(('low', '', 'dash')):
+        for quality, format_id in enumerate(('low', '')):
             format_url = video_url(format_id.capitalize())
-            if not format_url:
-                continue
-            # DASH link returns plain mp4
-            if format_id == 'dash' and determine_ext(format_url) == 'mpd':
-                formats.extend(self._extract_mpd_formats(
-                    format_url, video_id, mpd_id='dash', fatal=False))
-            else:
+            if format_url:
                 formats.append({
                     'url': format_url,
                     'format_id': format_id or 'standard',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Sometime after the archive status put upon Vine, the `dash` and `low` video URLs stopped working and returned a 403 whenever accessed. These URLs were only provided for newer HD Vines and therefore left some Vines still working and others not. An example of the broken URLs can be seen in a [newer Vine](https://archive.vine.co/posts/5QTWuphYH5T.json) here.

I have removed the `dash` and `low` URLs from being available to download, and as `low` was the default for youtube-dl it also fixes downloading newer Vines without providing a format as discussed in #17883.