### PR TITLE
Fix for missing release year in metadata

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -448,7 +448,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
                     break
 
         add('title', ('track', 'title'))
-        add('date', 'upload_date')
+        add('date', ('release_year', 'upload_date'))
         add(('description', 'comment'), 'description')
         add('purl', 'webpage_url')
         add('track', 'track_number')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When downloading and extracting audio with metadata-from-title, release year is ignored.

example
--metadata-from-title '%(artist)s - %(title)s %(release_year)s'

youtube_dl --verbose --metadata-from-title '%(artist)s - %(title)s %(release_year)s' --add-metadata  --output 'out/%(title)s.%(ext)s' --extract-audio --audio-format m4a 'https://www.youtube.com/watch?v=IXquDAJZEOk'
