### PR TITLE
RaiPlay: Handle multiple arrays of subtitles

### DIFF
--- a/youtube_dl/extractor/rai.py
+++ b/youtube_dl/extractor/rai.py
@@ -120,6 +120,19 @@ class RaiBaseIE(InfoExtractor):
                 })
         return subtitles
 
+    @staticmethod
+    def _extract_subtitles_from_list(subtitle_array):
+        subtitles = {}
+        if isinstance(subtitle_array, list):
+            for item in subtitle_array:
+                lang = item.get('language')
+                url = item.get('url')
+                if isinstance(url, compat_str) and '' != url and isinstance(lang, compat_str) and '' != lang:
+                    subtitles[lang.lower()] = [{
+                        'ext': url[-3:],
+                        'url': url,
+                    }]
+        return subtitles
 
 class RaiPlayIE(RaiBaseIE):
     _VALID_URL = r'(?P<url>https?://(?:www\.)?raiplay\.it/.+?-(?P<id>%s)\.html)' % RaiBaseIE._UUID_RE
@@ -142,21 +155,25 @@ class RaiPlayIE(RaiBaseIE):
             'season': '2016',
         },
     }, {
-        'url': 'http://www.raiplay.it/video/2014/04/Report-del-07042014-cb27157f-9dd0-4aee-b788-b1f67643a391.html',
+        'url': 'https://www.raiplay.it/video/2019/10/Report-del-21102019-La-fabbrica-della-paura-825ce3a7-8573-46c8-80d2-cde1b519fd01.html',
         'md5': '8970abf8caf8aef4696e7b1f2adfc696',
         'info_dict': {
-            'id': 'cb27157f-9dd0-4aee-b788-b1f67643a391',
-            'ext': 'mp4',
-            'title': 'Report del 07/04/2014',
-            'alt_title': 'S2013/14 - Puntata del 07/04/2014',
+            "id": "825ce3a7-8573-46c8-80d2-cde1b519fd01",
+            "title": "Report - La fabbrica della paura",
+            "alt_title": "St 2019/20 - La fabbrica della paura - 21/10/2019 ",
             'description': 'md5:f27c544694cacb46a078db84ec35d2d9',
-            'thumbnail': r're:^https?://.*\.jpg$',
-            'uploader': 'Rai 5',
-            'creator': 'Rai 5',
-            'duration': 6160,
-            'series': 'Report',
-            'season_number': 5,
-            'season': '2013/14',
+            "ext": "mp4",
+            "series": "Report",
+            "season_number": 7,
+            "season": "2019/20",
+            "subtitles": {
+                "it": [
+                    {
+                        "ext": "srt",
+                        "url": "http://creativemedia4-rai-it.akamaized.net/infocdn/raitre/report/Report_EP_Puntate/11217587.srt"
+                    }
+                ]
+            },
         },
         'params': {
             'skip_download': True,
@@ -191,8 +208,12 @@ class RaiPlayIE(RaiBaseIE):
         timestamp = unified_timestamp(try_get(
             media, lambda x: x['availabilities'][0]['start'], compat_str))
 
-        subtitles = self._extract_subtitles(url, video.get('subtitles'))
-
+        subtitles = {}
+        if '' != video.get('subtitles'):
+            subtitles = self._extract_subtitles(url, video.get('subtitles'))
+        else:
+            if video.get('subtitlesArray'):
+                subtitles = self._extract_subtitles_from_list(video.get('subtitlesArray'))
         info = {
             'id': video_id,
             'title': self._live_title(title) if relinker_info.get(

--- a/youtube_dl/extractor/rai.py
+++ b/youtube_dl/extractor/rai.py
@@ -125,12 +125,17 @@ class RaiBaseIE(InfoExtractor):
     def _extract_subtitles_from_list(subtitle_array, subtitles):
         if isinstance(subtitle_array, list):
             for item in subtitle_array:
-                lang = item.get('language')
-                url = item.get('url')
-                if url_or_none(url) and str_or_none(lang):
-                    subtitles[lang.lower()] = [{
-                        'ext': url[-3:],
-                        'url': url,
+                subtitle_lang = item.get('language')
+                subtitle_url = item.get('url')
+
+                # Handle relative subtitles URL
+                if None ==  url_or_none(subtitle_url):
+                    subtitle_url = 'https://www.raiplay.it'+subtitle_url
+
+                if url_or_none(subtitle_url) and str_or_none(subtitle_lang):
+                    subtitles[subtitle_lang.lower()] = [{
+                        'ext': subtitle_url[-3:],
+                        'url': subtitle_url,
                     }]
         return subtitles
 
@@ -183,7 +188,6 @@ class RaiPlayIE(RaiBaseIE):
         url, video_id = mobj.group('url', 'id')
 
         media = self._download_json(url.replace('.html', '.json'), video_id, 'Downloading video JSON')
-
         title = media['name']
 
         video = media['video']


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bugfix
- [x] Improvement
---

### Description of your *pull request* and other information
Subtitles from RaiPlay could be defined in a new "subtitlesArray" property of the JSON.
This PR allows subtitles to be extracted from the new structure
