### PR TITLE
[twitch] Strip title to avoid download error #24575

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -180,6 +180,8 @@ class TwitchItemBaseIE(TwitchBaseIE):
 
     def _extract_info(self, info):
         status = info.get('status')
+        # avoid filesystem's 255 bytes limit on filelength
+        title = info.get('title', '').encode()[:210].decode(errors='ignore')
         if status == 'recording':
             is_live = True
         elif status == 'recorded':
@@ -188,7 +190,7 @@ class TwitchItemBaseIE(TwitchBaseIE):
             is_live = None
         return {
             'id': info['_id'],
-            'title': info.get('title') or 'Untitled Broadcast',
+            'title': title or 'Untitled Broadcast',
             'description': info.get('description'),
             'duration': int_or_none(info.get('length')),
             'thumbnail': info.get('preview'),


### PR DESCRIPTION
Since we create filename from title, it's very easy to get following
error:

  ERROR: unable to open for writing: [Errno 36] File name too long: ...

This commit strips title to 210 bytes so we'll fit into FS's 255 bytes
filesize limit.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.
