### PR TITLE
Check nooverwrite in case postprocessors are to be applied

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1922,6 +1922,18 @@ class YoutubeDL(object):
                         info_dict['__files_to_merge'] = downloaded
                 else:
                     # Just a single file
+                    if self.params.get('nooverwrites', False) and self.params['postprocessors']:
+                        # check if the postprocessed files already exists
+                        filename_real_ext = os.path.splitext(filename)[1][1:]
+                        filename_wo_ext = (
+                            os.path.splitext(filename)[0]
+                            if filename_real_ext == info_dict['ext']
+                            else filename)
+                        files = ['%s.%s' % (filename_wo_ext, pp['preferredcodec']) for pp in self.params['postprocessors']]
+                        files = [f for f in files if os.path.exists(f)]
+                        if files:
+                            self.to_screen('[info] File(s) %s already present' % ", ".join(repr(f) for f in files))
+                            return
                     success = dl(filename, info_dict)
             except (compat_urllib_error.URLError, compat_http_client.HTTPException, socket.error) as err:
                 self.report_error('unable to download video data: %s' % error_to_compat_str(err))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Usually I do something like this:

    python3 -m youtube_dl -w -x --audio-format=mp3 https://youtu.be/s0m3th1ng

and what it does behind the scene is usually download the video (e.g., in webm format), then run ffmpeg to convert the video into mp3, and then the webm file is deleted. If I run this command once again, the whole process goes over once more and effectively the `-w` (no overwrite) flag is ignored.

Indeed, I can avoid downloading again only if I did not remove the webm file. In this patch, at before proceed to download the webm file, we guess what the file would be (in the above example, it means the same filename but with .mp3 extension) and do `os.path.exists()` check to avoid download once the postprocessed file is believed to be exist.

I am not sure this is the best approach to do, especially on the filename guessing part. Comments and suggestions welcomed.