### PR TITLE
New URL sanitized request  mewatch was changed

### DIFF
--- a/youtube_dl/extractor/toggle.py
+++ b/youtube_dl/extractor/toggle.py
@@ -125,8 +125,10 @@ class ToggleIE(InfoExtractor):
             'mediaType': 0,
         }
 
+        #  sanitized request:
+        # 'http://tvpapi.as.tvinci.com/v2_9/gateways/jsonpostgw.aspx?m=GetMediaInfo'
         req = sanitized_Request(
-            'http://tvpapi.as.tvinci.com/v2_9/gateways/jsonpostgw.aspx?m=GetMediaInfo',
+            'https://tvpapi-as.ott.kaltura.com/v3_9/gateways/jsonpostgw.aspx?m=GetMediaInfo',
             json.dumps(params).encode('utf-8'))
         info = self._download_json(req, video_id, 'Downloading video info json')
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Today, I found bug after  download via toggle, then I checked this code, I found url sanitized was changed version then I try to change and its work again:

Logs error (branch Master):
$ python -m youtube_dl https://www.mewatch.sg/en/series/cna-2020/ep286/920671                                                            
[toggle] 920671: Downloading video page
[toggle] 920671: Downloading video info json
[toggle] 920671: Downloading SS_Web ISM manifest
[toggle] 920671: Downloading SS_TV ISM manifest
[toggle] 920671: Downloading DASH_Mobile MPD manifest
[toggle] 920671: Downloading DASH_Web MPD manifest
[toggle] 920671: Downloading DASH_TV MPD manifest
[toggle] 920671: Downloading HLS_Mobile m3u8 information
[toggle] 920671: Downloading HLS_Web m3u8 information
[toggle] 920671: Downloading HLS_TV m3u8 information
[toggle] 920671: Downloading DASH_Tablet MPD manifest
[toggle] 920671: Downloading HLS_Tablet m3u8 information
[toggle] 920671: Downloading DASH_HBBTV MPD manifest
[toggle] 920671: Downloading DASH_360 MPD manifest
[toggle] 920671: Downloading HLS_360 m3u8 information
[toggle] 920671: Downloading SS_360 ISM manifest
[toggle] 920671: Downloading DASH_TV_4K MPD manifest
[toggle] 920671: Downloading DASH_Web_Clear MPD manifest
[toggle] 920671: Downloading HLS_Web_Clear m3u8 information
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
WARNING: "url" field is not a string - forcing string conversion, there is an error in extractor
[dashsegments] Total fragments: 54
[download] Destination: CNA 2020-920671.fDASH_Web_Clear-f4-v1-x3.mp4
[download] 100% of 64.08MiB in 02:24
[dashsegments] Total fragments: 54
[download] Destination: CNA 2020-920671.fDASH_Web_Clear-f4-a1-x3.m4a
[download] 100% of 3.31MiB in 02:18
[ffmpeg] Merging formats into "CNA 2020-920671.mp4"
Deleting original file CNA 2020-920671.fDASH_Web_Clear-f4-v1-x3.mp4 (pass -k to keep)
Deleting original file CNA 2020-920671.fDASH_Web_Clear-f4-a1-x3.m4a (pass -k to keep)
