### PR TITLE
[yourporn] Drop support for yourporn.sexy and fix support for sxyprn.com

### DIFF
--- a/youtube_dl/extractor/yourporn.py
+++ b/youtube_dl/extractor/yourporn.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import time
+
 from .common import InfoExtractor
 from ..utils import (
     parse_duration
@@ -39,9 +41,11 @@ class YourPornIE(InfoExtractor):
         aid = self._search_regex(r'data-aid=["\'](?P<aid>.+?)["\']',
                                  webpage, 'aid')
 
-        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/'\
-                    + url_parts[3] + '/' + url_parts[4] + '/' + url_parts[5]\
-                    + '/' + aid + '/' + video_id + '.mp4'
+        epoch = int(time.time() + 3600)
+
+        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/vidi/' \
+                    + url_parts[3] + '/' + url_parts[4] + '/' + str(epoch) \
+                    + '/' + aid + '/' + video_id + '.vid'
 
         title = (self._search_regex(
             r'<[^>]+\bclass=["\']PostEditTA[^>]+>([^<]+)', webpage, 'title',
@@ -58,4 +62,5 @@ class YourPornIE(InfoExtractor):
             'thumbnail': thumbnail,
             'duration': duration,
             'age_limit': 18,
+            'ext': 'mp4',
         }

--- a/youtube_dl/extractor/yourporn.py
+++ b/youtube_dl/extractor/yourporn.py
@@ -33,12 +33,15 @@ class YourPornIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id)
 
         url_parts = self._parse_json(self._search_regex(
-            r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info', group='data'), video_id)[video_id].split("/")
+            r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info',
+            group='data'), video_id)[video_id].split('/')
 
-        aid = self._search_regex(r'data-aid=\'(.*?)\'', webpage, 'aid')
+        aid = self._search_regex(r'data-aid=["\'](?P<aid>.+?)["\']',
+                                 webpage, 'aid')
 
-        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/' + url_parts[3] + '/' + url_parts[
-            4] + '/' + url_parts[5] + '/' + aid + '/' + video_id + '.mp4'
+        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/'\
+                    + url_parts[3] + '/' + url_parts[4] + '/' + url_parts[5]\
+                    + '/' + aid + '/' + video_id + '.mp4'
 
         title = (self._search_regex(
             r'<[^>]+\bclass=["\']PostEditTA[^>]+>([^<]+)', webpage, 'title',

--- a/youtube_dl/extractor/yourporn.py
+++ b/youtube_dl/extractor/yourporn.py
@@ -2,15 +2,14 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from ..utils import (
-    parse_duration,
-    urljoin,
+    parse_duration
 )
 
 
 class YourPornIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:yourporn\.sexy|sxyprn\.com)/post/(?P<id>[^/?#&.]+)'
+    _VALID_URL = r'https?://(?:www\.)?sxyprn\.com/post/(?P<id>[^/?#&.]+)'
     _TESTS = [{
-        'url': 'https://yourporn.sexy/post/57ffcb2e1179b.html',
+        'url': 'https://sxyprn.com/post/57ffcb2e1179b.html',
         'md5': '6f8682b6464033d87acaa7a8ff0c092e',
         'info_dict': {
             'id': '57ffcb2e1179b',
@@ -33,11 +32,13 @@ class YourPornIE(InfoExtractor):
 
         webpage = self._download_webpage(url, video_id)
 
-        video_url = urljoin(url, self._parse_json(
-            self._search_regex(
-                r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info',
-                group='data'),
-            video_id)[video_id]).replace('/cdn/', '/cdn5/')
+        url_parts = self._parse_json(self._search_regex(
+            r'data-vnfo=(["\'])(?P<data>{.+?})\1', webpage, 'data info', group='data'), video_id)[video_id].split("/")
+
+        aid = self._search_regex(r'data-aid=\'(.*?)\'', webpage, 'aid')
+
+        video_url = 'https://' + url_parts[2] + '.trafficdeposit.com/video/' + url_parts[3] + '/' + url_parts[
+            4] + '/' + url_parts[5] + '/' + aid + '/' + video_id + '.mp4'
 
         title = (self._search_regex(
             r'<[^>]+\bclass=["\']PostEditTA[^>]+>([^<]+)', webpage, 'title',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

https://yourporn.sexy doesn't exist anymore since a couple of months, but all the content is now available under https://sxyprn.com. For a period of time the [yourporn]-extractor worked for sxyprn.com anyways, but now it's broken (see #21645).

This PR drops support for the non-existing site yourporn.sexy and fixes the extraction of the `video_url` for sxyprn.com
