### PR TITLE
Install bash completion into share/bash-completion/completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ dist/
 MANIFEST
 README.txt
 youtube-dl.1
-youtube-dl.bash-completion
+bash-completion/youtube-dl
 youtube-dl.fish
 youtube_dl/extractor/lazy_extractors.py
 youtube-dl

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.md
 include LICENSE
 include AUTHORS
 include ChangeLog
-include youtube-dl.bash-completion
+include bash-completion/youtube-dl
 include youtube-dl.fish
 include youtube-dl.1
 recursive-include docs Makefile conf.py *.rst

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-all: youtube-dl README.md CONTRIBUTING.md README.txt youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish supportedsites
+all: youtube-dl README.md CONTRIBUTING.md README.txt youtube-dl.1 bash-completion/youtube-dl youtube-dl.zsh youtube-dl.fish supportedsites
 
 clean:
-	rm -rf youtube-dl.1.temp.md youtube-dl.1 youtube-dl.bash-completion README.txt MANIFEST build/ dist/ .coverage cover/ youtube-dl.tar.gz youtube-dl.zsh youtube-dl.fish youtube_dl/extractor/lazy_extractors.py *.dump *.part* *.ytdl *.info.json *.mp4 *.m4a *.flv *.mp3 *.avi *.mkv *.webm *.3gp *.wav *.ape *.swf *.jpg *.png CONTRIBUTING.md.tmp youtube-dl youtube-dl.exe
+	rm -rf youtube-dl.1.temp.md youtube-dl.1 bash-completion README.txt MANIFEST build/ dist/ .coverage cover/ youtube-dl.tar.gz youtube-dl.zsh youtube-dl.fish youtube_dl/extractor/lazy_extractors.py *.dump *.part* *.ytdl *.info.json *.mp4 *.m4a *.flv *.mp3 *.avi *.mkv *.webm *.3gp *.wav *.ape *.swf *.jpg *.png CONTRIBUTING.md.tmp youtube-dl youtube-dl.exe
 	find . -name "*.pyc" -delete
 	find . -name "*.class" -delete
 
@@ -17,13 +17,13 @@ SYSCONFDIR = $(shell if [ $(PREFIX) = /usr -o $(PREFIX) = /usr/local ]; then ech
 # set markdown input format to "markdown-smart" for pandoc version 2 and to "markdown" for pandoc prior to version 2
 MARKDOWN = $(shell if [ `pandoc -v | head -n1 | cut -d" " -f2 | head -c1` = "2" ]; then echo markdown-smart; else echo markdown; fi)
 
-install: youtube-dl youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish
+install: youtube-dl youtube-dl.1 bash-completion/youtube-dl youtube-dl.zsh youtube-dl.fish
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 755 youtube-dl $(DESTDIR)$(BINDIR)
 	install -d $(DESTDIR)$(MANDIR)/man1
 	install -m 644 youtube-dl.1 $(DESTDIR)$(MANDIR)/man1
-	install -d $(DESTDIR)$(SYSCONFDIR)/bash_completion.d
-	install -m 644 youtube-dl.bash-completion $(DESTDIR)$(SYSCONFDIR)/bash_completion.d/youtube-dl
+	install -d $(DESTDIR)$(SHAREDIR)/bash-completion/completions
+	install -m 644 bash-completion/youtube-dl $(DESTDIR)$(SHAREDIR)/bash-completion/completions/youtube-dl
 	install -d $(DESTDIR)$(SHAREDIR)/zsh/site-functions
 	install -m 644 youtube-dl.zsh $(DESTDIR)$(SHAREDIR)/zsh/site-functions/_youtube-dl
 	install -d $(DESTDIR)$(SYSCONFDIR)/fish/completions
@@ -53,9 +53,9 @@ offlinetest: codetest
 
 tar: youtube-dl.tar.gz
 
-.PHONY: all clean install test tar bash-completion pypi-files zsh-completion fish-completion ot offlinetest codetest supportedsites
+.PHONY: all clean install test tar pypi-files zsh-completion fish-completion ot offlinetest codetest supportedsites
 
-pypi-files: youtube-dl.bash-completion README.txt youtube-dl.1 youtube-dl.fish
+pypi-files: bash-completion/youtube-dl README.txt youtube-dl.1 youtube-dl.fish
 
 youtube-dl: youtube_dl/*.py youtube_dl/*/*.py
 	mkdir -p zip
@@ -96,10 +96,9 @@ youtube-dl.1: README.md
 	pandoc -s -f $(MARKDOWN) -t man youtube-dl.1.temp.md -o youtube-dl.1
 	rm -f youtube-dl.1.temp.md
 
-youtube-dl.bash-completion: youtube_dl/*.py youtube_dl/*/*.py devscripts/bash-completion.in
+bash-completion/youtube-dl: youtube_dl/*.py youtube_dl/*/*.py devscripts/bash-completion.in
+	mkdir -p bash-completion
 	$(PYTHON) devscripts/bash-completion.py
-
-bash-completion: youtube-dl.bash-completion
 
 youtube-dl.zsh: youtube_dl/*.py youtube_dl/*/*.py devscripts/zsh-completion.in
 	$(PYTHON) devscripts/zsh-completion.py
@@ -117,7 +116,7 @@ _EXTRACTOR_FILES = $(shell find youtube_dl/extractor -iname '*.py' -and -not -in
 youtube_dl/extractor/lazy_extractors.py: devscripts/make_lazy_extractors.py devscripts/lazy_load_template.py $(_EXTRACTOR_FILES)
 	$(PYTHON) devscripts/make_lazy_extractors.py $@
 
-youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 youtube-dl.bash-completion youtube-dl.zsh youtube-dl.fish ChangeLog AUTHORS
+youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 bash-completion/youtube-dl youtube-dl.zsh youtube-dl.fish ChangeLog AUTHORS
 	@tar -czf youtube-dl.tar.gz --transform "s|^|youtube-dl/|" --owner 0 --group 0 \
 		--exclude '*.DS_Store' \
 		--exclude '*.kate-swp' \
@@ -130,6 +129,6 @@ youtube-dl.tar.gz: youtube-dl README.md README.txt youtube-dl.1 youtube-dl.bash-
 		-- \
 		bin devscripts test youtube_dl docs \
 		ChangeLog AUTHORS LICENSE README.md README.txt \
-		Makefile MANIFEST.in youtube-dl.1 youtube-dl.bash-completion \
+		Makefile MANIFEST.in youtube-dl.1 bash-completion/youtube-dl \
 		youtube-dl.zsh youtube-dl.fish setup.py setup.cfg \
 		youtube-dl

--- a/devscripts/bash-completion.py
+++ b/devscripts/bash-completion.py
@@ -8,7 +8,7 @@ import sys
 sys.path.insert(0, dirn(dirn((os.path.abspath(__file__)))))
 import youtube_dl
 
-BASH_COMPLETION_FILE = "youtube-dl.bash-completion"
+BASH_COMPLETION_FILE = "bash-completion/youtube-dl"
 BASH_COMPLETION_TEMPLATE = "devscripts/bash-completion.in"
 
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if len(sys.argv) >= 2 and sys.argv[1] == 'py2exe':
     params = py2exe_params
 else:
     files_spec = [
-        ('etc/bash_completion.d', ['youtube-dl.bash-completion']),
+        ('share/bash-completion/completions', ['bash-completion/youtube-dl']),
         ('etc/fish/completions', ['youtube-dl.fish']),
         ('share/doc/youtube_dl', ['README.txt']),
         ('share/man/man1', ['youtube-dl.1'])


### PR DESCRIPTION
Starting with bash-completion 1.90 (released in November 2011) completion files should be installed in the `share/` directory.

They must use the executable’s name for loading on demand, so for this reason, it was necessary to generate the completion file in a new directory, so that it does not clash with the `youtube-dl` executable.

This is because Python’s setup-tools does not support data files to be installed with a different base name.

I have tested this change with both `make install` and `pip install`, as these two install procedures have slightly different code paths.

I removed the `bash-completion` (phony) target from the make file, as we now have a directory with that name, and I could not see the target being referenced anywhere.

Closes #804.

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix (if we call installing in obsolete location a bug)
- [ ] Improvement
- [ ] New extractor
- [ ] New feature
