### PR TITLE
[options] assign -V to --version to resolve conflict with --verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
 
 # OPTIONS
     -h, --help                       Print this help text and exit
-    --version                        Print program version and exit
+    -V, --version                    Print program version and exit
     -U, --update                     Update this program to latest version. Make
                                      sure that you have sufficient permissions
                                      (run with sudo if needed)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
 
 # OPTIONS
     -h, --help                       Print this help text and exit
-    -V, --version                    Print program version and exit
+    --version                        Print program version and exit
     -U, --update                     Update this program to latest version. Make
                                      sure that you have sufficient permissions
                                      (run with sudo if needed)

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -134,7 +134,7 @@ def parseOpts(overrideArguments=None):
         action='help',
         help='Print this help text and exit')
     general.add_option(
-        '-V', '--version',
+        '--version',
         action='version',
         help='Print program version and exit')
     general.add_option(

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -134,7 +134,7 @@ def parseOpts(overrideArguments=None):
         action='help',
         help='Print this help text and exit')
     general.add_option(
-        '-v', '--version',
+        '-V', '--version',
         action='version',
         help='Print program version and exit')
     general.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This resolves conflict of shorthand of `--version` and `--verbose`.    
Because `-v` is widely used for `--verbose`, this PR changes only `--version` and keep others unchanged.