### PR TITLE
I wish there was a timestamp in "OUTPUT TEMPLATE" for RSS/Atom

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -896,6 +896,9 @@ class YoutubeDL(object):
             if new_result.get('_type') == 'url':
                 new_result['_type'] = 'url_transparent'
 
+            if ie_result.get('timestamp') is not None:
+                extra_info['timestamp'] = ie_result.get('timestamp')
+
             return self.process_ie_result(
                 new_result, download=download, extra_info=extra_info)
         elif result_type in ('playlist', 'multi_video'):

--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -30,6 +30,7 @@ from ..utils import (
     smuggle_url,
     unescapeHTML,
     unified_strdate,
+    unified_timestamp,
     unsmuggle_url,
     UnsupportedError,
     xpath_text,
@@ -2182,10 +2183,12 @@ class GenericIE(InfoExtractor):
             if not next_url:
                 continue
 
+            pubDate = it.find('pubDate')
             entries.append({
                 '_type': 'url_transparent',
                 'url': next_url,
                 'title': it.find('title').text,
+                'timestamp': None if (pubDate is None) else unified_timestamp(pubDate.text),
             })
 
         return {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is more like a feature request, not a real pull request. The title sums it up good, here is a copy: enable the `timestamp` variable in "OUTPUT TEMPLATE" for RSS/Atom