### PR TITLE
Protect "fixup" postprocessors from user config

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -551,7 +551,7 @@ class FFmpegFixupStretchedPP(FFmpegPostProcessor):
 
     def _configuration_args(self, default=[]):
         return []  # Make sure the users extra arguments don't mess up the fix
-    
+
 
 class FFmpegFixupM4aPP(FFmpegPostProcessor):
     def run(self, info):
@@ -573,6 +573,7 @@ class FFmpegFixupM4aPP(FFmpegPostProcessor):
     def _configuration_args(self, default=[]):
         return []  # Make sure the users extra arguments don't mess up the fix
 
+
 class FFmpegFixupM3u8PP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
@@ -586,7 +587,7 @@ class FFmpegFixupM3u8PP(FFmpegPostProcessor):
             os.remove(encodeFilename(filename))
             os.rename(encodeFilename(temp_filename), encodeFilename(filename))
         return [], info
-    
+
     def _configuration_args(self, default=[]):
         return []  # Make sure the users extra arguments don't mess up the fix
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

If the user specifies postprocessor_args they will interfere with the postprocessors for automatically fixing containers and stretched image (FFmpegFixupStretchedPP, FFmpegFixupM4aPP, FFmpegFixupM3u8PP). This pull request corrects this.

Before:
```
PS C:\Users\rasmu\Desktop\youtube test\ffmpeg test> youtube-dl --format 'bestaudio' --postprocessor-args "-acodec libopus -b:a 32K" -v _yDZY5_u8FQ
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['--format', 'bestaudio', '--postprocessor-args', '-acodec libopus -b:a 32K', '-v', '_yDZY5_u8FQ']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2020.01.24
[debug] Python version 3.8.1 (CPython) - Windows-10-10.0.18362-SP0
[debug] exe versions: ffmpeg 4.2.1, ffprobe 4.2.1
[debug] Proxy map: {}
[youtube] _yDZY5_u8FQ: Downloading webpage
[youtube] _yDZY5_u8FQ: Downloading video info webpage
[debug] Invoking downloader on 'https://r4---sn-uqj-j2iz.googlevideo.com/videoplayback?expire=1580179293&ei=_EovXrG5O9Hn7QSb35DADg&ip=85.129.39.156&id=o-AGl-QaqCwM23zMS0NKBGIs7O8zB-MmAcR6uTNL-2r1Ja&itag=258&source=youtube&requiressl=yes&mm=31%2C29&mn=sn-uqj-j2iz%2Csn-5goeen7y&ms=au%2Crdu&mv=m&mvi=3&pl=24&initcwndbps=1635000&vprv=1&mime=audio%2Fmp4&gir=yes&clen=3266848&dur=67.370&lmt=1579640280116448&mt=1580157610&fvip=4&keepalive=yes&fexp=23842630&c=WEB&txp=1311222&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=ALgxI2wwRAIgCYXccnAAqM5H-Nuyp9Mocbc9wYeVG_VxAuv--vNa-o0CIBbLhvFyrqVZpaerSAqSTIIRU6wK1JHnJ65rMMAZBqU-&lsparams=mm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AHylml4wRAIgFSmlCUrtYya1rYxt95jN2EtNgFm1QcovQxmaSdzvxPcCIFp0RS-QjqkCl11uf80kIEPEM7pds9TmS0VhH1tDswqE&ratebypass=yes'
[download] Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a has already been downloaded
[download] 100% of 3.11MiB
[ffmpeg] Correcting container in "Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a"
[debug] ffmpeg command line: ffmpeg -y -loglevel "repeat+info" -i "file:Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a" -c copy -f mp4 -acodec libopus "-b:a" 32K "file:Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.temp.m4a"
ERROR: Conversion failed!
Traceback (most recent call last):
  File "c:\users\rasmu\appdata\local\programs\python\python38\lib\site-packages\youtube_dl\YoutubeDL.py", line 2064, in post_process
    files_to_delete, info = pp.run(info)
  File "c:\users\rasmu\appdata\local\programs\python\python38\lib\site-packages\youtube_dl\postprocessor\ffmpeg.py", line 561, in run
    self.run_ffmpeg(filename, temp_filename, options)
  File "c:\users\rasmu\appdata\local\programs\python\python38\lib\site-packages\youtube_dl\postprocessor\ffmpeg.py", line 239, in run_ffmpeg
    self.run_ffmpeg_multiple_files([path], out_path, opts)
  File "c:\users\rasmu\appdata\local\programs\python\python38\lib\site-packages\youtube_dl\postprocessor\ffmpeg.py", line 235, in run_ffmpeg_multiple_files
    raise FFmpegPostProcessorError(msg)
youtube_dl.postprocessor.ffmpeg.FFmpegPostProcessorError: Conversion failed!
```

After:
```
PS C:\Users\rasmu\Desktop\youtube test\ffmpeg test> youtube-dl --format 'bestaudio' --postprocessor-args "-acodec libopus -b:a 32K" -v _yDZY5_u8FQ
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['--format', 'bestaudio', '--postprocessor-args', '-acodec libopus -b:a 32K', '-v', '_yDZY5_u8FQ']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2020.01.24
[debug] Python version 3.8.1 (CPython) - Windows-10-10.0.18362-SP0
[debug] exe versions: ffmpeg 4.2.1, ffprobe 4.2.1
[debug] Proxy map: {}
[youtube] _yDZY5_u8FQ: Downloading webpage
[youtube] _yDZY5_u8FQ: Downloading video info webpage
[debug] Invoking downloader on 'https://r4---sn-uqj-j2iz.googlevideo.com/videoplayback?expire=1580179322&ei=GksvXriNE4mI7AS_4LegAg&ip=85.129.39.156&id=o-AGIFJj5fP5ZWL3s9sLF1x9ERbLGlWQS5FDB8Qbh-TxqS&itag=258&source=youtube&requiressl=yes&mm=31%2C29&mn=sn-uqj-j2iz%2Csn-5go7yne6&ms=au%2Crdu&mv=m&mvi=3&pl=24&initcwndbps=1635000&vprv=1&mime=audio%2Fmp4&gir=yes&clen=3266848&dur=67.370&lmt=1579640280116448&mt=1580157610&fvip=4&keepalive=yes&fexp=23842630&c=WEB&txp=1311222&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cvprv%2Cmime%2Cgir%2Cclen%2Cdur%2Clmt&sig=ALgxI2wwRgIhAMTlCOhhdF7W9WDJzgOIrn6QbSYIC38NhnK-b928VSbMAiEAn5pzWfcMwtN0wCKu244e9aFoFZ1AvMod_nNyzDAkBmg%3D&lsparams=mm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Cinitcwndbps&lsig=AHylml4wRAIgAbOcrNz5CxLxiakDR5hKO_RmVkNVnelpxo6F4R-G1UECIDbRxMJjuXD1QfYUaaKk87HBVqK-vPwMl1voL1XN7Jwt&ratebypass=yes'
[download] Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a has already been downloaded
[download] 100% of 3.11MiB
[ffmpeg] Correcting container in "Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a"
[debug] ffmpeg command line: ffmpeg -y -loglevel "repeat+info" -i "file:Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.m4a" -c copy -f mp4 "file:Why Does Space Inspire Us Elon Musk-_yDZY5_u8FQ.temp.m4a"
```