### PR TITLE
Introduce new '--add-music-metadata' option for music downloaded from music.youtube.com

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -276,6 +276,8 @@ def _real_main(argv=None):
     # so metadata can be added here.
     if opts.addmetadata:
         postprocessors.append({'key': 'FFmpegMetadata'})
+    if opts.addmusicmetadata:
+        postprocessors.append({'key': 'FFmpegMusicMetadata'})
     if opts.convertsubtitles:
         postprocessors.append({
             'key': 'FFmpegSubtitlesConvertor',

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -819,6 +819,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(
+        '--add-music-metadata',
+        action='store_true', dest='addmusicmetadata', default=False,
+        help='Write music metadata to video file (this works only for songs from music.youtube.com)')
+    postproc.add_option(
         '--metadata-from-title',
         metavar='FORMAT', dest='metafromtitle',
         help='Parse additional metadata like song title / artist from the video title. '

--- a/youtube_dl/postprocessor/__init__.py
+++ b/youtube_dl/postprocessor/__init__.py
@@ -10,6 +10,7 @@ from .ffmpeg import (
     FFmpegFixupM4aPP,
     FFmpegMergerPP,
     FFmpegMetadataPP,
+    FFmpegMusicMetadataPP,
     FFmpegVideoConvertorPP,
     FFmpegSubtitlesConvertorPP,
 )
@@ -32,6 +33,7 @@ __all__ = [
     'FFmpegFixupStretchedPP',
     'FFmpegMergerPP',
     'FFmpegMetadataPP',
+    'FFmpegMusicMetadataPP',
     'FFmpegPostProcessor',
     'FFmpegSubtitlesConvertorPP',
     'FFmpegVideoConvertorPP',


### PR DESCRIPTION
### Code copyright
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
### Purpose of pull request
- [X] Improvement
- [X] New feature

### Description
When downloading music from https://music.youtube.com/ and extracting metadata using the default provided option, we get invalid or not so accurate metadata. For example:
```
$ youtube-dl -x --audio-format mp3 --add-metadata -o "%(title)s.%(ext)s" "https://music.youtube.com/watch?v=ExDykQQ3woM"
[youtube] ExDykQQ3woM: Downloading webpage
[youtube] ExDykQQ3woM: Downloading video info webpage
[youtube] ExDykQQ3woM: Downloading js player vflbwmoEe
[youtube] ExDykQQ3woM: Downloading js player vflbwmoEe
[download] Destination: I Still Can't Stop.webm
[download] 100% of 3.89MiB in 00:05
[ffmpeg] Destination: I Still Can't Stop.mp3
Deleting original file I Still Can't Stop.webm (pass -k to keep)
[ffmpeg] Adding metadata to 'I Still Can't Stop.mp3'
$ mpv I\ Still\ Can\'t\ Stop.mp3 
 (+) Audio --aid=1 (mp3 2ch 48000Hz)
File tags:
 Artist: Flux Pavilion
 Album: Blow The Roof
 Comment: Provided to YouTube by Atlantic Records UK

I Still Can't Stop · Flux Pavilion

Blow The Roof

℗ 2013 Circus Records in association with Atlantic Records / Big Beat Records

Writer: Joshua Steele

Auto-generated by YouTube.
 Date: 20151005
 Description: Provided to YouTube by Atlantic Records UK

I Still Can't Stop · Flux Pavilion

Blow The Roof

℗ 2013 Circus Records in association with Atlantic Records / Big Beat Records

Writer: Joshua Steele

Auto-generated by YouTube.
 Title: I Still Can't Stop
AO: [pulse] 48000Hz stereo 2ch float
A: 00:00:02 / 00:04:16 (0%)


Exiting... (Quit)
$
```
As you can see, 'Date' is the youtube upload date and not the actual song/record release date, and the 'Description'/'Comment' are provided twice and are unnecessary when hoarding music.
That's why I added '--add-music-metadata' so instead of that, I'd get this:
```
$ youtube-dl -x --audio-format mp3 --add-music-metadata -o "%(track)s.%(ext)s" "https://music.youtube.com/watch?v=ExDykQQ3woM"
[youtube] ExDykQQ3woM: Downloading webpage
[youtube] ExDykQQ3woM: Downloading video info webpage
[download] Destination: I Still Can't Stop.webm
[download] 100% of 3.89MiB in 00:08
[ffmpeg] Destination: I Still Can't Stop.mp3
Deleting original file I Still Can't Stop.webm (pass -k to keep)
[ffmpeg] Adding metadata to 'I Still Can't Stop.mp3'
$ mpv I\ Still\ Can\'t\ Stop.mp3 
 (+) Audio --aid=1 (mp3 2ch 48000Hz)
File tags:
 Artist: Flux Pavilion
 Album: Blow The Roof
 Date: 2013
 Title: I Still Can't Stop
AO: [pulse] 48000Hz stereo 2ch float
A: 00:00:08 / 00:04:16 (3%)


Exiting... (Quit)
$
```
Much better... and the 'Date' is the actual release date.