### PR TITLE
[archiveorg] Fix extraction

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1401,7 +1401,48 @@ Line 1
         '''
 
         self.assertEqual(get_element_by_class('foo', html), 'nice')
+        self.assertEqual(get_element_by_class('foo', html, include_tag=True), '<span class="foo bar">nice</span>')
         self.assertEqual(get_element_by_class('no-such-class', html), None)
+
+        html = '''
+            <span class="foo bar"/>
+        '''
+
+        self.assertEqual(get_element_by_class('foo', html), None)
+        self.assertEqual(get_element_by_class('foo', html, include_tag=True), '<span class="foo bar"/>')
+
+        html = '''
+            <span class="foo bar"></span>
+        '''
+
+        self.assertEqual(get_element_by_class('foo', html), '')
+        self.assertEqual(get_element_by_class('foo', html, include_tag=True), '<span class="foo bar"></span>')
+
+        html = '''
+            <span class="content-section__wrap bar">nice</span>
+        '''
+
+        self.assertEqual(get_element_by_class('content-section__wrap', html), 'nice')
+        self.assertEqual(get_element_by_class('content-section__wrap', html, include_tag=True), '<span class="content-section__wrap bar">nice</span>')
+
+        html = '''
+            <span class="-test-hyphen">nice</span>
+        '''
+
+        self.assertEqual(get_element_by_class('-test-hyphen', html), 'nice')
+
+        html = '''
+            <span class="_test_underscore">nice</span>
+        '''
+
+        self.assertEqual(get_element_by_class('_test_underscore', html), 'nice')
+
+        html = '''
+            <span class="ä-umlaut ↑-unicode">nice</span>
+        '''
+
+        self.assertEqual(get_element_by_class('ä-umlaut', html), 'nice')
+        self.assertEqual(get_element_by_class('↑-unicode', html), 'nice')
 
     def test_get_element_by_attribute(self):
         html = '''

--- a/youtube_dl/extractor/archiveorg.py
+++ b/youtube_dl/extractor/archiveorg.py
@@ -52,10 +52,13 @@ class ArchiveOrgIE(InfoExtractor):
         def get_optional(metadata, field):
             return metadata.get(field, [None])[0]
 
-        metadata = self._download_json(
+        json_metadata = self._download_json(
             'http://archive.org/details/' + video_id, video_id, query={
                 'output': 'json',
-            }).get('metadata', {})
+            }, fatal=False)
+        metadata = (json_metadata.get('metadata', {})
+                    if isinstance(json_metadata, dict)
+                    else {})
         info.update({
             'title': get_optional(metadata, 'title') or info.get('title'),
             'description': clean_html(get_optional(metadata, 'description')),

--- a/youtube_dl/extractor/archiveorg.py
+++ b/youtube_dl/extractor/archiveorg.py
@@ -40,9 +40,12 @@ class ArchiveOrgIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(
             'http://archive.org/embed/' + video_id, video_id)
+        input_element_with_playlist = self._search_regex(
+            r'(<\s*input.*\s*class\s*=\s*[\'"].*\s*js-play8-playlist\s*.*[\'"]\s*.*>)',
+            webpage, 'jwplayer playlist')
         jwplayer_playlist = self._parse_json(self._search_regex(
-            r"(?s)Play\('[^']+'\s*,\s*(\[.+\])\s*,\s*{.*?}\)",
-            webpage, 'jwplayer playlist'), video_id)
+            r'.*\s+value\s*=\s*[\'"](.+)[\'"][\s/]',
+            input_element_with_playlist, 'playlist data'), video_id)
         info = self._parse_jwplayer_data(
             {'playlist': jwplayer_playlist}, video_id, base_url=url)
 
@@ -52,7 +55,7 @@ class ArchiveOrgIE(InfoExtractor):
         metadata = self._download_json(
             'http://archive.org/details/' + video_id, video_id, query={
                 'output': 'json',
-            })['metadata']
+            }).get('metadata', {})
         info.update({
             'title': get_optional(metadata, 'title') or info.get('title'),
             'description': clean_html(get_optional(metadata, 'description')),

--- a/youtube_dl/extractor/archiveorg.py
+++ b/youtube_dl/extractor/archiveorg.py
@@ -4,6 +4,7 @@ from .common import InfoExtractor
 from ..utils import (
     clean_html,
     extract_attributes,
+    get_element_by_class,
     unified_strdate,
 )
 
@@ -41,9 +42,8 @@ class ArchiveOrgIE(InfoExtractor):
         video_id = self._match_id(url)
         webpage = self._download_webpage(
             'http://archive.org/embed/' + video_id, video_id)
-        input_element_with_playlist = self._search_regex(
-            r'(<\s*input.*\s*class\s*=\s*[\'"].*\s*js-play8-playlist\s*.*[\'"]\s*.*>)',
-            webpage, 'jwplayer playlist')
+        input_element_with_playlist = get_element_by_class(
+            'js-play8-playlist', webpage, include_tag=True)
         jwplayer_playlist = self._parse_json(extract_attributes(
             input_element_with_playlist)['value'], video_id)
         info = self._parse_jwplayer_data(

--- a/youtube_dl/extractor/archiveorg.py
+++ b/youtube_dl/extractor/archiveorg.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 from ..utils import (
-    unified_strdate,
     clean_html,
+    extract_attributes,
+    unified_strdate,
 )
 
 
@@ -43,9 +44,8 @@ class ArchiveOrgIE(InfoExtractor):
         input_element_with_playlist = self._search_regex(
             r'(<\s*input.*\s*class\s*=\s*[\'"].*\s*js-play8-playlist\s*.*[\'"]\s*.*>)',
             webpage, 'jwplayer playlist')
-        jwplayer_playlist = self._parse_json(self._search_regex(
-            r'.*\s+value\s*=\s*[\'"](.+)[\'"][\s/]',
-            input_element_with_playlist, 'playlist data'), video_id)
+        jwplayer_playlist = self._parse_json(extract_attributes(
+            input_element_with_playlist)['value'], video_id)
         info = self._parse_jwplayer_data(
             {'playlist': jwplayer_playlist}, video_id, base_url=url)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The archive.org website has changed the way it embeds the JW Player playlist. That's why the regular expression can't find the playlist and the extractor is currently not working.

This pull request updates the extraction of the playlist to work with the new version of archive.org.

There's an `input` element with the class `js-play8-playlist`. Its value contains the playlist.

Closes #21330, closes #23586, closes #23700.