### PR TITLE
[veoh] Accept "videos" URLs; prefer HQ format; get additional metadata

### DIFF
--- a/youtube_dl/extractor/veoh.py
+++ b/youtube_dl/extractor/veoh.py
@@ -9,7 +9,7 @@ from ..utils import (
 
 
 class VeohIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?veoh\.com/(?:watch|embed|iphone/#_Watch)/(?P<id>(?:v|e|yapi-)[\da-zA-Z]+)'
+    _VALID_URL = r'https?://(?:www\.)?veoh\.com/(?:watch|videos|embed|iphone/#_Watch)/(?P<id>(?:v|e|yapi-)[\da-zA-Z]+)'
 
     _TESTS = [{
         'url': 'http://www.veoh.com/watch/v56314296nk7Zdmz3',

--- a/youtube_dl/extractor/veoh.py
+++ b/youtube_dl/extractor/veoh.py
@@ -51,6 +51,21 @@ class VeohIE(InfoExtractor):
     }, {
         'url': 'http://www.veoh.com/watch/e152215AJxZktGS',
         'only_matching': True,
+    }, {
+        'url': 'https://www.veoh.com/videos/v16374379WA437rMH',
+        'md5': 'cceb73f3909063d64f4b93d4defca1b3',
+        'info_dict': {
+            'id': 'v16374379WA437rMH',
+            'ext': 'mp4',
+            'title': 'Phantasmagoria 2, pt. 1-3',
+            'description': 'Phantasmagoria: a Puzzle of Flesh',
+            'thumbnail': 'https://fcache.veoh.com/file/f/th16374379.jpg?h=b87b6851eaa47c9421c95ee8d9ffa7ff',
+            'uploader': 'davidspackage',
+            'duration': 968,
+            'age_limit': 18,
+            'categories': ['technology_and_gaming', 'gaming'],
+            'tags': ['puzzle', 'of', 'flesh'],
+        },
     }]
 
     def _extract_video(self, source):

--- a/youtube_dl/extractor/veoh.py
+++ b/youtube_dl/extractor/veoh.py
@@ -13,7 +13,7 @@ class VeohIE(InfoExtractor):
 
     _TESTS = [{
         'url': 'http://www.veoh.com/watch/v56314296nk7Zdmz3',
-        'md5': '9e7ecc0fd8bbee7a69fe38953aeebd30',
+        'md5': '620e68e6a3cff80086df3348426c9ca3',
         'info_dict': {
             'id': 'v56314296nk7Zdmz3',
             'ext': 'mp4',
@@ -74,7 +74,7 @@ class VeohIE(InfoExtractor):
         title = video['title']
 
         thumbnail_url = None
-        q = qualities(['HQ', 'Regular'])
+        q = qualities(['Regular', 'HQ'])
         formats = []
         for f_id, f_url in video.get('src', {}).items():
             if not f_url:

--- a/youtube_dl/extractor/veoh.py
+++ b/youtube_dl/extractor/veoh.py
@@ -68,19 +68,6 @@ class VeohIE(InfoExtractor):
         },
     }]
 
-    def _extract_video(self, source):
-        return {
-            'id': source.get('videoId'),
-            'title': source.get('title'),
-            'description': source.get('description'),
-            'thumbnail': source.get('highResImage') or source.get('medResImage'),
-            'uploader': source.get('username'),
-            'duration': int_or_none(source.get('length')),
-            'view_count': int_or_none(source.get('views')),
-            'age_limit': 18 if source.get('isMature') == 'true' or source.get('isSexy') == 'true' else 0,
-            'formats': self._extract_formats(source),
-        }
-
     def _real_extract(self, url):
         video_id = self._match_id(url)
         json = self._download_json(

--- a/youtube_dl/extractor/veoh.py
+++ b/youtube_dl/extractor/veoh.py
@@ -68,9 +68,10 @@ class VeohIE(InfoExtractor):
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-        video = self._download_json(
+        json = self._download_json(
             'https://www.veoh.com/watch/getVideo/' + video_id,
-            video_id)['video']
+            video_id)
+        video = json['video']
         title = video['title']
 
         thumbnail_url = None
@@ -89,6 +90,8 @@ class VeohIE(InfoExtractor):
                 })
         self._sort_formats(formats)
 
+        tags = video.get('tags')
+
         return {
             'id': video_id,
             'title': title,
@@ -100,4 +103,7 @@ class VeohIE(InfoExtractor):
             'formats': formats,
             'average_rating': int_or_none(video.get('rating')),
             'comment_count': int_or_none(video.get('numOfComments')),
+            'age_limit': 18 if video.get('contentRatingId') == 2 else 0,
+            'categories': json.get('categoryPath'),
+            'tags': tags.split(', ') if tags else None,
         }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

veoh.com videos can be viewed at both `watch/<video ID>` and `videos/<video ID>` (the pages appear identical). However, youtube-dl currently does not support `videos` URLs.

This prompted me to look at the Veoh extractor, where I have made the following changes:
- Accept `videos` URLs.
- Prefer high quality (2019.09.28 incorrectly marks "Regular" rather than "HQ" as "best").
- Extract metadata for `age_limit`, `categories`, and `tags`.

I have also added a test covering the above and removed the `_extract_video` method (which was both out-of-date and apparently never called).