### PR TITLE
Added Support for HGTV.ca

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -425,7 +425,7 @@ from .heise import HeiseIE
 from .hellporno import HellPornoIE
 from .helsinki import HelsinkiIE
 from .hentaistigma import HentaiStigmaIE
-from .hgtv import HGTVComShowIE
+from .hgtv import HGTVShowIE
 from .hketv import HKETVIE
 from .hidive import HiDiveIE
 from .historicfilms import HistoricFilmsIE

--- a/youtube_dl/extractor/hgtv.py
+++ b/youtube_dl/extractor/hgtv.py
@@ -4,17 +4,17 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 
 
-class HGTVComShowIE(InfoExtractor):
-    IE_NAME = 'hgtv.com:show'
-    _VALID_URL = r'https?://(?:www\.)?hgtv\.com/shows/[^/]+/(?P<id>[^/?#&]+)'
+class HGTVShowIE(InfoExtractor):
+    IE_NAME = 'hgtv:show'
+    _VALID_URL = r'https?://(?:www\.)?hgtv\.(?:com|ca)/shows/[^/]+/(?P<id>[^/?#&]+)'
     _TESTS = [{
         # data-module="video"
-        'url': 'http://www.hgtv.com/shows/flip-or-flop/flip-or-flop-full-episodes-season-4-videos',
+        'url': 'https://www.hgtv.com/shows/fixer-upper/fixer-upper-full-episodes-videos',
         'info_dict': {
-            'id': 'flip-or-flop-full-episodes-season-4-videos',
-            'title': 'Flip or Flop Full Episodes',
+            'id': 'fixer-upper-full-episodes-videos',
+            'title': 'Fixer Upper - Full Episodes',
         },
-        'playlist_mincount': 15,
+        'playlist_mincount': 14,
     }, {
         # data-deferred-module="video"
         'url': 'http://www.hgtv.com/shows/good-bones/episodes/an-old-victorian-house-gets-a-new-facelift',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

**Added support for hgtv.ca**
Since both hgtv.ca and hgtv.com are using the same CMS, by updating the
existing script to support both domains, it works well with videos on both
websites. 