### PR TITLE
Added login support for PornHub and PornHub Premium.

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -62,8 +62,7 @@ class PornHubBaseIE(InfoExtractor):
                     ' You may want to use --cookies or --netrc.',
                     expected=True)
 
-        cookies = self._get_cookies('https://%s' % host)
-        if all(login_info) and not cookies:
+        if all(login_info):
             self._login(host, login_info)
 
     def _login(self, host, login_info):

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -27,6 +27,9 @@ from ..utils import (
 
 
 class PornHubBaseIE(InfoExtractor):
+
+    _NETRC_MACHINE = 'pornhub'  # or 'pornhubpremium'
+
     def _download_webpage_handle(self, *args, **kwargs):
         def dl(*args, **kwargs):
             return super(PornHubBaseIE, self)._download_webpage_handle(*args, **kwargs)

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -62,7 +62,6 @@ class PornHubBaseIE(InfoExtractor):
                     ' You may want to use --cookies or --netrc.',
                     expected=True)
 
-        # Authenticate, if required
         cookies = self._get_cookies('https://%s' % host)
         if all(login_info) and not cookies:
             self._login(host, login_info)
@@ -73,10 +72,10 @@ class PornHubBaseIE(InfoExtractor):
 
         if 'premium' in host:
             login_form_url = 'https://%s/premium/login' % host
-            login_post_url = 'https://www.%s/front/authenticate' % host
         else:
             login_form_url = 'https://%s/login' % host
-            login_post_url = 'https://www.%s/front/authenticate' % host
+
+        login_post_url = 'https://www.%s/front/authenticate' % host
 
         # Fetch login page
         login_page = self._download_webpage(

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -231,7 +231,6 @@ class PornHubIE(PornHubBaseIE):
 
         self._set_cookie(host, 'age_verified', '1')
 
-        # Authenticate, if required
         self._login_if_required(host)
 
         def dl_webpage(platform):
@@ -454,7 +453,6 @@ class PornHubPlaylistBaseIE(PornHubBaseIE):
         host = mobj.group('host')
         playlist_id = mobj.group('id')
 
-        # Authenticate, if required
         self._login_if_required(host)
 
         webpage = self._download_webpage(url, playlist_id)
@@ -500,7 +498,6 @@ class PornHubUserIE(PornHubPlaylistBaseIE):
         host = mobj.group('host')
         user_id = mobj.group('id')
 
-        # Authenticate, if required
         self._login_if_required(host)
 
         return self.url_result(
@@ -523,7 +520,6 @@ class PornHubPagedPlaylistBaseIE(PornHubPlaylistBaseIE):
         host = mobj.group('host')
         item_id = mobj.group('id')
 
-        # Authenticate, if required
         self._login_if_required(host)
 
         page = int_or_none(self._search_regex(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves https://github.com/ytdl-org/youtube-dl/issues/18797

The pornhub extractor has been updated with support for --netrc and
--username/password authentication.