### PR TITLE
[Airvuz] New extractor

### DIFF
--- a/docs/supportedsites.md
+++ b/docs/supportedsites.md
@@ -37,6 +37,7 @@
  - **aenetworks**: A+E Networks: A&E, Lifetime, History.com, FYI Network and History Vault
  - **afreecatv**: afreecatv.com
  - **AirMozilla**
+ - **AirVuz**
  - **AliExpressLive**
  - **AlJazeera**
  - **Allocine**

--- a/youtube_dl/extractor/airvuz.py
+++ b/youtube_dl/extractor/airvuz.py
@@ -2,27 +2,45 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
+from ..compat import compat_urllib_parse_unquote
 
 import re
 
 
 class AirVuzIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?airvuz\.com/video/(?P<display_id>.+)\?id=(?P<id>.+)'
-    _TEST = {
-        'url': 'https://www.airvuz.com/video/An-Imaginary-World?id=599e85c49282a717c50f2f7a',
-        'info_dict': {
-            'id': '599e85c49282a717c50f2f7a',
-            'display_id': 'An-Imaginary-World',
-            'title': 'md5:7fc56270e7a70fa81a5935b72eacbe29',
-            'ext': 'mp4',
-            'thumbnail': r're:^https?://.*\.jpg$',
+    _TESTS = [
+        {
+            'url': 'https://www.airvuz.com/video/An-Imaginary-World?id=599e85c49282a717c50f2f7a',
+            'info_dict': {
+                'id': '599e85c49282a717c50f2f7a',
+                'display_id': 'An-Imaginary-World',
+                'title': 'An Imaginary World',
+                'ext': 'mp4',
+                'thumbnail': r're:^https?://.*\.jpg',
+                'uploader': 'Tobias Hägg',
+                'description': 'md5:176b43a79a0a19d592c0261d9c0a48c7',
+            }
         },
-    }
+        # Emojis in the URL, title and description
+        {
+            'url': 'https://www.airvuz.com/video/Cinematic-FPV-Flying-at-a-Cove-%F0%9F%8C%8A%F0%9F%8C%8A%F0%9F%8C%8A-The-rocks-waves-and-seaweed%F0%9F%98%8D?id=5d3db133ec63bf7e65c2226e',
+            'info_dict': {
+                'id': '5d3db133ec63bf7e65c2226e',
+                'display_id': 'Cinematic-FPV-Flying-at-a-Cove-🌊🌊🌊-The-rocks-waves-and-seaweed😍',
+                'title': 'Cinematic FPV Flying at a Cove! 🌊🌊🌊 The rocks, waves, and seaweed😍!',
+                'ext': 'mp4',
+                'thumbnail': r're:^https?://.*\.jpg',
+                'uploader': 'Mako Reactra',
+                'description': 'md5:ac91310ff7c2de26a0f1e8e8caae2ee6'
+            },
+        },
+    ]
 
     def _real_extract(self, url):
         groups = re.match(self._VALID_URL, url)
         video_id = groups.group('id')
-        display_id = groups.group('display_id')
+        display_id = compat_urllib_parse_unquote(groups.group('display_id'))
 
         webpage = self._download_webpage(url, video_id)
 
@@ -47,7 +65,6 @@ class AirVuzIE(InfoExtractor):
                 formats.append({
                     'url': video_url,
                     'format_id': res.get('label'),
-                    'height': res.get('res')
                 })
         else:
             self.report_extraction(video_id)
@@ -57,6 +74,7 @@ class AirVuzIE(InfoExtractor):
             if video_url:
                 format_id = video_url.split("-")[-1].split(".")[0]
                 if len(format_id) <= 2:
+                    # Format can't be induced from the filename
                     format_id = None
 
                 formats.append({

--- a/youtube_dl/extractor/airvuz.py
+++ b/youtube_dl/extractor/airvuz.py
@@ -2,28 +2,46 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
+from ..utils import determine_ext
+
+import re
 
 
 class AirVuzIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?airvuz\.com/video/(?:.+)?id=(?P<id>.+)'
+    _VALID_URL = r'https?://(?:www\.)?airvuz\.com/video/(?P<display_id>.+)\?id=(?P<id>.+)'
     _TEST = {
         'url': 'https://www.airvuz.com/video/An-Imaginary-World?id=599e85c49282a717c50f2f7a',
         'info_dict': {
             'id': '599e85c49282a717c50f2f7a',
-            'ext': 'mp4',
+            'display_id': 'An-Imaginary-World',
             'title': 'md5:7fc56270e7a70fa81a5935b72eacbe29',
+            'ext': 'mp4',
+            'thumbnail': r're:^https?://.*\.jpg$',
         },
     }
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        groups = re.match(self._VALID_URL, url)
+        video_id = groups.group('id')
+        display_id = groups.group('display_id')
+
         webpage = self._download_webpage(url, video_id)
 
-        title = self._html_search_meta('og:title', webpage)
+        title = self._og_search_title(webpage)
+        thumbnail = self._og_search_thumbnail(webpage)
+        description = self._og_search_description(webpage)
+        uploader = self._html_search_regex(r'class=(?:\'img-circle\'|"img-circle"|img-circle)[^>]+?alt=(?:"([^"]+?)"|\'([^\']+?)\'|([^\s"\'=<>`]+))', webpage, 'uploader', fatal=False) or self._html_search_regex(r'https?://(?:www\.)?airvuz\.com/user/([^>]*)', webpage, 'uploader', fatal=False)
+
         video_url = self._html_search_regex(r'<meta[^>]+?(?:name|property)=(?:\'og:video:url\'|"og:video:url"|og:video:url)[^>]+?content=(?:"([^"]+?)"|\'([^\']+?)\'|([^\s"\'=<>`]+))', webpage, 'video_url')
+        ext = determine_ext(video_url)
 
         return {
             'id': video_id,
+            'display_id': display_id,
             'title': title,
             'url': video_url,
+            'ext': ext,
+            'thumbnail': thumbnail,
+            'description': description,
+            'uploader': uploader,
         }

--- a/youtube_dl/extractor/airvuz.py
+++ b/youtube_dl/extractor/airvuz.py
@@ -1,0 +1,29 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class AirVuzIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?airvuz\.com/video/(?:.+)?id=(?P<id>.+)'
+    _TEST = {
+        'url': 'https://www.airvuz.com/video/An-Imaginary-World?id=599e85c49282a717c50f2f7a',
+        'info_dict': {
+            'id': '599e85c49282a717c50f2f7a',
+            'ext': 'mp4',
+            'title': 'md5:7fc56270e7a70fa81a5935b72eacbe29',
+        },
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        title = self._html_search_meta('og:title', webpage)
+        video_url = self._html_search_regex(r'<meta[^>]+?(?:name|property)=(?:\'og:video:url\'|"og:video:url"|og:video:url)[^>]+?content=(?:"([^"]+?)"|\'([^\']+?)\'|([^\s"\'=<>`]+))', webpage, 'video_url')
+
+        return {
+            'id': video_id,
+            'title': title,
+            'url': video_url,
+        }

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -34,6 +34,7 @@ from .aenetworks import (
 )
 from .afreecatv import AfreecaTVIE
 from .airmozilla import AirMozillaIE
+from .airvuz import AirVuzIE
 from .aljazeera import AlJazeeraIE
 from .alphaporno import AlphaPornoIE
 from .amcnetworks import AMCNetworksIE


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [X] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

PR is complete, although the dash extraction is a bit hacky. I'm not familiar with the spec, but wanted to add it anyway.
There are two other methods of extraction as fallback.

The original `format_id` come as `AUDIO-*` and `VIDEO-*`. I added the audio+video files with  `av-*`, which keeps the same ID number across the media. For instance, `VIDEO-1` corresponds to the audio+video file `av-1` (lowercase). Couldn't find any documentation for a convention.
Since the format flag is case-sensitive, usability is sacrificed when the `format_id` is `uppercase`, as the original formats are, but I left it as it is.

If the low priority formats have `acodec` equals `none`, the dash videos have priority over the whole media files. I used that field to assign a description instead.

---

Couldn't use the `_og_search_video_url` function to extract properties, because the regex from `_og_regexes` derived function was being lazy. It worked only with values that were between quotes. As an example:
```
<meta property=og:video:url content=https://cdn.airvuz.com/drone-video/4fbf27d545cc7cb5c83321a00c4dbc73/4fbf27d545cc7cb5c83321a00c4dbc73-720p.mp4>
```

Result would be `h`.
`_html_search_meta` didn't help either. Thus I made my own, from modifications to the original.