### PR TITLE
README.md: clarify how to combine + and /

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ Note that none of the aforementioned meta fields are guaranteed to be present si
 
 Formats for which the value is not known are excluded unless you put a question mark (`?`) after the operator. You can combine format filters, so `-f "[height <=? 720][tbr>500]"` selects up to 720p videos (or videos where the height is not known) with a bitrate of at least 500 KBit/s.
 
-You can merge the video and audio of two formats into a single file using `-f <video-format>+<audio-format>` (requires ffmpeg or avconv installed), for example `-f bestvideo+bestaudio` will download the best video-only format, the best audio-only format and mux them together with ffmpeg/avconv.
+You can merge the video and audio of two formats into a single file using `-f <video-format>+<audio-format>` (requires ffmpeg or avconv installed), for example `-f bestvideo+bestaudio` will download the best video-only format, the best audio-only format and mux them together with ffmpeg/avconv. If you want to merge video and audio formats with precedence, group the video and audio together with `+` and then use `/`, for example `-f 136+140/mp4+m4a/bestvideo+bestaudio`.
 
 Format selectors can also be grouped using parentheses, for example if you want to download the best mp4 and webm formats with a height lower than 480 you can use `-f '(mp4,webm)[height<480]'`.
 
@@ -705,6 +705,9 @@ $ youtube-dl -f 'bestvideo[height<=480]+bestaudio/best[height<=480]'
 
 # Download best video only format but no bigger than 50 MB
 $ youtube-dl -f 'best[filesize<50M]'
+
+# Download preferred formats, with merge and precedence
+$ youtube-dl -f '136+140/mp4+m4a/bestvideo+bestaudio'
 
 # Download best format available via direct link over HTTP/HTTPS protocol
 $ youtube-dl -f '(bestvideo+bestaudio/best)[protocol^=http]'


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

A while back I wanted to use both merging and precedence in format
selection. I encountered complaints from the program and eventually
figured out I was doing it backwards.

I was trying things like this:

`-f 136/mp4/bestvideo+140/m4a/bestaudio`

When what I needed to do was:

`-f 136+140/mp4+m4a/bestvideo+bestaudio`

I wrote a couple lines to try to clarify this. I hope this is helpful.

--Matt