### PR TITLE
[tele5] Fix extractor

### DIFF
--- a/youtube_dl/extractor/nexx.py
+++ b/youtube_dl/extractor/nexx.py
@@ -364,6 +364,13 @@ class NexxIE(InfoExtractor):
                     'X-Request-Token': request_token,
                 })
 
+        # some videos have 'bumpers' (ads), the API returns a list in that case
+        if isinstance(video, list):
+            for v in video:
+                if compat_str(v['general']['ID']) == video_id:
+                    # the bumpers have differing IDs
+                    video = v
+                    break
         general = video['general']
         title = general['title']
 

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -9,13 +9,13 @@ from ..compat import compat_urlparse
 class Tele5IE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?tele5\.de/(?:[^/]+/)*(?P<id>[^/?#&]+)'
     _TESTS = [{
-        'url': 'https://www.tele5.de/mediathek/filme-online/videos?vid=1549416',
+        'url': 'https://www.tele5.de/sea-patrol/ganze-folge/lebenswege/',
         'info_dict': {
-            'id': '1549416',
+            'id': '1630238',
             'ext': 'mp4',
-            'upload_date': '20180814',
-            'timestamp': 1534290623,
-            'title': 'Pandorum',
+            'upload_date': '20190915',
+            'timestamp': 1568553091,
+            'title': 'Lebenswege'
         },
         'params': {
             'skip_download': True,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix

### Description of your *pull request* and other information

The API returns a list of videos if a 'bumper' (an ad) is supposed to be played before the video. The extractor will now select the video with the originally requested ID. This PR should fix #22666.