### PR TITLE
[Youporn] Regex fix for newer URLs

### DIFF
--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -57,7 +57,27 @@ class YouPornIE(InfoExtractor):
         'params': {
             'skip_download': True,
         },
-    }]
+    }, {
+        # the source urls in the "formats" array of newer videos might have a new format
+        'url': 'https://www.youporn.com/watch/15573378/visit-x-unschuldiges-deutsches-luder-bekommt-hintern-versohlen/',
+        'md5': '3744d24c50438cf5b6f6d59feb5055c2',
+        'info_dict': {
+            'id': '15573378',
+            'display_id': 'visit-x-unschuldiges-deutsches-luder-bekommt-hintern-versohlen',
+            'ext': 'mp4',
+            'title': 'VISIT-X | Unschuldiges deutsches Luder bekommt Hintern versohlen',
+            'description': 'Watch VISIT-X | Unschuldiges deutsches Luder bekommt Hintern versohlen online on YouPorn.com. YouPorn is the largest Blowjob porn video site with the hottest selection of free, high quality german movies. Enjoy our HD porno videos on any device of your choosing!',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            'uploader': 'Visit-X',
+            'upload_date': '20190910',
+            'average_rating': int,
+            'view_count': int,
+            'comment_count': int,
+            'categories': list,
+            'tags': list,
+            'age_limit': 18,
+        },
+   }]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
@@ -147,7 +167,7 @@ class YouPornIE(InfoExtractor):
             webpage, 'uploader', fatal=False)
         upload_date = unified_strdate(self._html_search_regex(
             [r'Date\s+[Aa]dded:\s*<span>([^<]+)',
-             r'(?s)<div[^>]+class=["\']videoInfo(?:Date|Time)["\'][^>]*>(.+?)</div>'],
+             r'(?s)<div[^>]+class=["\']video-uploaded["\'][^>]*>[^<]+?<span>([^<]+)'],
             webpage, 'upload date', fatal=False))
 
         age_limit = self._rta_search(webpage)

--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -167,7 +167,8 @@ class YouPornIE(InfoExtractor):
             webpage, 'uploader', fatal=False)
         upload_date = unified_strdate(self._html_search_regex(
             [r'Date\s+[Aa]dded:\s*<span>([^<]+)',
-             r'(?s)<div[^>]+class=["\']video-uploaded["\'][^>]*>[^<]+?<span>([^<]+)'],
+             r'(?s)<div[^>]+class=["\']video-uploaded["\'][^>]*>[^<]+?<span>([^<]+)',
+             r'(?s)<div[^>]+class=["\']videoInfo(?:Date|Time)["\'][^>]*>(.+?)</div>'],
             webpage, 'upload date', fatal=False))
 
         age_limit = self._rta_search(webpage)

--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -77,7 +77,7 @@ class YouPornIE(InfoExtractor):
             'tags': list,
             'age_limit': 18,
         },
-   }]
+    }]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)

--- a/youtube_dl/extractor/youporn.py
+++ b/youtube_dl/extractor/youporn.py
@@ -119,8 +119,9 @@ class YouPornIE(InfoExtractor):
             # Video URL's path looks like this:
             #  /201012/17/505835/720p_1500k_505835/YouPorn%20-%20Sex%20Ed%20Is%20It%20Safe%20To%20Masturbate%20Daily.mp4
             #  /201012/17/505835/vl_240p_240k_505835/YouPorn%20-%20Sex%20Ed%20Is%20It%20Safe%20To%20Masturbate%20Daily.mp4
+            #  /201909/10/247477171/720P_1500K_247477171.mp4?rate=350k&burst=1600k&validfrom=1578384700&validto=1578399100&hash=0pse1EbrOQbQF%2FJjZgeLX4K%2F0qw%3D
             # We will benefit from it by extracting some metadata
-            mobj = re.search(r'(?P<height>\d{3,4})[pP]_(?P<bitrate>\d+)[kK]_\d+/', video_url)
+            mobj = re.search(r'(?P<height>\d{3,4})[pP]_(?P<bitrate>\d+)[kK]_\d+', video_url)
             if mobj:
                 height = int(mobj.group('height'))
                 bitrate = int(mobj.group('bitrate'))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---
The URLs of new videos have a different format. A slash in the regex prevented the information from being read.