### PR TITLE
fixed error when parsing fm4 url

### DIFF
--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -192,7 +192,7 @@ class ORFRadioIE(InfoExtractor):
 class ORFFM4IE(ORFRadioIE):
     IE_NAME = 'orf:fm4'
     IE_DESC = 'radio FM4'
-    _VALID_URL = r'https?://(?P<station>fm4)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>\w+)'
+    _VALID_URL = r'https?://(?P<station>fm4)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>4\w+)'
 
     _TEST = {
         'url': 'https://fm4.orf.at/player/20200101/4HOP',

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -195,16 +195,16 @@ class ORFFM4IE(ORFRadioIE):
     _VALID_URL = r'https?://(?P<station>fm4)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>4\w+)'
 
     _TEST = {
-        'url': 'https://fm4.orf.at/player/20200101/4HOP',
-        'md5': '643bcd94f1f08128b53656b18a6a1f14',
+        'url': 'http://fm4.orf.at/player/20170107/4CC',
+        'md5': '2b0be47375432a7ef104453432a19212',
         'info_dict': {
-            'id': '2020-01-01_2156_tl_54_7DaysWed16_90867',
+            'id': '2017-01-07_2100_tl_54_7DaysSat18_31295',
             'ext': 'mp3',
-            'title': 'House Of Pain',
-            'description': '<p>Der mittwöchige Streifzug durch die Welt der schweren Riffs und grollenden Bässe, metallischen Sounds und düsteren Elektronik. Mit Christian Fuchs und seiner Gang.</p>',
-            'duration': 7288.0,
-            'timestamp': 1577912190.0,
-            'upload_date': '20200101',
+            'title': 'Solid Steel Radioshow',
+            'description': 'Die Mixshow von Coldcut und Ninja Tune.',
+            'duration': 3599,
+            'timestamp': 1483819257,
+            'upload_date': '20170107',
         },
         'skip': 'Shows from ORF radios are only available for 7 days.'
     }
@@ -216,16 +216,15 @@ class ORFOE1IE(ORFRadioIE):
     _VALID_URL = r'https?://(?P<station>oe1)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>\w+)'
 
     _TEST = {
-        'url': 'https://oe1.orf.at/player/20191231/583045',
-        'md5': '3c37eb61909609c9e7069957c2ba453d',
+        'url': 'http://oe1.orf.at/player/20170108/456544',
+        'md5': '34d8a6e67ea888293741c86a099b745b',
         'info_dict': {
-            'id': '2019-12-31_0659_tl_51_7DaysTue6_1159893',
+            'id': '2017-01-08_0759_tl_51_7DaysSun6_256141',
             'ext': 'mp3',
-            'title': 'Ö1 Morgenjournal',
-            'description': '<p>mit Kultur aktuell</p>',
-            'duration': 1992.0,
-            'timestamp': 1577771996.0,
-            'upload_date': '20191231',
+            'title': 'Morgenjournal',
+            'duration': 609,
+            'timestamp': 1483858796,
+            'upload_date': '20170108',
         },
         'skip': 'Shows from ORF radios are only available for 7 days.'
     }

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -161,9 +161,6 @@ class ORFRadioIE(InfoExtractor):
         show_date = mobj.group('date')
         show_id = mobj.group('show')
 
-        if station == 'fm4':
-            show_id = '4%s' % show_id
-
         data = self._download_json(
             'http://audioapi.orf.at/%s/api/json/current/broadcast/%s/%s' % (station, show_id, show_date),
             show_id
@@ -198,16 +195,16 @@ class ORFFM4IE(ORFRadioIE):
     _VALID_URL = r'https?://(?P<station>fm4)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>\w+)'
 
     _TEST = {
-        'url': 'http://fm4.orf.at/player/20170107/CC',
-        'md5': '2b0be47375432a7ef104453432a19212',
+        'url': 'https://fm4.orf.at/player/20200101/4HOP',
+        'md5': '643bcd94f1f08128b53656b18a6a1f14',
         'info_dict': {
-            'id': '2017-01-07_2100_tl_54_7DaysSat18_31295',
+            'id': '2020-01-01_2156_tl_54_7DaysWed16_90867',
             'ext': 'mp3',
-            'title': 'Solid Steel Radioshow',
-            'description': 'Die Mixshow von Coldcut und Ninja Tune.',
-            'duration': 3599,
-            'timestamp': 1483819257,
-            'upload_date': '20170107',
+            'title': 'House Of Pain',
+            'description': '<p>Der mittwöchige Streifzug durch die Welt der schweren Riffs und grollenden Bässe, metallischen Sounds und düsteren Elektronik. Mit Christian Fuchs und seiner Gang.</p>',
+            'duration': 7288.0,
+            'timestamp': 1577912190.0,
+            'upload_date': '20200101',
         },
         'skip': 'Shows from ORF radios are only available for 7 days.'
     }
@@ -219,15 +216,16 @@ class ORFOE1IE(ORFRadioIE):
     _VALID_URL = r'https?://(?P<station>oe1)\.orf\.at/player/(?P<date>[0-9]+)/(?P<show>\w+)'
 
     _TEST = {
-        'url': 'http://oe1.orf.at/player/20170108/456544',
-        'md5': '34d8a6e67ea888293741c86a099b745b',
+        'url': 'https://oe1.orf.at/player/20191231/583045',
+        'md5': '3c37eb61909609c9e7069957c2ba453d',
         'info_dict': {
-            'id': '2017-01-08_0759_tl_51_7DaysSun6_256141',
+            'id': '2019-12-31_0659_tl_51_7DaysTue6_1159893',
             'ext': 'mp3',
-            'title': 'Morgenjournal',
-            'duration': 609,
-            'timestamp': 1483858796,
-            'upload_date': '20170108',
+            'title': 'Ö1 Morgenjournal',
+            'description': '<p>mit Kultur aktuell</p>',
+            'duration': 1992.0,
+            'timestamp': 1577771996.0,
+            'upload_date': '20191231',
         },
         'skip': 'Shows from ORF radios are only available for 7 days.'
     }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

removed if clause for special fm4 show_id handling, as url has been changed to a new format where the station is natively correct.

updated only test url of ORFRadio Extractors. While other extractors are not updated because they worked with a simple test in the console with random current links and the links would get invalid again quickly anyway in a short time.
