### PR TITLE
[francetv] Add fallback video url extraction (closes ytdl-org#22561)

### DIFF
--- a/youtube_dl/extractor/francetv.py
+++ b/youtube_dl/extractor/francetv.py
@@ -166,6 +166,23 @@ class FranceTVIE(InfoExtractor):
                         'url': video_url,
                         'format_id': format_id,
                     })
+
+        if not formats:
+            fallback_info = self._download_json(
+                'https://player.webservices.francetelevisions.fr/v1/videos/%s' % video_id,
+                video_id, 'Downloading fallback video JSON', query={
+                    'device_type': 'mobile',
+                    'browser': 'firefox',
+                })
+
+            video_url = fallback_info['video']['url']
+            format_id = fallback_info['video']['format']
+
+            formats.extend(self._extract_m3u8_formats(
+                sign(video_url, format_id), video_id, 'mp4',
+                entry_protocol='m3u8_native', m3u8_id=format_id,
+                fatal=False))
+
         self._sort_formats(formats)
 
         title = info['titre']


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Issue

The current extractor for FranceTV relies on the following JSON endpoint to retrieve video URLs https://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/. These URLs are then matched based on their extension. Unfortunately, the associated field in the returned manifest is `null` with results outlined in issue #22561 (and for reasons that would necessitate further investigation).

As an example, the following URL exhibits this behavior: https://www.france.tv/france-5/echappees-belles/echappees-belles-saison-13/1066323-l-alsace-de-village-en-village.html.

### Fix

In case no video URLs can be retrieved, this commit falls back on the subsequent endpoint https://player.webservices.francetelevisions.fr/v1/videos/. To prevent a 400 status code with an "Origin unknown" message, the following query parameters are mandatory:

- `device_type` (e.g. `mobile`)
- `browser` (e.g. `firefox`)

### Details

Retrieve the video ID from a URL, for instance, `5da51221-d6c7-4de4-ba5b-46a657ad5a32`:

```console
$ youtube-dl -f best 'https://www.france.tv/france-2/tout-compte-fait/1919537-une-maison-plus-saine-et-plus-ecolo.html'       
[FranceTVSite] 1919537-une-maison-plus-saine-et-plus-ecolo: Downloading webpage
[FranceTV] 5da51221-d6c7-4de4-ba5b-46a657ad5a32: Downloading video JSON
```

The new API answers depending on the `device_type` (maybe some `browser` values get special treatment, but even `ytdl` works fine):

<details>
<summary><code>curl 'https://player.webservices.francetelevisions.fr/v1/videos/5da51221-d6c7-4de4-ba5b-46a657ad5a32?device_type=desktop&browser=firefox'</code></summary>

```json
{
  "video": {
    "workflow": "token-akamai",
    "token": "https://hdfauthftv-a.akamaihd.net/esi/TA?format=json&url=https%3A%2F%2Fcloudreplayfrancetv.akamaized.net%2F1daedb0b835f5%2F236202674_france-domtom_TA.ism%2Fmanifest.mpd",
    "duration": 2705,
    "embed": false,
    "format": "dash",
    "offline_rights": false,
    "is_live": false,
    "drm": false,
    "drm_type": null,
    "license_type": null,
    "player_verification": false,
    "is_DVR": false,
    "spritesheets": [
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead10.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead11.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead12.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead13.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead14.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead15.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead16.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead17.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead18.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead19.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead110.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead111.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead112.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead113.jpeg",
      "https://staticftv-a.akamaihd.net/videospritesheets/202036/5f538b0bdead1/236202674-5f538b0bdead114.jpeg"
    ],
    "is_startover_enabled": false,
    "coming_next": {
      "timecode": 2695,
      "duration": 8
    },
    "url": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/manifest.mpd",
    "captions": []
  },
  "meta": {
    "id": "5da51221-d6c7-4de4-ba5b-46a657ad5a32",
    "plurimedia_id": "236202674",
    "title": "Tout compte fait",
    "additional_title": "Une maison plus saine et plus écolo",
    "pre_title": null,
    "broadcasted_at": "2020-09-05T14:06:45+02:00",
    "image_url": "https://sivideo.webservices.francetelevisions.fr/staticftv/ref_emissions//2020-09-05/PDM_236202674.jpg"
  },
  "streamroot": {
    "enabled": true,
    "content_id": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/manifest.mpd",
    "property": "replay",
    "license": "6fa93815-2dc9-4df6-9967-3bb108d14bb5"
  },
  "markers": {
    "analytics": {
      "isTrackingEnabled": false
    },
    "estat": {
      "crmID": null,
      "dom": null,
      "level1": "france2",
      "level2": "toutcomptefait",
      "level3": "info",
      "level4": "INTEGRAL",
      "level5": null,
      "serial": "260060207982",
      "streamGenre": "web",
      "streamName": "Tout compte fait-05/09/2020-236202674",
      "streamDuration": 2705,
      "newLevel1": "05/09/2020",
      "newLevel2": "5da51221-d6c7-4de4-ba5b-46a657ad5a32",
      "newLevel3": "francetv",
      "newLevel4": "S00_E00",
      "newLevel5": "Une maison plus saine et plus écolo",
      "newLevel6": "online",
      "newLevel7": null,
      "newLevel8": "magazinedinformation",
      "newLevel9": null,
      "newLevel10": null,
      "newLevel11": null,
      "newLevel12": null,
      "newLevel13": null,
      "newLevel14": null,
      "newLevel15": null,
      "mediaContentId": "236202674",
      "mediaDiffMode": "TVOD",
      "mediaChannel": "825",
      "netMeasurement": null
    },
    "npaw": {
      "customDimension1": null,
      "customDimension2": "web-desktop",
      "customDimension3": "toutcomptefait",
      "customDimension4": "france2",
      "customDimension5": "info",
      "customDimension6": "Intégrale",
      "customDimension7": null,
      "customDimension8": "single"
    },
    "pub": {
      "csid": "www.france.tv",
      "caid": "5da51221-d6c7-4de4-ba5b-46a657ad5a32",
      "afid": "137378050",
      "sfid": "6963749",
      "midroll_timecode": [],
      "isPreview6h": false,
      "mediaTailorUrl": null,
      "pollingInterval": -1
    }
  }
}
```

</details>

On mobile, the manifest is HLS m3u8, whereas on desktop, it is DASH MPD.

<details>
<summary>Desktop vs mobile diff</summary>

```diff
4c4
<     "token": "https://hdfauthftv-a.akamaihd.net/esi/TA?format=json&url=https%3A%2F%2Fcloudreplayfrancetv.akamaized.net%2F1daedb0b835f5%2F236202674_france-domtom_TA.ism%2Fmanifest.mpd",
---
>     "token": "https://hdfauthftv-a.akamaihd.net/esi/TA?format=json&url=https%3A%2F%2Fcloudreplayfrancetv.akamaized.net%2F1daedb0b835f5%2F236202674_france-domtom_TA.ism%2Fmaster.m3u8",
7c7
<     "format": "dash",
---
>     "format": "hls",
37c37
<     "url": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/manifest.mpd",
---
>     "url": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/master.m3u8",
51c51
<     "content_id": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/manifest.mpd",
---
>     "content_id": "https://cloudreplayfrancetv.akamaized.net/1daedb0b835f5/236202674_france-domtom_TA.ism/master.m3u8",
93c93
<       "customDimension2": "web-desktop",
---
>       "customDimension2": "web-mobile",
```

</details>

The manifests are both generated by Unified Streaming Platform, and seem to contain the same tracks, with no bitrate or format variations:

<details>
<summary><code>manifest.mpd</code></summary>

```xml
<?xml version="1.0" encoding="utf-8"?>
<!-- Created with Unified Streaming Platform(version=1.8.3) -->
<MPD
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xmlns="urn:mpeg:dash:schema:mpd:2011"
  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
  xmlns:cenc="urn:mpeg:cenc:2013"
  xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd"
  type="static"
  mediaPresentationDuration="PT45M5.365333S"
  maxSegmentDuration="PT15S"
  minBufferTime="PT20S"
  profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264">
  <Period
    id="1"
    duration="PT45M5.365333S">
    <BaseURL>dash/</BaseURL>
    <AdaptationSet
      id="1"
      group="1"
      contentType="audio"
      lang="fr"
      segmentAlignment="true"
      audioSamplingRate="48000"
      mimeType="audio/mp4"
      codecs="mp4a.40.2"
      startWithSAP="1">
      <AudioChannelConfiguration
        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
        value="2">
      </AudioChannelConfiguration>
      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
      <SegmentTemplate
        timescale="48000"
        initialization="236202674_france-domtom_TA-$RepresentationID$.dash"
        media="236202674_france-domtom_TA-$RepresentationID$-$Time$.dash">
        <SegmentTimeline>
          <S t="0" d="96256" r="2" />
          <S d="96256" r="2" />
          <S d="95232" />
          <S d="65536" />
        </SegmentTimeline>
      </SegmentTemplate>
      <Representation
        id="audio_fre=96000"
        bandwidth="96000">
      </Representation>
    </AdaptationSet>
    <AdaptationSet
      id="2"
      group="3"
      contentType="text"
      lang="fr"
      mimeType="application/mp4"
      codecs="stpp"
      startWithSAP="1">
      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle" />
      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="subtitle" />
      <SegmentTemplate
        timescale="1000"
        initialization="236202674_france-domtom_TA-$RepresentationID$.dash"
        media="236202674_france-domtom_TA-$RepresentationID$-$Time$.dash">
        <SegmentTimeline>
          <S t="0" d="10000" r="268" />
          <S d="14433" />
        </SegmentTimeline>
      </SegmentTemplate>
      <Representation
        id="textstream_fre=1000"
        bandwidth="1000">
      </Representation>
    </AdaptationSet>
    <AdaptationSet
      id="3"
      group="2"
      contentType="video"
      par="16:9"
      minBandwidth="400000"
      maxBandwidth="2000000"
      maxWidth="1280"
      maxHeight="720"
      segmentAlignment="true"
      sar="1:1"
      frameRate="25"
      mimeType="video/mp4"
      startWithSAP="1">
      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
      <SegmentTemplate
        timescale="25"
        initialization="236202674_france-domtom_TA-$RepresentationID$.dash"
        media="236202674_france-domtom_TA-$RepresentationID$-$Time$.dash">
        <SegmentTimeline>
          <S t="0" d="50" r="1351" />
          <S d="33" />
        </SegmentTimeline>
      </SegmentTemplate>
      <Representation
        id="video=400000"
        bandwidth="400000"
        width="384"
        height="216"
        codecs="avc1.42C01E"
        scanType="progressive">
      </Representation>
      <Representation
        id="video=950000"
        bandwidth="950000"
        width="640"
        height="360"
        codecs="avc1.4D401F"
        scanType="progressive">
      </Representation>
      <Representation
        id="video=1400000"
        bandwidth="1400000"
        width="960"
        height="540"
        codecs="avc1.4D401F"
        scanType="progressive">
      </Representation>
      <Representation
        id="video=2000000"
        bandwidth="2000000"
        width="1280"
        height="720"
        codecs="avc1.64001F"
        scanType="progressive">
      </Representation>
    </AdaptationSet>
  </Period>
</MPD>
```

</details>

<details>
<summary><code>master.m3u8</code></summary>

```m3u8
#EXTM3U
#EXT-X-VERSION:5
## Created with Unified Streaming Platform(version=1.8.3)
#EXT-X-SESSION-KEY:METHOD=AES-128,URI="https://cloudreplayfrancetv.akamaized.net/keys/crypt.key"

# AUDIO groups
#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio-aacl-96",NAME="Audio Français",LANGUAGE="fr",AUTOSELECT=YES,DEFAULT=YES,CHANNELS="2",URI="236202674_france-domtom_TA-audio_fre=96000.m3u8"

# SUBTITLES groups
#EXT-X-MEDIA:TYPE=SUBTITLES,SUBFORMAT=WebVTT,GROUP-ID="textstream",NAME="Sous-Titres Malentendant",LANGUAGE="fr",AUTOSELECT=YES,DEFAULT=YES,URI="236202674_france-domtom_TA-textstream_fre=1000.m3u8"

# variants
#EXT-X-STREAM-INF:BANDWIDTH=522000,CODECS="mp4a.40.2,avc1.42C01E",RESOLUTION=384x216,FRAME-RATE=25,AUDIO="audio-aacl-96",SUBTITLES="textstream",CLOSED-CAPTIONS=NONE
236202674_france-domtom_TA-video=400000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1105000,CODECS="mp4a.40.2,avc1.4D401F",RESOLUTION=640x360,FRAME-RATE=25,AUDIO="audio-aacl-96",SUBTITLES="textstream",CLOSED-CAPTIONS=NONE
236202674_france-domtom_TA-video=950000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=1582000,CODECS="mp4a.40.2,avc1.4D401F",RESOLUTION=960x540,FRAME-RATE=25,AUDIO="audio-aacl-96",SUBTITLES="textstream",CLOSED-CAPTIONS=NONE
236202674_france-domtom_TA-video=1400000.m3u8
#EXT-X-STREAM-INF:BANDWIDTH=2218000,CODECS="mp4a.40.2,avc1.64001F",RESOLUTION=1280x720,FRAME-RATE=25,AUDIO="audio-aacl-96",SUBTITLES="textstream",CLOSED-CAPTIONS=NONE
236202674_france-domtom_TA-video=2000000.m3u8

# keyframes
#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=53000,CODECS="avc1.42C01E",RESOLUTION=384x216,URI="keyframes/236202674_france-domtom_TA-video=400000.m3u8"
#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=126000,CODECS="avc1.4D401F",RESOLUTION=640x360,URI="keyframes/236202674_france-domtom_TA-video=950000.m3u8"
#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=186000,CODECS="avc1.4D401F",RESOLUTION=960x540,URI="keyframes/236202674_france-domtom_TA-video=1400000.m3u8"
#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=265000,CODECS="avc1.64001F",RESOLUTION=1280x720,URI="keyframes/236202674_france-domtom_TA-video=2000000.m3u8"
```

</details>

My implementation relies on the mobile manifest as a fallback, but @oilarabla rewrote the extraction logic <https://github.com/ytdl-org/youtube-dl/pull/23000#issuecomment-687623558>, which might be more appropriate if the API change is permanent.

### Need examples!

I have no idea of the scale of this issue, so **if you have some examples of non-working videos, please post them below** (or even write some script to find them).