### PR TITLE
[utils.py:js_to_json] add support for octal escape sequences

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -918,6 +918,9 @@ class TestUtil(unittest.TestCase):
         inp = '''{segments: [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}'''
         self.assertEqual(js_to_json(inp), '''{"segments": [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}''')
 
+        inp = '''{label: "Fran\347ais"}'''
+        self.assertEqual(js_to_json(inp), '''{"label": "Fran\u00e7ais"}''')
+
     def test_js_to_json_edgecases(self):
         on = js_to_json("{abc_def:'1\\'\\\\2\\\\\\'3\"4'}")
         self.assertEqual(json.loads(on), {"abc_def": "1'\\2\\'3\"4"})


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some websites use (to my knowledge now deprecated) Javascript octal escape sequences. This pull request aims to provider support for those in `js_to_json()`. This PR is needed to implement the extractor for [Enseigner TV5 Monde](https://enseigner.tv5monde.com) (PR #22958).
