### PR TITLE
Add language prefixes for --sub-lang

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1664,7 +1664,13 @@ class YoutubeDL(object):
             requested_langs = available_subs.keys()
         else:
             if self.params.get('subtitleslangs', False):
-                requested_langs = self.params.get('subtitleslangs')
+                requested_langs = []
+                for lang in self.params.get('subtitleslangs'):
+                    if lang.endswith('*'):
+                        prefix = lang[:-1]
+                        requested_langs += [l for l in available_subs.keys() if l.startswith(prefix)]
+                    else:
+                        requested_langs.append(lang)
             elif 'en' in available_subs:
                 requested_langs = ['en']
             else:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Allows selecting subtitle language by prefix with `--sub-lang`. For example, `--sub-lang 'en*'` may select `en`, `en-US`, `en-GB`, etc., whichever are available.

Only prefixes are supported (e.g. `*CA` doesn't work), because they are by far the most common use case -- choosing a language ignoring the dialect.

Closes #8120