### PR TITLE
[utils] Fix handling of comments in js_to_json

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -918,6 +918,34 @@ class TestUtil(unittest.TestCase):
         inp = '''{segments: [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}'''
         self.assertEqual(js_to_json(inp), '''{"segments": [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}''')
 
+        inp = '''{
+            foo: "value",
+            // bar: { nested:'x' },
+            bar: { nested:'x' },
+            chaff: "something"
+        }'''
+        self.assertEqual(js_to_json(inp), '''{
+            "foo": "value",
+
+            "bar": { "nested":"x" },
+            "chaff": "something"
+        }''')
+
+        inp = '''{
+            id: "player_prog",
+            googleCast: true,
+            //extraSettings: { googleCastReceiverAppId:'1A6F2224', skin:'s3',  skinAccentColor: '0073FF'},
+            extraSettings: { googleCastReceiverAppId:'1A6F2224'},
+            mediaType: "video",
+        }'''
+        self.assertEqual(js_to_json(inp), '''{
+            "id": "player_prog",
+            "googleCast": true,
+
+            "extraSettings": { "googleCastReceiverAppId":"1A6F2224"},
+            "mediaType": "video"
+        }''')
+
     def test_js_to_json_edgecases(self):
         on = js_to_json("{abc_def:'1\\'\\\\2\\\\\\'3\"4'}")
         self.assertEqual(json.loads(on), {"abc_def": "1'\\2\\'3\"4"})

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -3984,7 +3984,7 @@ def js_to_json(code):
     # This regular expression is based on this Stack Overflow answer:
     #   https://stackoverflow.com/a/25735600
     code = re.sub(r'("(?:[^"\\]|\\[\s\S])*"|\'(?:[^\'\\]|\\[\s\S])*\')|[ \t]*//.*|[ \t]*/\*(?:[^*]|\*(?!/))*\*/',
-                  '\\1', code)
+                  lambda m: m.group(1) or '', code)
 
     def fix_kv(m):
         v = m.group(0)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

`js_to_json()` removes commas that appear right before a comment line, creating invalid JSON.

This pull request fixes this by making the conversion a two-step process. It first removes all comments and then the actual JS to JSON fix-up happens. This also somewhat simplifies the conversion as comment handling is no longer needed in the second step.

Doing it in one step makes it hard to deal properly with both commas right before comments and trailing commas at the end of a dictionary or array. A two-step approach is easy to follow and works.

The regular expression used for comment removal is not thrown off by comments within string literals. It is based on this Stack Overflow answer: [https://stackoverflow.com/a/25735600](https://stackoverflow.com/a/25735600)

Additional tests in `test/test_utils.py` based on issue #23785 are also provided.

Closes #23707, closes #23785.