### PR TITLE
[pbs] restore subtitles

### DIFF
--- a/youtube_dl/extractor/pbs.py
+++ b/youtube_dl/extractor/pbs.py
@@ -14,6 +14,7 @@ from ..utils import (
     orderedSet,
     strip_jsonp,
     strip_or_none,
+    try_get,
     unified_strdate,
     url_or_none,
     US_RATINGS,
@@ -685,6 +686,17 @@ class PBSIE(InfoExtractor):
                         ttml_caption_suffix, '/%d_Encoded.vtt' % (ttml_caption_id + 2)),
                     'ext': 'vtt',
                 }])
+        else:
+            captions = try_get(info, lambda x: x['cc'], dict) or {}
+
+            if captions:
+                subtitles['en'] = []
+                for caption_url in captions.values():
+                    subtitles['en'].extend([{
+                        'ext': re.search(r'\.(\w{3,4})$',
+                                         caption_url).group(1),
+                        'url': caption_url
+                    }])
 
         # info['title'] is often incomplete (e.g. 'Full Episode', 'Episode 5', etc)
         # Try turning it to 'program - title' naming scheme if possible


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
  - PR #17434 appears to be abandoned
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:

- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- ~I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)~

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes an issue where PBS was no longer able to download subtitles after a sitewide markup update.

Resolves #18796