### PR TITLE
[gfycat] support when accidentally prodiving media uri

### DIFF
--- a/youtube_dl/extractor/gfycat.py
+++ b/youtube_dl/extractor/gfycat.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 
 class GfycatIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:(www|giant|thumbs)\.)?gfycat\.com/(?:ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#\.]+)'
+    _VALID_URL = r'https?://(?:(?:www|giant|thumbs)\.)?gfycat\.com/(?:ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#\.]+)'
     _TESTS = [{
         'url': 'http://gfycat.com/DeadlyDecisiveGermanpinscher',
         'info_dict': {

--- a/youtube_dl/extractor/gfycat.py
+++ b/youtube_dl/extractor/gfycat.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 
 class GfycatIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?gfycat\.com/(?:ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#]+)'
+    _VALID_URL = r'https?://(?:(www|giant|thumbs)\.)?gfycat\.com/(?:ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#\.]+)'
     _TESTS = [{
         'url': 'http://gfycat.com/DeadlyDecisiveGermanpinscher',
         'info_dict': {
@@ -52,6 +52,12 @@ class GfycatIE(InfoExtractor):
         'only_matching': True
     }, {
         'url': 'https://gfycat.com/acceptablehappygoluckyharborporpoise-baseball',
+        'only_matching': True
+    }, {
+        'url': 'https://thumbs.gfycat.com/acceptablehappygoluckyharborporpoise-size_restricted.gif',
+        'only_matching': True
+    }, {
+        'url': 'https://giant.gfycat.com/acceptablehappygoluckyharborporpoise.mp4',
         'only_matching': True
     }]
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When pasting gfycat URLs copied from the browser, or pasting URLs shared via chat/social media, links are often provided as direct media urls, e.g.

```
https://thumbs.gfycat.com/acceptablehappygoluckyharborporpoise-size_restricted.gif
https://giant.gfycat.com/acceptablehappygoluckyharborporpoise.mp4
```

youtube-dl had downloaded these URLs using the `generic` extractor, though using the `gfycat` extractor would yield the best results (and not simply download the reduced gif preview).

I have verified that my changes work by adding tests and running `tests/test_all_urls.py` and also running it myself on the Terminal.

```
C:\Users\anhnh\dev\youtube-dl (gfycat-contenturls)
λ python -m youtube_dl https://thumbs.gfycat.com/DopeyBigAfricanclawedfrog-max-1mb.gif
[Gfycat] DopeyBigAfricanclawedfrog: Downloading video info
[download] Destination: a saerom-fromis 180727 [UeBMgvOQmR8]-9-DopeyBigAfricanclawedfrog.mp4
[download] 100% of 663.43KiB in 00:01

C:\Users\anhnh\dev\youtube-dl (gfycat-contenturls)
λ python -m youtube_dl https://giant.gfycat.com/DefinitePlayfulAmazonparrot.webm
[Gfycat] DefinitePlayfulAmazonparrot: Downloading video info
[download] Destination: saerom-fromis 180727 [UeBMgvOQmR8]-6-DefinitePlayfulAmazonparrot.mp4
[download] 100% of 203.81KiB in 00:01
```

Note that the `gfycat` extractor has been selected and the info dict provided the video title.