### PR TITLE
fix(extractor: odnoklassniki): for download URL use the same protocol as in original URL

### DIFF
--- a/youtube_dl/extractor/odnoklassniki.py
+++ b/youtube_dl/extractor/odnoklassniki.py
@@ -121,6 +121,10 @@ class OdnoklassnikiIE(InfoExtractor):
         # Paid video
         'url': 'https://ok.ru/video/954886983203',
         'only_matching': True,
+    }, {
+        # Downloads only via https
+        'url': 'https://ok.ru/video/1704000096969',
+        'only_matching': True,
     }]
 
     @staticmethod

--- a/youtube_dl/extractor/odnoklassniki.py
+++ b/youtube_dl/extractor/odnoklassniki.py
@@ -123,7 +123,7 @@ class OdnoklassnikiIE(InfoExtractor):
         'only_matching': True,
     }, {
         # Downloads only via https
-        'url': 'https://ok.ru/video/1704000096969',
+        'url': 'https://ok.ru/video/1705664645833',
         'only_matching': True,
     }]
 

--- a/youtube_dl/extractor/odnoklassniki.py
+++ b/youtube_dl/extractor/odnoklassniki.py
@@ -131,13 +131,14 @@ class OdnoklassnikiIE(InfoExtractor):
             return mobj.group('url')
 
     def _real_extract(self, url):
+        parsed_url = compat_urllib_parse_urlparse(url)
         start_time = int_or_none(compat_parse_qs(
-            compat_urllib_parse_urlparse(url).query).get('fromTime', [None])[0])
+            parsed_url.query).get('fromTime', [None])[0])
 
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(
-            'http://ok.ru/video/%s' % video_id, video_id)
+            '%s://ok.ru/video/%s' % (parsed_url.scheme, video_id), video_id)
 
         error = self._search_regex(
             r'[^>]+class="vp_video_stub_txt"[^>]*>([^<]+)<',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some videos are not downloading well via http. While investigating the problem i've noticed what when i change the hardcoded protocol from http to https those videos downloading well.