### PR TITLE
[NhkVod] Use Piksel instead of Ooyala for VOD

### DIFF
--- a/youtube_dl/extractor/nhk.py
+++ b/youtube_dl/extractor/nhk.py
@@ -20,6 +20,7 @@ class NhkVodIE(InfoExtractor):
         'only_matching': True,
     }]
     _API_URL_TEMPLATE = 'https://api.nhk.or.jp/nhkworld/%sodesdlist/v7/episode/%s/%s/all%s.json'
+    _API_PIKSEL_BASE_TEMPLATE = 'https://movie-s.nhk.or.jp/v/refid/nhkworld/prefid/%s'
 
     def _real_extract(self, url):
         lang, m_type, episode_id = re.match(self._VALID_URL, url).groups()
@@ -57,11 +58,19 @@ class NhkVodIE(InfoExtractor):
             'series': series,
             'episode': title,
         }
+
         if is_video:
+            vod_id = episode['vod_id']
+            metadata_page = self._download_webpage(self._API_PIKSEL_BASE_TEMPLATE % vod_id, vod_id)
+            video_uuid = self._html_search_regex(
+                r'data-de-program-uuid="(.+?)"',
+                metadata_page,
+                'video_uuid'
+            )
             info.update({
                 '_type': 'url_transparent',
-                'ie_key': 'Ooyala',
-                'url': 'ooyala:' + episode['vod_id'],
+                'ie_key': 'Piksel',
+                'url': 'https://player.piksel.com/v/%s' % video_uuid
             })
         else:
             audio = episode['audio']


### PR DESCRIPTION
Fixes #22249

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The web player back-end has subtly changed for the NHK On Demand service -- some VOD URLs are still accessible with the older provider (Ooyala) but not newer ones (Piksel). Since these URLs in particular have a set time limit anyway I've tested all the URLs mentioned in #22249 manually (plus two more); no issues thus far.