### PR TITLE
Made changes that work to close #23019

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -626,6 +626,20 @@ class TwitchStreamIE(TwitchBaseIE):
                 'height': int(m.group('height')),
             })
 
+        ## My additions ##
+
+        # TLDR: no need to fix the "real title" problem described in #22501
+        # The issue mentioned in #22501 regarding the "real" title
+        # can be resolved by specifying the 'description' output parameter
+        # i.e. youtube-dl --get-filename -o "%(description)s" https://twitch.tv/channel/
+        # which will output the name that you see under the video as opposed to
+        # the channel's name and the date (as described in #22501).
+
+        # finding fps
+        fps = stream.get('average_fps')
+        game = channel.get('game') or stream.get('game')
+        ## End List ##
+
         return {
             'id': compat_str(stream['_id']),
             'display_id': channel_id,
@@ -638,6 +652,10 @@ class TwitchStreamIE(TwitchBaseIE):
             'view_count': view_count,
             'formats': formats,
             'is_live': True,
+            ## My additions ##
+            'game': game,
+            'average_fps': fps,
+            ## End List ##
         }
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

The issue that I'm addressing can be found here: https://github.com/ytdl-org/youtube-dl/issues/23019

The user asked that there be support for "game" and "title" tags when using "--get-filename" and "-o" together. The feature request also referenced another (closed) report #22501 that asked for support for "fps".  I was able to add support for both fps (denoted "average_fps") and game. Judging from the users report, they'd like the "title" tag to return the name that you see under a twitch livestream. However, the 'title' tag currently returns the name of the twitch channel followed by the date and time.  I did, however, discover that the "description" tag returns the name that appears underneath a video on Twitch livestream and therefore did no additional work for this feature.