### PR TITLE
[twitter] Add support for public Nitter instances

### DIFF
--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -30,7 +30,8 @@ from .periscope import (
 
 class TwitterBaseIE(InfoExtractor):
     _API_BASE = 'https://api.twitter.com/1.1/'
-    _BASE_REGEX = r'https?://(?:(?:www|m(?:obile)?)\.)?twitter\.com/'
+    _BASE_REGEX = r'https?://((?:(?:www|m(?:obile)?)\.)?twitter\.com|' \
+            'nitter\.(net|42l\.fr|snopyta\.org|nixnet\.services|pussthecat\.org|mastodont\.cat|13ad\.de)|tw\.openalgeria\.org)/'
     _GUEST_TOKEN = None
 
     def _extract_variant_formats(self, variant, video_id):

--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -30,8 +30,7 @@ from .periscope import (
 
 class TwitterBaseIE(InfoExtractor):
     _API_BASE = 'https://api.twitter.com/1.1/'
-    _BASE_REGEX = r'https?://((?:(?:www|m(?:obile)?)\.)?twitter\.com|' \
-            'nitter\.(net|42l\.fr|snopyta\.org|nixnet\.services|pussthecat\.org|mastodont\.cat|13ad\.de)|tw\.openalgeria\.org)/'
+    _BASE_REGEX = r'https?://((?:(?:www|m(?:obile)?)\.)?twitter\.com|nitter\.(net|42l\.fr|snopyta\.org|nixnet\.services|pussthecat\.org|mastodont\.cat|13ad\.de)|tw\.openalgeria\.org)/'
     _GUEST_TOKEN = None
 
     def _extract_variant_formats(self, variant, video_id):

--- a/youtube_dl/extractor/twitter.py
+++ b/youtube_dl/extractor/twitter.py
@@ -204,6 +204,21 @@ class TwitterIE(TwitterBaseIE):
             'age_limit': 18,
         },
     }, {
+        'url': 'https://nitter.net/freethenipple/status/643211948184596480',
+        'info_dict': {
+            'id': '643211948184596480',
+            'ext': 'mp4',
+            'title': 'FREE THE NIPPLE - FTN supporters on Hollywood Blvd today!',
+            'thumbnail': r're:^https?://.*\.jpg',
+            'description': 'FTN supporters on Hollywood Blvd today! http://t.co/c7jHH749xJ',
+            'uploader': 'FREE THE NIPPLE',
+            'uploader_id': 'freethenipple',
+            'duration': 12.922,
+            'timestamp': 1442188653,
+            'upload_date': '20150913',
+            'age_limit': 18,
+        },
+    }, {
         'url': 'https://twitter.com/giphz/status/657991469417025536/photo/1',
         'md5': 'f36dcd5fb92bf7057f155e7d927eeb42',
         'info_dict': {
@@ -219,6 +234,18 @@ class TwitterIE(TwitterBaseIE):
         'skip': 'Account suspended',
     }, {
         'url': 'https://twitter.com/starwars/status/665052190608723968',
+        'info_dict': {
+            'id': '665052190608723968',
+            'ext': 'mp4',
+            'title': 'Star Wars - A new beginning is coming December 18. Watch the official 60 second #TV spot for #StarWars: #TheForceAwakens.',
+            'description': 'A new beginning is coming December 18. Watch the official 60 second #TV spot for #StarWars: #TheForceAwakens. https://t.co/OkSqT2fjWJ',
+            'uploader_id': 'starwars',
+            'uploader': 'Star Wars',
+            'timestamp': 1447395772,
+            'upload_date': '20151113',
+        },
+    }, {
+        'url': 'https://nitter.net/starwars/status/665052190608723968',
         'info_dict': {
             'id': '665052190608723968',
             'ext': 'mp4',
@@ -262,6 +289,19 @@ class TwitterIE(TwitterBaseIE):
         },
     }, {
         'url': 'https://twitter.com/Filmdrunk/status/713801302971588609',
+        'md5': '89a15ed345d13b86e9a5a5e051fa308a',
+        'info_dict': {
+            'id': 'MIOxnrUteUd',
+            'ext': 'mp4',
+            'title': 'Dr.Pepperの飲み方 #japanese #バカ #ドクペ #電動ガン',
+            'uploader': 'TAKUMA',
+            'uploader_id': '1004126642786242560',
+            'timestamp': 1402826626,
+            'upload_date': '20140615',
+        },
+        'add_ie': ['Vine'],
+    }, {
+        'url': 'https://nitter.42l.fr/Filmdrunk/status/713801302971588609',
         'md5': '89a15ed345d13b86e9a5a5e051fa308a',
         'info_dict': {
             'id': 'MIOxnrUteUd',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

[Nitter](https://github.com/zedeus/nitter) is a privacy-friendly twitter web-client. The url are the same, except the domain, it depends on the [Nitter instances](https://github.com/zedeus/nitter/wiki/Instances) you use. So I added the possibility to download from nitter link, it just consists of accepting Nitter url, the rest of the extractor is untouched.

I tested tweets with videos, it works, and also images, which link is kinda different: ``https://nitter.net/pic/https%3A%2F%2Fabs.twimg.com%2Fsticky%2Fdefault_profile_images%2Fdefault_profile.png``, it works.

Url to test:
+ https://nitter.net/realmemeskids/status/1238408755215138816
+ https://nitter.net/pic/https%3A%2F%2Fabs.twimg.com%2Fsticky%2Fdefault_profile_images%2Fdefault_profile.png
+ … (change any twitter link, from https://twitter.com/whatever to https://nitterinstanceyouwant/whatever)