### PR TITLE
Feature metadata override

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,11 +409,6 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      webm and mkv videos)
     --embed-thumbnail                Embed thumbnail in the audio as cover art
     --add-metadata                   Write metadata to the video file
-    --preferred-info                 References a JSON file that contains the
-                                     metadata that will be used preferentially
-                                     over the extracted metadata and upated onto
-                                     the output file. This argument will only be
-                                     utilized when add-metadata is used
     --metadata-from-title FORMAT     Parse additional metadata like song title /
                                      artist from the video title. The format
                                      syntax is the same as --output. Regular

--- a/README.md
+++ b/README.md
@@ -409,6 +409,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      webm and mkv videos)
     --embed-thumbnail                Embed thumbnail in the audio as cover art
     --add-metadata                   Write metadata to the video file
+    --preferred-info                 References a JSON file that contains the
+                                     metadata that will be used preferentially
+                                     over the extracted metadata and upated onto
+                                     the output file
     --metadata-from-title FORMAT     Parse additional metadata like song title /
                                      artist from the video title. The format
                                      syntax is the same as --output. Regular

--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --preferred-info                 References a JSON file that contains the
                                      metadata that will be used preferentially
                                      over the extracted metadata and upated onto
-                                     the output file
+                                     the output file. This argument will only be
+                                     utilized when add-metadata is used
     --metadata-from-title FORMAT     Parse additional metadata like song title /
                                      artist from the video title. The format
                                      syntax is the same as --output. Regular

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -10,6 +10,7 @@ import io
 import os
 import random
 import sys
+import json
 
 
 from .options import (
@@ -275,7 +276,11 @@ def _real_main(argv=None):
     # source and target containers. From this point the container won't change,
     # so metadata can be added here.
     if opts.addmetadata:
-        postprocessors.append({'key': 'FFmpegMetadata'})
+        postprocessors.append({
+            'key': 'FFmpegMetadata',
+            'preferredinfo': json.load(opts.preferredinfo),
+            })
+
     if opts.convertsubtitles:
         postprocessors.append({
             'key': 'FFmpegSubtitlesConvertor',

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -276,10 +276,18 @@ def _real_main(argv=None):
     # source and target containers. From this point the container won't change,
     # so metadata can be added here.
     if opts.addmetadata:
-        postprocessors.append({
-            'key': 'FFmpegMetadata',
-            'preferredinfo': json.load(opts.preferredinfo),
+        if hasattr(opts, 'preferredinfo'):
+            with open(opts.preferredinfo) as read_file:
+                preferredinfo = json.load(read_file)
+            postprocessors.append({
+                'key': 'FFmpegMetadata',
+                'preferredinfo': preferredinfo,
+                })
+        else:
+            postprocessors.append({
+                'key': 'FFmpegMetadata'
             })
+        
 
     if opts.convertsubtitles:
         postprocessors.append({

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -276,12 +276,11 @@ def _real_main(argv=None):
     # source and target containers. From this point the container won't change,
     # so metadata can be added here.
     if opts.addmetadata:
-        if hasattr(opts, 'preferredinfo'):
-            with open(opts.preferredinfo) as read_file:
-                preferredinfo = json.load(read_file)
+        if hasattr(opts, 'preferredmetadatatoembed'):
+            preferredmetadatatoembed = json.loads(opts.preferredmetadatatoembed)
             postprocessors.append({
                 'key': 'FFmpegMetadata',
-                'preferredinfo': preferredinfo,
+                'preferredmetadatatoembed': preferredmetadatatoembed,
                 })
         else:
             postprocessors.append({

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -12,7 +12,6 @@ import random
 import sys
 import json
 
-
 from .options import (
     parseOpts,
 )
@@ -281,13 +280,11 @@ def _real_main(argv=None):
             postprocessors.append({
                 'key': 'FFmpegMetadata',
                 'preferredmetadatatoembed': preferredmetadatatoembed,
-                })
+            })
         else:
             postprocessors.append({
                 'key': 'FFmpegMetadata'
             })
-        
-
     if opts.convertsubtitles:
         postprocessors.append({
             'key': 'FFmpegSubtitlesConvertor',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -830,8 +830,7 @@ def parseOpts(overrideArguments=None):
              'inputted from the info_list, only one will be used. Fields '
              'curently supported for metadata override are '
              '((info_list) => (meta_list)):\n {}'.format(',\n'.join(
-                 ['({}) => ({})'.format(*[', '.join(a) for a in reversed(x)]) for x in get_metadata_override_elements()]
-                 )))
+                 ['({}) => ({})'.format(*[', '.join(a) for a in reversed(x)]) for x in get_metadata_override_elements()])))
     postproc.add_option(
         '--preferred-metadata-json'
     )

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -13,6 +13,9 @@ from .compat import (
     compat_kwargs,
     compat_shlex_split,
 )
+from .postprocessor.ffmpeg import (
+    get_metadata_override_elements
+)
 from .utils import (
     preferredencoding,
     write_string,
@@ -821,7 +824,14 @@ def parseOpts(overrideArguments=None):
     postproc.add_option(
         '--preferred-metadata-to-embed',
         dest='preferredmetadatatoembed', metavar='JSON', type=str,
-        help='Override metadata on the outputted file')
+        help='Override metadata on the outputted file. Pass in a JSON string '
+             'with one element from the info_list in order to override all '
+             'elements from the meta_list. Note, if multiple values are '
+             'inputted from the info_list, only one will be used. Fields '
+             'curently supported for metadata override are '
+             '((info_list) => (meta_list)):\n {}'.format(',\n'.join(
+                 ['({}) => ({})'.format(*[', '.join(a) for a in reversed(x)]) for x in get_metadata_override_elements()]
+                 )))
     postproc.add_option(
         '--preferred-metadata-json'
     )

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -819,6 +819,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
+        '--preferred-info',
+        dest='preferredinfo', metavar='FILE',
+        help='Override metadata on the outputted file')
+    postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',
         help='Parse additional metadata like song title / artist from the video title. '

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -819,9 +819,12 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
-        '--preferred-info',
-        dest='preferredinfo', metavar='FILE',
+        '--preferred-metadata-to-embed',
+        dest='preferredmetadatatoembed', metavar='JSON', type=str,
         help='Override metadata on the outputted file')
+    postproc.add_option(
+        '--preferred-metadata-json'
+    )
     postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -431,7 +431,6 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
 
 
 class FFmpegMetadataPP(FFmpegPostProcessor):
-
     def __init__(self, downloader=None, preferredinfo=None):
         super(FFmpegMetadataPP, self).__init__(downloader)
         self._preferredinfo = preferredinfo if isinstance(preferredinfo, dict) else None

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -445,8 +445,8 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
                     if info_obj.get(info_f) is not None:
                         for meta_f in meta_list:
                             metadata[meta_f] = info_obj[info_f]
-                        return True
-            return False
+                        return info_f
+            return None
 
         def add(meta_list, info_list=None):
             if not info_list:
@@ -455,8 +455,12 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
                 meta_list = (meta_list,)
             if not isinstance(info_list, (list, tuple)):
                 info_list = (info_list,)
-            if not add_info(meta_list, info_list, metadata, self._preferredinfo):
+            preferred_key = add_info(meta_list, info_list, metadata, self._preferredinfo)
+            if preferred_key is None:
                 add_info(meta_list, info_list, metadata, info)
+            else:
+                for info_f in info_list:
+                    info[info_f] = self._preferredinfo[preferred_key]
 
         add('title', ('track', 'title'))
         add('date', 'upload_date')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -459,9 +459,6 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             preferred_key = add_info(meta_list, info_list, metadata, self._preferredinfo)
             if preferred_key is None:
                 add_info(meta_list, info_list, metadata, info)
-            else:
-                for info_f in info_list:
-                    info[info_f] = self._preferredinfo[preferred_key]
 
         add('title', ('track', 'title'))
         add('date', 'upload_date')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -48,17 +48,18 @@ ACODECS = {
 
 
 METADATA_TO_INFO_LIST_ELEMENTS = [
-    ['title', ('track','title')]
-    , ['date', 'upload_date']
-    , [('description','comment'), 'description']
-    , ['purl','webpage_url']
-    , ['track','track_number']
-    , ['artist', ('artist', 'creator', 'uploader', 'uploader_id')]
-    , ['genre']
-    , ['album']
-    , ['album_artists']
-    , ['disc', 'disc_number']
+    ['title', ('track', 'title')],
+    ['date', 'upload_date'],
+    [('description', 'comment'), 'description'],
+    ['purl', 'webpage_url'],
+    ['track', 'track_number'],
+    ['artist', ('artist', 'creator', 'uploader', 'uploader_id')],
+    ['genre'],
+    ['album'],
+    ['album_artists'],
+    ['disc', 'disc_number']
 ]
+
 
 def get_meta_and_info_lists(meta_to_info_list):
     convert_to_tuple = lambda x: tuple(x) if isinstance(x, (list, tuple)) else tuple([x])
@@ -70,11 +71,13 @@ def get_meta_and_info_lists(meta_to_info_list):
         info_list = meta_list
     return (meta_list, info_list)
 
+
 def get_metadata_override_elements():
     elements = []
     for metadata_to_info_lists in METADATA_TO_INFO_LIST_ELEMENTS:
         elements.append(get_meta_and_info_lists(metadata_to_info_lists))
     return elements
+
 
 class FFmpegPostProcessorError(PostProcessingError):
     pass
@@ -463,9 +466,9 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
     def __init__(self, downloader=None, preferredmetadatatoembed=None):
         super(FFmpegMetadataPP, self).__init__(downloader)
         assert (
-            (isinstance(preferredmetadatatoembed, dict) or
-            preferredmetadatatoembed != None)
-            ), 'preferredmetadatatoembed must be a dictionary, if provided'
+            (isinstance(preferredmetadatatoembed, dict)
+                or preferredmetadatatoembed is not None)
+        ), 'preferredmetadatatoembed must be a dictionary, if provided'
         self._preferredmetadatatoembed = preferredmetadatatoembed
 
     def run(self, info):

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -433,7 +433,9 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
 class FFmpegMetadataPP(FFmpegPostProcessor):
     def __init__(self, downloader=None, preferredinfo=None):
         super(FFmpegMetadataPP, self).__init__(downloader)
-        self._preferredinfo = preferredinfo if isinstance(preferredinfo, dict) else None
+        if not (isinstance(preferredinfo, dict) or preferredinfo == None):
+            raise TypeError('preferredinfo must be a dictionary, if provided')
+        self._preferredinfo = preferredinfo
 
     def run(self, info):
         metadata = {}

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -467,7 +467,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         super(FFmpegMetadataPP, self).__init__(downloader)
         assert (
             (isinstance(preferredmetadatatoembed, dict)
-                or preferredmetadatatoembed is not None)
+                or preferredmetadatatoembed is None)
         ), 'preferredmetadatatoembed must be a dictionary, if provided'
         self._preferredmetadatatoembed = preferredmetadatatoembed
 

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -431,11 +431,13 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
 
 
 class FFmpegMetadataPP(FFmpegPostProcessor):
-    def __init__(self, downloader=None, preferredinfo=None):
+    def __init__(self, downloader=None, preferredmetadatatoembed=None):
         super(FFmpegMetadataPP, self).__init__(downloader)
-        if not (isinstance(preferredinfo, dict) or preferredinfo == None):
-            raise TypeError('preferredinfo must be a dictionary, if provided')
-        self._preferredinfo = preferredinfo
+        assert (
+            (isinstance(preferredmetadatatoembed, dict) or
+            preferredmetadatatoembed != None)
+            ), 'preferredmetadatatoembed must be a dictionary, if provided'
+        self._preferredmetadatatoembed = preferredmetadatatoembed
 
     def run(self, info):
         metadata = {}
@@ -456,7 +458,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
                 meta_list = (meta_list,)
             if not isinstance(info_list, (list, tuple)):
                 info_list = (info_list,)
-            preferred_key = add_info(meta_list, info_list, metadata, self._preferredinfo)
+            preferred_key = add_info(meta_list, info_list, metadata, self._preferredmetadatatoembed)
             if preferred_key is None:
                 add_info(meta_list, info_list, metadata, info)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This pull request is for a new feature that modifies the FFmpegMetadataPP post-processor in order to accept an optional argument "preferredinfo". This goal of this is to support the post-processing overriding of metadata on the extracted file.

When present this dictionary will take precedence when populating the metadata dictionary that is used to update the metadata on the extracted file. If an attribute is not present in the preferredinfo dictionary, the info dictionary will be used.

As an additional step, the info dictionary is modified to reflect the information present in the preferredinfo dictionary if, and only if, this information was used to set the attribute on the metadata object. This behavior may or may not be preferred due to the impacts the modification of the info dictionary can have on post-processors executed after FFmpegMEtadataPP. Feedback on this update is requested.