### PR TITLE
[gfycat] Added support for french URL

### DIFF
--- a/youtube_dl/extractor/gfycat.py
+++ b/youtube_dl/extractor/gfycat.py
@@ -11,7 +11,7 @@ from ..utils import (
 
 
 class GfycatIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:(?:www|giant|thumbs)\.)?gfycat\.com/(?:ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#\.]+)'
+    _VALID_URL = r'https?://(?:(?:www|giant|thumbs)\.)?gfycat\.com/(?:fr/|ru/|ifr/|gifs/detail/)?(?P<id>[^-/?#\.]+)'
     _TESTS = [{
         'url': 'http://gfycat.com/DeadlyDecisiveGermanpinscher',
         'info_dict': {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
The following command would not works :  
```bash
$ youtube-dl -v -F https://gfycat.com/fr/remarkabledrearyamurstarfish
[debug] System config: []
[debug] User config: ['-o', 'Downloads/%(title)s.%(ext)s']
[debug] Custom config: []
[debug] Command-line args: ['-v', '-F', 'https://gfycat.com/fr/remarkabledrearyamurstarfish']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2019.09.28
[debug] Python version 3.7.0 (CPython) - Windows-10-10.0.17134-SP0
[debug] exe versions: ffmpeg 3.4, ffprobe N-81729-g7d17d31, phantomjs 2.1.1
[debug] Proxy map: {}
[Gfycat] fr: Downloading video info
ERROR: Unable to download JSON metadata: HTTP Error 404: Not Found (caused by <HTTPError 404: 'Not Found'>); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
  File "c:\program files\python37\lib\site-packages\youtube_dl\extractor\common.py", line 627, in _request_webpage
    return self._downloader.urlopen(url_or_request)
  File "c:\program files\python37\lib\site-packages\youtube_dl\YoutubeDL.py", line 2237, in urlopen
    return self._opener.open(req, timeout=self._socket_timeout)
  File "c:\program files\python37\lib\urllib\request.py", line 531, in open
    response = meth(req, response)
  File "c:\program files\python37\lib\urllib\request.py", line 641, in http_response
    'http', request, response, code, msg, hdrs)
  File "c:\program files\python37\lib\urllib\request.py", line 569, in error
    return self._call_chain(*args)
  File "c:\program files\python37\lib\urllib\request.py", line 503, in _call_chain
    result = func(*args)
  File "c:\program files\python37\lib\urllib\request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
```

I looked a bit for similar issues and stumbled upon this one : https://github.com/ytdl-org/youtube-dl/issues/21779
The issue was that the regex matching the url was not supporting URL with language code "ru" in it.  
It has been fixed by simply updating the regex : https://github.com/Lamieur/youtube-dl/commit/0209649dbd4d1294f7119f02b8aff35b3a46bd66?diff=unified  
Thus, i did the exact same update but with the french language code "fr". It is now properly matching the URL :  
```bash
youtube-dl -v -F https://gfycat.com/fr/remarkabledrearyamurstarfish
[debug] System config: []
[debug] User config: ['-o', 'Downloads/%(title)s.%(ext)s']
[debug] Custom config: []
[debug] Command-line args: ['-v', '-F', 'https://gfycat.com/fr/remarkabledrearyamurstarfish']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2019.09.28
[debug] Python version 3.7.0 (CPython) - Windows-10-10.0.17134-SP0
[debug] exe versions: ffmpeg 3.4, ffprobe N-81729-g7d17d31, phantomjs 2.1.1
[debug] Proxy map: {}
[Gfycat] remarkabledrearyamurstarfish: Downloading video info
[info] Available formats for remarkabledrearyamurstarfish:
format code  extension  resolution note
gif          gif        460x460    30fps
webm         webm       460x460    30fps, 2.21MiB
mp4          mp4        460x460    30fps, 1.67MiB (best)
```
While the command properly works for me, It may be necessary to update the regex for each language code supported by gfycat. But I do not know which languages are supported.

