### PR TITLE
[eroprofile] Update regexes

### DIFF
--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -82,7 +82,7 @@ class EroProfileIE(InfoExtractor):
         title = self._html_search_regex(
             [r'<h1[^>]*>([^<]+)</h1>', r'Title:</th><td>([^<]+)</td>'],
             webpage, 'title')
-        thumbnail = self._search_regex(
+        thumbnail = self._html_search_regex(
             [r'<div class="playlistItem current">.*?<img src="([^"]+)"', r'onclick="showVideoPlayer\(\)"><img src="([^"]+)'],
             webpage, 'thumbnail', fatal=False)
 

--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -83,7 +83,7 @@ class EroProfileIE(InfoExtractor):
             [r'<h1[^>]*>([^<]+)</h1>', r'Title:</th><td>([^<]+)</td>'],
             webpage, 'title')
         thumbnail = self._search_regex(
-            [r'<div class="playlistItem current">.*<img src="([^"]+)"', r'onclick="showVideoPlayer\(\)"><img src="([^"]+)'],
+            [r'<div class="playlistItem current">.*?<img src="([^"]+)"', r'onclick="showVideoPlayer\(\)"><img src="([^"]+)'],
             webpage, 'thumbnail', fatal=False)
 
         return {

--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -80,9 +80,9 @@ class EroProfileIE(InfoExtractor):
         video_url = unescapeHTML(self._search_regex(
             r'<source src="([^"]+)', webpage, 'video url'))
         title = self._html_search_regex(
-            r'Title:</th><td>([^<]+)</td>', webpage, 'title')
+            r'<h1[^>]*>([^<]+)</h1>', webpage, 'title')
         thumbnail = self._search_regex(
-            r'onclick="showVideoPlayer\(\)"><img src="([^"]+)',
+            r'<div class="playlistItem current">.*<img src="([^"]+)"',
             webpage, 'thumbnail', fatal=False)
 
         return {

--- a/youtube_dl/extractor/eroprofile.py
+++ b/youtube_dl/extractor/eroprofile.py
@@ -80,9 +80,10 @@ class EroProfileIE(InfoExtractor):
         video_url = unescapeHTML(self._search_regex(
             r'<source src="([^"]+)', webpage, 'video url'))
         title = self._html_search_regex(
-            r'<h1[^>]*>([^<]+)</h1>', webpage, 'title')
+            [r'<h1[^>]*>([^<]+)</h1>', r'Title:</th><td>([^<]+)</td>'],
+            webpage, 'title')
         thumbnail = self._search_regex(
-            r'<div class="playlistItem current">.*<img src="([^"]+)"',
+            [r'<div class="playlistItem current">.*<img src="([^"]+)"', r'onclick="showVideoPlayer\(\)"><img src="([^"]+)'],
             webpage, 'thumbnail', fatal=False)
 
         return {


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It updates the regular expressions following the eroprofile.com site update pointed out in #23200. The title is hopefully stable as long as they stick to `<h1>` elements; the thumbnail is a bit more fragile, but at least it's optional. (I could only find it in one place on the page, in the playlist bar above the video, together with other thumbnails.)

Note that the first video in `_TESTS` appears to no longer exist, but I assume that's unrelated.