### PR TITLE
[vivo] use ROT47 instead of base64 to decode the stream url

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -5594,3 +5594,15 @@ def random_birthday(year_field, month_field, day_field):
         month_field: str(random_date.month),
         day_field: str(random_date.day),
     }
+
+
+# source: https://rot47.net/_py/rot47.txt
+def rot47(s):
+    x = []
+    for i in range(len(s)):
+        j = ord(s[i])
+        if j >= 33 and j <= 126:
+            x.append(chr(33 + ((j + 14) % 94)))
+        else:
+            x.append(s[i])
+    return ''.join(x)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

vivo.sx doesn't encode the stream url with base64 anymore. ROT47 is used.
The test video is not available, so I updated the test, too.