### PR TITLE
[Vimeo] Adds a specific hint for which param to use when a video is password protected

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -68,7 +68,7 @@ class VimeoBaseInfoExtractor(InfoExtractor):
         except ExtractorError as e:
             if isinstance(e.cause, compat_HTTPError) and e.cause.code == 418:
                 raise ExtractorError(
-                    'Unable to log in: bad username or password',
+                    'Unable to log in: bad username or password, use the --video-password option for password protected videos',
                     expected=True)
             raise ExtractorError('Unable to log in')
 


### PR DESCRIPTION
#22094  Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

With Vimeo vids, we see lots of people raising issues (like this one, #15980 ) when they are trying to provide a -Password param, which is the wrong choice for the Vimeo domain for password protected videos.  If a user tries to download a password protected video and provides no password, there is a UI hint in the error message for that...but not if they use the patently wrong param like this.

This patch adds a specific hint on the Vimeo wrong username/password scenario to mitigate this in the future, like #15980
