### PR TITLE
[chaturbate] fix url extraction and parsing

### DIFF
--- a/youtube_dl/extractor/chaturbate.py
+++ b/youtube_dl/extractor/chaturbate.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import codecs
 import re
 
 from .common import InfoExtractor
@@ -41,9 +42,9 @@ class ChaturbateIE(InfoExtractor):
         m3u8_urls = []
 
         for m in re.finditer(
-                r'(["\'])(?P<url>http.+?\.m3u8.*?)\1', webpage):
-            m3u8_fast_url, m3u8_no_fast_url = m.group('url'), m.group(
-                'url').replace('_fast', '')
+                r'\\u002[27](?P<url>http.+?\.m3u8.*?)\\u002[27]', webpage):
+            url = codecs.decode(m.group('url'), 'unicode-escape')
+            m3u8_fast_url, m3u8_no_fast_url = url, url.replace('_fast', '')
             for m3u8_url in (m3u8_fast_url, m3u8_no_fast_url):
                 if m3u8_url not in m3u8_urls:
                     m3u8_urls.append(m3u8_url)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes issue #23010 

The chaturbate extractor broke some time this evening. The regex looking for .m3u8 URLs no longer matched anything. Additionally, the URL now needs a bit of extra processing.

The page source contains a large JavaScript string containing an encoded JSON object. The nested quotes, as well as other special characters, are encoded as e.g. \u0022. So, we match the URL delimited by \u0022 or \u0027 (double or single quotes, respectively) and then decode any \uXXXX sequences in the match group.
