### PR TITLE
[facebook] Add support for user video playlist

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -334,6 +334,7 @@ from .eyedotv import EyedoTVIE
 from .facebook import (
     FacebookIE,
     FacebookPluginsVideoIE,
+    FacebookUserIE,
 )
 from .faz import FazIE
 from .fc2 import (

--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -512,6 +512,7 @@ class FacebookPluginsVideoIE(InfoExtractor):
             compat_urllib_parse_unquote(self._match_id(url)),
             FacebookIE.ie_key())
 
+
 class FacebookUserIE(InfoExtractor):
     _VALID_URL = r'(?P<url>https?://(?:[^/]+\.)?facebook\.com/(?:pg/)?(?P<id>[^/?#&]+))/videos(?!/\d)'
 
@@ -549,7 +550,7 @@ class FacebookUserIE(InfoExtractor):
             page, 'collection_token', default=None)
         cursor = None
         entries = []
-            
+
         if fb_url_mobj.group('type') == 'page':
             endpoint = 'PagesVideoHubVideoContainerPagelet'
             a_class = '_5asm'
@@ -590,7 +591,7 @@ class FacebookUserIE(InfoExtractor):
                 user_id, fatal=True)
 
             for video in re.findall(
-                r'href="(?P<url>[^"]+)"[^>]+%s' % a_class,
+                r'href="(?P<url>[^"]+)"[^>]+%s' % a_class, 
                 js_data['payload']):
                 entries.append(
                     self.url_result(
@@ -599,7 +600,7 @@ class FacebookUserIE(InfoExtractor):
 
             cursor = None
             if fb_url_mobj.group('type') == 'page':
-                if not 'instances' in js_data['jsmods']:
+                if 'instances' not in js_data['jsmods']:
                     break
                 for parent in js_data['jsmods']['instances']:
                     if type(parent) is list:

--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -518,13 +518,15 @@ class FacebookUserIE(InfoExtractor):
 
     _TESTS = [{
         # page
-        'url': 'https://www.facebook.com/uniladmag/videos'
+        'url': 'https://www.facebook.com/Coca-Cola/videos/?ref=page_internal',
+        'info_dict': {
+            'id': 'Coca-Cola'
+        },
+        'playlist_mincount': 90,
     }, {
-        # page
-        'url': 'https://www.facebook.com/Coca-Cola/videos/?ref=page_internal'
-    }, {
-        # profile
-        'url': 'https://www.facebook.com/zuck/videos'
+        # profile (requires login)
+        'url': 'https://www.facebook.com/zuck/videos',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -556,7 +558,7 @@ class FacebookUserIE(InfoExtractor):
             a_class = '_5asm'
             data = {
                 'page': page_id
-                }
+            }
         elif fb_url_mobj.group('type') == 'profile':
             if not (fb_dtsg_ag and pagelet_token and collection_token):
                 raise ExtractorError('You must be logged in to extract profile videos', expected=True)
@@ -570,7 +572,7 @@ class FacebookUserIE(InfoExtractor):
                 'pagelet_token': pagelet_token,
                 'order': None,
                 'sk': 'videos'
-                }
+            }
 
         for page_num in itertools.count(1):
             js_data_page = self._download_webpage(
@@ -582,7 +584,7 @@ class FacebookUserIE(InfoExtractor):
                         {**data, 'cursor': cursor},
                         separators=(',', ':')),
                     '__a': 1
-                    })
+                })
 
             js_data = self._parse_json(
                 self._search_regex(
@@ -591,8 +593,8 @@ class FacebookUserIE(InfoExtractor):
                 user_id, fatal=True)
 
             for video in re.findall(
-                r'href="(?P<url>[^"]+)"[^>]+%s' % a_class, 
-                js_data['payload']):
+                    r'href="(?P<url>[^"]+)"[^>]+%s' % a_class,
+                    js_data['payload']):
                 entries.append(
                     self.url_result(
                         'https://www.facebook.com%s' % video,

--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -26,6 +26,7 @@ from ..utils import (
     sanitized_Request,
     try_get,
     urlencode_postdata,
+    merge_dicts,
 )
 
 
@@ -581,7 +582,7 @@ class FacebookUserIE(InfoExtractor):
                 query={
                     'fb_dtsg_ag': fb_dtsg_ag if fb_dtsg_ag else None,
                     'data': json.dumps(
-                        {**data, 'cursor': cursor},
+                        merge_dicts(data, {'cursor': cursor}),
                         separators=(',', ':')),
                     '__a': 1
                 })

--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -518,7 +518,7 @@ class FacebookPluginsVideoIE(InfoExtractor):
 class FacebookUserIE(InfoExtractor):
     _VALID_URL = r'https?://(?:[^/]+\.)?facebook\.com/(?:pg/)?(?P<id>[^/?#&]+)/videos'
     IE_NAME = 'facebook:user'
-    
+
     @classmethod
     def suitable(cls, url):
         return (False

--- a/youtube_dl/extractor/facebook.py
+++ b/youtube_dl/extractor/facebook.py
@@ -514,7 +514,7 @@ class FacebookPluginsVideoIE(InfoExtractor):
 
 
 class FacebookUserIE(InfoExtractor):
-    _VALID_URL = r'(?P<url>https?://(?:[^/]+\.)?facebook\.com/(?:pg/)?(?P<id>[^/?#&]+))/videos(?!/\d)'
+    _VALID_URL = r'(?P<url>https?://(?:[^/]+\.)?facebook\.com/(?:pg/)?(?P<id>[^/?#&]+))/videos(?!/[\w\.])'
 
     _TESTS = [{
         # page


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

Fixes #10563

I've implemented Facebook user video playlists. Apologies if it's a bit unclean, I'm still a bit of a novice. It uses the ajax pagelet API for full compatibility (https://www.facebook.com/api/graphql/ didn't support some pages for some reason). A limitation is that you must be signed in (i.e. via --cookies) to extract videos from user profiles instead of a page.