### PR TITLE
M4A files use 'mutagen' for thumbnail embedding

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -3,24 +3,19 @@ from __future__ import unicode_literals
 
 
 import os
-import subprocess
 
 try:
     import imghdr
-    from mutagen.id3 import PictureType, ID3, APIC
-    from mutagen.mp4 import MP4, MP4Cover
+    from mutagen.id3 import PictureType, ID3, APIC, ID3NoHeaderError
+    from mutagen.mp4 import MP4, MP4Cover, MP4MetadataError
 except ImportError:
     raise Exception('[embedthumbnail] Mutagen isn\'t found as a dependency to embed thumbnails!')
 
 from .ffmpeg import FFmpegPostProcessor
 
 from ..utils import (
-    check_executable,
-    encodeArgument,
     encodeFilename,
-    PostProcessingError,
-    prepend_extension,
-    shell_quote
+    PostProcessingError
 )
 
 
@@ -49,41 +44,36 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
         if info['ext'] == 'mp3':
             try:
-               meta = ID3(filename)
-            except:
-               raise EmbedThumbnailPPError("MP3 file doesn't have a existing ID3v2 tag.")
-            
-            # Update older tags (eg. ID3v1) to a newer version,
-            # which supports embedded-thumbnails (e.g ID3v2.3).
-            # NOTE: ID3v2.4 might not be supported by programs.
-            meta.update_to_v23()
-            
+                meta = ID3(filename)
+            except ID3NoHeaderError:
+                raise EmbedThumbnailPPError("MP3 file doesn't have a existing ID3v2 tag.")
+
             # Appends a Cover-front thumbnail, it's the most common
             # type of thumbnail distributed with.
             meta.add(APIC(
-               data= open(thumbnail_filename, 'rb').read(),
-               mime= 'image/'+imghdr.what(thumbnail_filename),
-               type= PictureType.COVER_FRONT))
-            
-            meta.save() # Save the changes to file, does in-place replacement.
+                data=open(thumbnail_filename, 'rb').read(),
+                mime='image/' + imghdr.what(thumbnail_filename),
+                type=PictureType.COVER_FRONT))
+
+            meta.save()  # Save the changes to file, does in-place replacement.
             self._downloader.to_screen('[mutagen.id3] Merged Thumbnail into "%s"' % filename)
-            
+
             if not self._already_have_thumbnail:
-               os.remove(encodeFilename(thumbnail_filename))
+                os.remove(encodeFilename(thumbnail_filename))
 
         elif info['ext'] in ['m4a', 'mp4']:
             try:
                 meta = MP4(filename)
-            except:
+            except MP4MetadataError:
                 raise EmbedThumbnailPPError("MPEG-4 file's atomic structure for embedding isn't correct!")
 
             # NOTE: the 'covr' atom is a non-standard MPEG-4 atom,
             # Apple iTunes 'M4A' files include the 'moov.udta.meta.ilst' atom.
             meta.tags['covr'] = [MP4Cover(
-                data= open(thumbnail_filename, 'rb').read(),
-                imageformat= MP4Cover.FORMAT_JPEG if \
-                            imghdr.what(thumbnail_filename) == 'jpeg' \
-                            else MP4Cover.FORMAT_PNG)]
+                data=open(thumbnail_filename, 'rb').read(),
+                imageformat=MP4Cover.FORMAT_JPEG if
+                imghdr.what(thumbnail_filename) == 'jpeg'
+                else MP4Cover.FORMAT_PNG)]
 
             meta.save()
             self._downloader.to_screen('[mutagen.mp4] Merged thumbnail to "%s"' % filename)

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -5,9 +5,12 @@ from __future__ import unicode_literals
 import os
 import subprocess
 
-import imghdr
-from mutagen.id3 import PictureType, ID3, APIC
-from mutagen.mp4 import MP4, MP4Cover
+try:
+    import imghdr
+    from mutagen.id3 import PictureType, ID3, APIC
+    from mutagen.mp4 import MP4, MP4Cover
+except ImportError:
+    raise Exception('[embedthumbnail] Mutagen isn\'t found as a dependency to embed thumbnails!')
 
 from .ffmpeg import FFmpegPostProcessor
 

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -63,8 +63,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             meta.add(APIC(
                data= open(thumbnail_filename, 'rb').read(),
                mime= 'image/'+imghdr.what(thumbnail_filename),
-               type= PictureType.COVER_FRONT
-            ))
+               type= PictureType.COVER_FRONT))
             
             meta.save() # Save the changes to file, does in-place replacement.
             self._downloader.to_screen('[mutagen.id3] Merged Thumbnail into "%s"' % filename)
@@ -84,8 +83,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 data= open(thumbnail_filename, 'rb').read(),
                 imageformat= MP4Cover.FORMAT_JPEG if \
                             imghdr.what(thumbnail_filename) == 'jpeg' \
-                            else MP4Cover.FORMAT_PNG
-            )]
+                            else MP4Cover.FORMAT_PNG)]
 
             meta.save()
             self._downloader.to_screen('[mutagen.mp4] Merged thumbnail to "%s"' % filename)


### PR DESCRIPTION
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] The motive is *Improvement*

---
From the beginning, `AtomicParsley` was used for embedding artworks into `moov.udata.meta.ilst` atom. This required the executable to be in path for the sole reason of "embedding artworks".

Which seemed quite infuriating to me. So, I implemented `mutagen` for embedding thumbnails into M4A files, which is a native Python library for tagging multimedia files.

> Installing a PyPI package is easier than install a executable in PATH in my opinion, also compiling is required on some systems.

