### PR TITLE
[sxyprn] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1096,6 +1096,7 @@ from .svt import (
     SVTSeriesIE,
 )
 from .swrmediathek import SWRMediathekIE
+from .sxyprn import SxyPrnIE
 from .syfy import SyfyIE
 from .sztvhu import SztvHuIE
 from .tagesschau import (
@@ -1472,7 +1473,7 @@ from .younow import (
     YouNowMomentIE,
 )
 from .youporn import YouPornIE
-from .sxyprn import SxyPrnIE
+from .yourporn import YourPornIE
 from .yourupload import YourUploadIE
 from .youtube import (
     YoutubeIE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1472,7 +1472,7 @@ from .younow import (
     YouNowMomentIE,
 )
 from .youporn import YouPornIE
-from .yourporn import YourPornIE
+from .sxyprn import SxyPrnIE
 from .yourupload import YourUploadIE
 from .youtube import (
     YoutubeIE,

--- a/youtube_dl/extractor/sxyprn.py
+++ b/youtube_dl/extractor/sxyprn.py
@@ -6,10 +6,10 @@ from ..utils import (
 )
 
 
-class YourPornIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:yourporn\.sexy|sxyprn\.com)/post/(?P<id>[^/?#&.]+)'
-    _TESTS = [{
-        'url': 'https://yourporn.sexy/post/57ffcb2e1179b.html',
+class SxyPrnIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?sxyprn\.com/post/(?P<id>[^/?#&.]+)'
+    _TEST = {
+        'url': 'https://sxyprn.com/post/57ffcb2e1179b.html',
         'md5': '6f8682b6464033d87acaa7a8ff0c092e',
         'info_dict': {
             'id': '57ffcb2e1179b',
@@ -21,11 +21,8 @@ class YourPornIE(InfoExtractor):
         },
         'params': {
             'skip_download': True,
-        },
-    }, {
-        'url': 'https://sxyprn.com/post/57ffcb2e1179b.html',
-        'only_matching': True,
-    }]
+        }
+    }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
@@ -35,7 +32,7 @@ class YourPornIE(InfoExtractor):
         url_parts = self._parse_json(self._search_regex(
             r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info', group='data'), video_id)[video_id].split("/")
 
-        aid = self._search_regex(r'data-aid=\'([a-z0-9]+)\'', webpage, 'aid')
+        aid = self._search_regex(r'data-aid=\'(.*?)\'', webpage, 'aid')
 
         video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/' + url_parts[3] + '/' + url_parts[
             4] + '/' + url_parts[5] + '/' + aid + '/' + video_id + '.mp4'

--- a/youtube_dl/extractor/yourporn.py
+++ b/youtube_dl/extractor/yourporn.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    parse_duration,
+    urljoin,
+)
+
+
+class YourPornIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?(?:yourporn\.sexy|sxyprn\.com)/post/(?P<id>[^/?#&.]+)'
+    _TESTS = [{
+        'url': 'https://yourporn.sexy/post/57ffcb2e1179b.html',
+        'md5': '6f8682b6464033d87acaa7a8ff0c092e',
+        'info_dict': {
+            'id': '57ffcb2e1179b',
+            'ext': 'mp4',
+            'title': 'md5:c9f43630bd968267672651ba905a7d35',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'duration': 165,
+            'age_limit': 18,
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://sxyprn.com/post/57ffcb2e1179b.html',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, video_id)
+
+        video_url = urljoin(url, self._parse_json(
+            self._search_regex(
+                r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info',
+                group='data'),
+            video_id)[video_id]).replace('/cdn/', '/cdn5/')
+
+        title = (self._search_regex(
+            r'<[^>]+\bclass=["\']PostEditTA[^>]+>([^<]+)', webpage, 'title',
+            default=None) or self._og_search_description(webpage)).strip()
+        thumbnail = self._og_search_thumbnail(webpage)
+        duration = parse_duration(self._search_regex(
+            r'duration\s*:\s*<[^>]+>([\d:]+)', webpage, 'duration',
+            default=None))
+
+        return {
+            'id': video_id,
+            'url': video_url,
+            'title': title,
+            'thumbnail': thumbnail,
+            'duration': duration,
+            'age_limit': 18,
+        }

--- a/youtube_dl/extractor/yourporn.py
+++ b/youtube_dl/extractor/yourporn.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 from ..utils import (
     parse_duration,
-    urljoin,
 )
 
 
@@ -33,11 +32,13 @@ class YourPornIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        video_url = urljoin(url, self._parse_json(
-            self._search_regex(
-                r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info',
-                group='data'),
-            video_id)[video_id]).replace('/cdn/', '/cdn5/')
+        url_parts = self._parse_json(self._search_regex(
+            r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info', group='data'), video_id)[video_id].split("/")
+
+        aid = self._search_regex(r'data-aid=\'([a-z0-9]+)\'', webpage, 'aid')
+
+        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/' + url_parts[3] + '/' + url_parts[
+            4] + '/' + url_parts[5] + '/' + aid + '/' + video_id + '.mp4'
 
         title = (self._search_regex(
             r'<[^>]+\bclass=["\']PostEditTA[^>]+>([^<]+)', webpage, 'title',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As `yourporn.sexy` was renamed to `sxyprn.com` and all HTTP requests to `yourporn.sexy` are being 301-redirected to `https://www.youporn.com/?utm_source=yourporn.sexy&utm_medium=redirects&utm_campaign=tldredirects`, making `yourporn.sexy` unavailable, it makes sense to rename the according extractor as well.

This PR renames extractor `yourporn` to `sxyprn`and fixes the existing `video_url` extraction error.