### PR TITLE
[pornhub] Fix PC page video extraction

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -245,7 +245,10 @@ class PornHubIE(PornHubBaseIE):
                         continue
                     video_url = definition.get('videoUrl')
                     if not video_url or not isinstance(video_url, compat_str):
-                        video_url = js_vars["quality_%sp" % (definition.get("quality"))]
+                        js_vars_qual = js_vars.get('quality_%sp' % (definition.get('quality')))
+                        if not js_vars_qual:
+                            continue
+                        video_url = js_vars_qual
                     if video_url in video_urls_set:
                         continue
                     video_urls_set.add(video_url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

PornHub extractor can't find video URLs with the PC extractor and the TV page only offers up to 720p, so I moved the pre-existing code for TV pages which parses jsvars into a new function, added a new regex for PC and assign the qualities their video URL from the jsvars.