### PR TITLE
url_transparent and playlists? /NOT FOR MERGE

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -887,6 +887,10 @@ class YoutubeDL(object):
             new_result = info.copy()
             new_result.update(force_properties)
 
+            if new_result.get('entries', False):
+                for elem in new_result['entries']:
+                    elem.update(force_properties)
+
             # Extracted info may not be a video result (i.e.
             # info.get('_type', 'video') != video) but rather an url or
             # url_transparent. In such cases outer metadata (from ie_result)

--- a/youtube_dl/extractor/ceskatelevize.py
+++ b/youtube_dl/extractor/ceskatelevize.py
@@ -300,25 +300,24 @@ class CeskaTelevizePoradyIE(InfoExtractor):
             webpage, 'iframe player url', group='url')), query={
                 'autoStart': 'true',
         })
+
         date_string = unescapeHTML(self._search_regex((
             r'<span class=\"premiera\">.*?(?P<date>[0-9]{1,2}\.(?:&nbsp;|\s)*[0-9]{1,2}\.(?:&nbsp;|\s)*[0-9]{2,4})',
-            r'<meta\s+itemprop="uploadDate"\s+content=[\'"](?P<date>[0-9]{4}[-\s][0-9]{1,2}[-\s][0-9]{1,2})[\'"]\s*/?>'
-            ), webpage, 'date', fatal=False, default=None))
-        #date_string = unescapeHTML(self._search_regex(
-        #    r'<meta\s+itemprop=\"uploadDate\"\s+content=[\'\"](?P<date>[0-9]{4}[-\s][0-9]{1,2}[-\s][0-9]{1,2})[\'\"]\s*/?>'
-        #    , webpage, 'date', fatal=False, default=None))
+            r'<meta\s+itemprop="uploadDate"\s+content=[\'"](?P<date>[0-9]{4}[-\s][0-9]{1,2}[-\s][0-9]{1,2})[\'"]\s*/?>'),
+            webpage, 'date', fatal=False, default=None))
+
         if date_string:
             if re.match(r'^([0-9]{4})-(\d{2})-(\d{2})', date_string):
                 date_string = re.sub(r'^([0-9]{4})-(\d{2})-(\d{2})', r'\3.\2.\1', date_string)
-            date_string = re.sub('\s', '', date_string)
+            date_string = re.sub(r'\s', '', date_string)
             date_string = unified_strdate(date_string)
 
         info = {
-                '_type': 'url_transparent',
-                'url': data_url,
-                'ie_key': CeskaTelevizeIE.ie_key(),
-                'id': video_id,
-                'release_date': date_string,
-                'upload_date': date_string
-                }
+            '_type': 'url_transparent',
+            'url': data_url,
+            'ie_key': CeskaTelevizeIE.ie_key(),
+            'id': video_id,
+            'release_date': date_string,
+            'upload_date': date_string
+        }
         return info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [] Improvement
- [] New extractor
- [] New feature

---

### Description of your *pull request* and other information

Hi, I'm not sure how the url_transparent should interact with playlists w.r.t. overriding the fields. What I've found that for the playlist entries, the fields are not overriden, because, the information fields to be overriden are actually one level deeper (at least in the case of this given extractor). I'm attaching  a code that "fixes" it, i.e. documents what I had to change -- there might be other, correct/prefered, way how to do that correctly.