### PR TITLE
[generic] fix url src's unescape(closes ytdl-org#22704)

### DIFF
--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -21,6 +21,7 @@ from youtube_dl.compat import (
     compat_struct_unpack,
     compat_urllib_parse_unquote,
     compat_urllib_parse_unquote_plus,
+    compat_urllib_parse_quote,
     compat_urllib_parse_urlencode,
 )
 
@@ -75,6 +76,15 @@ class TestCompat(unittest.TestCase):
     def test_compat_urllib_parse_unquote_plus(self):
         self.assertEqual(compat_urllib_parse_unquote_plus('abc%20def'), 'abc def')
         self.assertEqual(compat_urllib_parse_unquote_plus('%7e/abc+def'), '~/abc def')
+
+    def test_compat_urllib_parse_quote(self):
+        self.assertEqual(compat_urllib_parse_quote('abc def'), 'abc%20def')
+        self.assertEqual(compat_urllib_parse_quote('~/abc+def'), '~/abc%2Bdef')
+        self.assertEqual(compat_urllib_parse_quote(''), '')
+        self.assertEqual(compat_urllib_parse_quote('%'), '%25')
+        self.assertEqual(compat_urllib_parse_quote('%%'), '%25%25')
+        self.assertEqual(compat_urllib_parse_quote('%%%'), '%25%25%25')
+        self.assertEqual(compat_urllib_parse_quote('/'), '/')
 
     def test_compat_urllib_parse_urlencode(self):
         self.assertEqual(compat_urllib_parse_urlencode({'abc': 'def'}), 'abc=def')

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -12,6 +12,7 @@ from ..compat import (
     compat_etree_fromstring,
     compat_str,
     compat_urllib_parse_unquote,
+    compat_urllib_parse_quote,
     compat_urlparse,
     compat_xml_parse_error,
 )
@@ -2405,6 +2406,13 @@ class GenericIE(InfoExtractor):
         if camtasia_res is not None:
             return camtasia_res
 
+        # We don't want strings to be unescaped, so escape them
+        # in order to transparently pass through the next unquote
+        # see https://github.com/ytdl-org/youtube-dl/issues/22704
+        webpage = re.sub(
+            "\"(.*?)\"",
+            lambda x: "\"" + compat_urllib_parse_quote(x.group(1)) + "\"",
+            webpage)
         # Sometimes embedded video player is hidden behind percent encoding
         # (e.g. https://github.com/ytdl-org/youtube-dl/issues/2448)
         # Unescaping the whole page allows to handle those cases in a generic way


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes #22704

Take a Google Cloud Storage object named `a/b.c`. When you generate a signed url meant for requesting the object, one component of the signature is the URL. The URL that google's driver generate is `https://storage.googleapis.com/[BUCKET]/a%2Fb.c`. This PR escapes any URL in quotes on the webpage before it goes through a whole page unescape[1] in order to keep the URLs intact.

[1] https://github.com/ytdl-org/youtube-dl/blob/c317b6163b294f4cdc2d1dff96e1a63da1bae910/youtube_dl/extractor/generic.py#L2408-L2411