### PR TITLE
[nbc] Hardcode v3.14 API to pick up recent programs (fixes #22693)

### DIFF
--- a/youtube_dl/extractor/nbc.py
+++ b/youtube_dl/extractor/nbc.py
@@ -85,7 +85,9 @@ class NBCIE(AdobePassIE):
         permalink, video_id = re.match(self._VALID_URL, url).groups()
         permalink = 'http' + compat_urllib_parse_unquote(permalink)
         response = self._download_json(
-            'https://api.nbc.com/v3/videos', video_id, query={
+            # Hardcode the latest v3 API, because 'v3' aliases to v3.0.0 which
+            # does not return metadata for new programs until hours/days later.
+            'https://api.nbc.com/v3.14/videos', video_id, query={
                 'filter[permalink]': permalink,
                 'fields[videos]': 'description,entitlement,episodeNumber,guid,keywords,seasonNumber,title,vChipRating',
                 'fields[shows]': 'shortTitle',


### PR DESCRIPTION
Starting in Oct. 2019, queries to the "v3" API started omitting recent
programs that are otherwise viewable for free on the NBC website,
causing an IndexException deferencing `response['data'][0]`.

API calls to "v3" are aliased to the v3.0.0 API, although the latest
v3 API is v3.14, (per https://api.nbc.com/).

Programs show up in the v3.0.0 API several hours or days after they
are actually available, so there is no simple test case for this
problem.

This problem does not affect the v3.2 API or later.

Hardcode the v3.14 API for now.
(The latest API is v4.21.0, but we do not know how to use it.)

---
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] Bug fix
---