### PR TITLE
Add --print-final-file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                      /sdcard/Music/ && rm {}'
     --convert-subs FORMAT            Convert the subtitles to other format
                                      (currently supported: srt|ass|vtt|lrc)
+    --print-final-file               Print the final output file name after
+                                     post-processing.
 
 # CONFIGURATION
 

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -297,6 +297,11 @@ def _real_main(argv=None):
     # contents
     if opts.xattrs:
         postprocessors.append({'key': 'XAttrMetadata'})
+    # Print the final file name close to the end
+    if opts.print_final_file:
+        postprocessors.append({
+            'key': 'PrintFilePath'
+        })
     # Please keep ExecAfterDownload towards the bottom as it allows the user to modify the final file in any way.
     # So if the user is able to remove the file before your postprocessor runs it might cause a few problems.
     if opts.exec_cmd:

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -858,6 +858,10 @@ def parseOpts(overrideArguments=None):
         '--convert-subs', '--convert-subtitles',
         metavar='FORMAT', dest='convertsubtitles', default=None,
         help='Convert the subtitles to other format (currently supported: srt|ass|vtt|lrc)')
+    postproc.add_option(
+        '--print-final-file',
+        action='store_true', dest='print_final_file', default=False,
+        help='Print the final output file name after post-processing.')
 
     parser.add_option_group(general)
     parser.add_option_group(network)

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -16,6 +16,7 @@ from .ffmpeg import (
 from .xattrpp import XAttrMetadataPP
 from .execafterdownload import ExecAfterDownloadPP
 from .metadatafromtitle import MetadataFromTitlePP
+from .printfilepath import PrintFilePathPP
 
 
 def get_postprocessor(key):
@@ -36,5 +37,6 @@ __all__ = [
     'FFmpegSubtitlesConvertorPP',
     'FFmpegVideoConvertorPP',
     'MetadataFromTitlePP',
+    'PrintFilePathPP',
     'XAttrMetadataPP',
 ]

--- a/youtube_dl/postprocessor/printfilepath.py
+++ b/youtube_dl/postprocessor/printfilepath.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+
+from .common import PostProcessor
+
+
+class PrintFilePathPP(PostProcessor):
+    def __init__(self, downloader):
+        super(PrintFilePathPP, self).__init__(downloader)
+
+    def run(self, information):
+        self._downloader.to_stdout(information['filepath'])
+        return [], information


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---
As described repeatedly in #5710, #16049, #7137, #14864 or #16461, the value outputted by `--get-filename` does not consider merging of files and post-processing steps, thus not giving the final file name.
As suggested in [#5710 (comment)](https://github.com/ytdl-org/youtube-dl/issues/5710#issuecomment-522213033), this PR adds an additional post-processing option `--print-final-file` that prints the final file name after all post-processing steps have completed.
