### PR TITLE
[teletask] Updated valid_url and media regex

### DIFF
--- a/youtube_dl/extractor/teletask.py
+++ b/youtube_dl/extractor/teletask.py
@@ -1,13 +1,11 @@
 from __future__ import unicode_literals
 
-import re
-
 from .common import InfoExtractor
 from ..utils import unified_strdate
 
 
 class TeleTaskIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?tele-task\.de/archive/video/html5/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?tele-task\.de/(archive|lecture)/video/(html5/)?(?P<id>[0-9]+)'
     _TEST = {
         'url': 'http://www.tele-task.de/archive/video/html5/26168/',
         'info_dict': {
@@ -15,7 +13,7 @@ class TeleTaskIE(InfoExtractor):
             'title': 'Duplicate Detection',
         },
         'playlist': [{
-            'md5': '290ef69fb2792e481169c3958dbfbd57',
+            'md5': 'bc7b130ebb52acca59dfb7d96570dee3',
             'info_dict': {
                 'id': '26168-speaker',
                 'ext': 'mp4',
@@ -23,7 +21,7 @@ class TeleTaskIE(InfoExtractor):
                 'upload_date': '20141218',
             }
         }, {
-            'md5': 'e1e7218c5f0e4790015a437fcf6c71b4',
+            'md5': '22a2da392d2e6a257230cf578df4aed4',
             'info_dict': {
                 'id': '26168-slides',
                 'ext': 'mp4',
@@ -38,16 +36,32 @@ class TeleTaskIE(InfoExtractor):
         webpage = self._download_webpage(url, lecture_id)
 
         title = self._html_search_regex(
-            r'itemprop="name">([^<]+)</a>', webpage, 'title')
+            r'<title>([^<]+)</title>', webpage, 'title')
         upload_date = unified_strdate(self._html_search_regex(
             r'Date:</td><td>([^<]+)</td>', webpage, 'date', fatal=False))
 
-        entries = [{
-            'id': '%s-%s' % (lecture_id, format_id),
+        video_url = self._html_search_regex(r'(https(?:(?!https).)*?(?:hls/video\.m3u8))', webpage, 'video_url')
+        video_formats = self._extract_m3u8_formats(
+            video_url, lecture_id, 'mp4', fatal=False)
+
+        desktop_url = video_url.replace('video', 'desktop')
+        desktop_formats = self._extract_m3u8_formats(desktop_url, lecture_id, 'mp4', fatal=False)
+
+        entries = []
+        entries.append({
+            'id': '%s-speaker' % (lecture_id),
             'url': video_url,
             'title': title,
             'upload_date': upload_date,
-        } for format_id, video_url in re.findall(
-            r'<video class="([^"]+)"[^>]*>\s*<source src="([^"]+)"', webpage)]
+            'formats': video_formats
+        })
+
+        entries.append({
+            'id': '%s-slides' % (lecture_id),
+            'url': desktop_url,
+            'title': title,
+            'upload_date': upload_date,
+            'formats': desktop_formats
+        })
 
         return self.playlist_result(entries, lecture_id, title)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
- Update _VALID_URL
    * Lecture urls can be current or archived, previous regex only matched archived urls.
    * Format for archived and current lectures have the same page format, so are handled by the same extractor.

- Update regex to grab m3u8 url and title
    * The site format has changed and so the regex is more flexible in how it grabs the url

- MD5 for test case has changed
    * I've downloaded and confirmed this is the same lecture video

- Removed import for re
   * flake8 complained about an unused import

Closes #22635 