### PR TITLE
[GoogleDrive] fix redirect loop (closes #23919)

### DIFF
--- a/youtube_dl/extractor/googledrive.py
+++ b/youtube_dl/extractor/googledrive.py
@@ -265,7 +265,7 @@ class GoogleDriveIE(InfoExtractor):
             subtitles_id = ttsurl.encode('utf-8').decode(
                 'unicode_escape').split('=')[-1]
 
-        self._downloader.cookiejar.clear('.google.com')
+        self._downloader.cookiejar.clear(domain='.google.com', path='/', name='NID')
 
         return {
             'id': video_id,

--- a/youtube_dl/extractor/googledrive.py
+++ b/youtube_dl/extractor/googledrive.py
@@ -265,6 +265,8 @@ class GoogleDriveIE(InfoExtractor):
             subtitles_id = ttsurl.encode('utf-8').decode(
                 'unicode_escape').split('=')[-1]
 
+        self._downloader.cookiejar.clear('.google.com')
+
         return {
             'id': video_id,
             'title': title,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

During the extractor of GoogleDrive, some cookies are set in the downloader cookiejar.
Upon inspecting issue #23919 i've noticed that a cookie set on `.google.com` was the root cause of the redirect loop (Google did an oopsie)

When running a request on the extracted source, everything works as expected

`curl -IL -XGET "https://drive.google.com/uc?id=1DIi4JBVXA3kihcTWr55paCt5aZyEVl83&export=download"`

<details>
<summary>Output</summary>

```
HTTP/2 302 
content-type: text/html; charset=UTF-8
cache-control: no-cache, no-store, max-age=0, must-revalidate
pragma: no-cache
expires: Mon, 01 Jan 1990 00:00:00 GMT
date: Wed, 08 Apr 2020 10:34:09 GMT
location: https://doc-0o-3s-docs.googleusercontent.com/docs/securesc/ha0ro937gcuc7l7deffksulhg5h7mbp1/f4rdochf4hg5csvafet676kahml3rudl/1586342025000/16108136141151180509/*/1DIi4JBVXA3kihcTWr55paCt5aZyEVl83?e=download
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
content-security-policy: script-src 'nonce-WIwghBpgKdF/mcUpkSwPag' 'unsafe-inline' 'strict-dynamic' https: http: 'unsafe-eval';object-src 'none';base-uri 'self';report-uri https://csp.withgoogle.com/csp/drive-explorer/
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
server: GSE
set-cookie: NID=201=zWECqKGHGBhRoK1mCntoHHZlV5FlDqK54pXSibX387oR2DOyHtde3kAKSifI6BqZHvE4r2flzVFHwX0uz3D8SNGBfqiuaUzkLTUQhtYviNhdr6vc8MlrLAlLsD5QTIayoEd4Y1RTrGj_1X_SayBqwNQlNgJnbYEh2JInJwM0egs; expires=Thu, 08-Oct-2020 10:34:09 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000
accept-ranges: none
vary: Accept-Encoding

HTTP/2 200 
x-guploader-uploadid: AEnB2UoEdLSB27nSkp-fkpHvYhyBoYX5YDcCT0EeZIdtKDk5HDWGdp1P8vxxXcxEzbpvG5nlcrQLb5HCLc6pcTAyEAKkWOdTH3pjkfIawuZpcDIU-lyPGow
access-control-allow-origin: *
access-control-allow-credentials: false
access-control-allow-headers: Accept, Accept-Language, Authorization, Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Content-Length, Content-MD5, Content-Range, Content-Type, Date, GData-Version, google-cloud-resource-prefix, Host, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Origin, OriginToken, Pragma, Range, Slug, Transfer-Encoding, Want-Digest, x-chrome-connected, X-ClientDetails, X-Client-Version, X-Firebase-Locale, X-Goog-Firebase-Installations-Auth, X-Firebase-Client, X-Firebase-Client-Log-Type, X-GData-Client, X-GData-Key, X-GoogApps-Allowed-Domains, X-Goog-AdX-Buyer-Impersonation, X-Goog-Api-Client, X-Goog-AuthUser, x-goog-ext-124712974-jspb, x-goog-ext-259736195-jspb, X-Goog-PageId, X-Goog-Encode-Response-If-Executable, X-Goog-Correlation-Id, X-Goog-Request-Info, X-Goog-Request-Reason, X-Goog-Experiments, x-goog-iam-authority-selector, x-goog-iam-authorization-token, X-Goog-Spatula, X-Goog-Travel-Bgr, X-Goog-Travel-Settings, X-Goog-Upload-Command, X-Goog-Upload-Content-Disposition, X-Goog-Upload-Content-Length, X-Goog-Upload-Content-Type, X-Goog-Upload-File-Name, X-Goog-Upload-Header-Content-Length, X-Goog-Upload-Offset, X-Goog-Upload-Protocol, x-goog-user-project, X-Goog-Visitor-Id, X-Goog-FieldMask, X-Google-Project-Override, X-Goog-Api-Key, X-HTTP-Method-Override, X-JavaScript-User-Agent, X-Pan-Versionid, X-Proxied-User-IP, X-Origin, X-Referer, X-Requested-With, X-Stadia-Client-Context, X-Upload-Content-Length, X-Upload-Content-Type, X-Use-HTTP-Status-Code-Override, X-Ios-Bundle-Identifier, X-Android-Package, X-Ariane-Xsrf-Token, X-YouTube-VVT, X-YouTube-Page-CL, X-YouTube-Page-Timestamp, X-Goog-Meeting-Botguardid, X-Goog-Meeting-Debugid, X-Goog-Meeting-Token, X-Client-Data, X-Sfdc-Authorization, MIME-Version, Content-Transfer-Encoding, X-Earth-Engine-App-ID-Token, X-Earth-Engine-Computation-Profile, X-Earth-Engine-Computation-Profiling, X-Play-Console-Experiments-Override, X-Play-Console-Session-Id
access-control-allow-methods: GET,OPTIONS
content-type: video/mp4
content-disposition: attachment;filename="test.mp4";filename*=UTF-8''test.mp4
date: Wed, 08 Apr 2020 10:34:09 GMT
expires: Wed, 08 Apr 2020 10:34:09 GMT
cache-control: private, max-age=0
x-goog-hash: crc32c=xf1PjQ==
content-length: 937854
server: UploadServer
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000


```

</details>

But when running the request with the cookies on '.google.com' set from the extractor stage it enters a redirect loop

`curl -IL -XGET "https://drive.google.com/uc?id=1DIi4JBVXA3kihcTWr55paCt5aZyEVl83&export=download" -H "Cookie: NID=201=Vgdy2UVlwmt4HOaKTwoCft7zHAslUJgpK1k7c0n5thYEgEFUurnNpeaUmcKlEvnHloFyzwdTks09P7H7QR7gGf2u2Z3qke9Vhxh87bhVi6M7MiMIBujKJfeMZ1hI3duoNUK8_gsysXvKeQxvW5T_cfdlYpH9i02h6Ai7LHe4bGY"`

<details>
<summary>Output</summary>

```
HTTP/2 302 
content-type: text/html; charset=UTF-8
cache-control: no-cache, no-store, max-age=0, must-revalidate
pragma: no-cache
expires: Mon, 01 Jan 1990 00:00:00 GMT
date: Wed, 08 Apr 2020 10:36:39 GMT
location: https://doc-0s-3s-docs.googleusercontent.com/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom/f32ua6bkbk5eirm90s927rf367krpvg7/1586342175000/16108136141151180509/00777619999987158088Z/1DIi4JBVXA3kihcTWr55paCt5aZyEVl83?e=download
content-security-policy: script-src 'nonce-a78Xwcl5+KftjxmGe9HL7Q' 'unsafe-inline' 'strict-dynamic' https: http: 'unsafe-eval';object-src 'none';base-uri 'self';report-uri https://csp.withgoogle.com/csp/drive-explorer/
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
server: GSE
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000
accept-ranges: none
vary: Accept-Encoding

HTTP/2 302 
x-guploader-uploadid: AEnB2UrPTF3xTCDwpELP-srrid-rbv1EnDHKr6uQ0U6pb4wyAPirK--AeD0Qli6aCT6mVB7LR35r45PBmFw29I9OYrgbX6pnl_5X361Y-97rwTnRhS8i3mo
access-control-allow-origin: *
access-control-allow-credentials: false
access-control-allow-headers: Accept, Accept-Language, Authorization, Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Content-Length, Content-MD5, Content-Range, Content-Type, Date, GData-Version, google-cloud-resource-prefix, Host, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Origin, OriginToken, Pragma, Range, Slug, Transfer-Encoding, Want-Digest, x-chrome-connected, X-ClientDetails, X-Client-Version, X-Firebase-Locale, X-Goog-Firebase-Installations-Auth, X-Firebase-Client, X-Firebase-Client-Log-Type, X-GData-Client, X-GData-Key, X-GoogApps-Allowed-Domains, X-Goog-AdX-Buyer-Impersonation, X-Goog-Api-Client, X-Goog-AuthUser, x-goog-ext-124712974-jspb, x-goog-ext-259736195-jspb, X-Goog-PageId, X-Goog-Encode-Response-If-Executable, X-Goog-Correlation-Id, X-Goog-Request-Info, X-Goog-Request-Reason, X-Goog-Experiments, x-goog-iam-authority-selector, x-goog-iam-authorization-token, X-Goog-Spatula, X-Goog-Travel-Bgr, X-Goog-Travel-Settings, X-Goog-Upload-Command, X-Goog-Upload-Content-Disposition, X-Goog-Upload-Content-Length, X-Goog-Upload-Content-Type, X-Goog-Upload-File-Name, X-Goog-Upload-Header-Content-Length, X-Goog-Upload-Offset, X-Goog-Upload-Protocol, x-goog-user-project, X-Goog-Visitor-Id, X-Goog-FieldMask, X-Google-Project-Override, X-Goog-Api-Key, X-HTTP-Method-Override, X-JavaScript-User-Agent, X-Pan-Versionid, X-Proxied-User-IP, X-Origin, X-Referer, X-Requested-With, X-Stadia-Client-Context, X-Upload-Content-Length, X-Upload-Content-Type, X-Use-HTTP-Status-Code-Override, X-Ios-Bundle-Identifier, X-Android-Package, X-Ariane-Xsrf-Token, X-YouTube-VVT, X-YouTube-Page-CL, X-YouTube-Page-Timestamp, X-Goog-Meeting-Botguardid, X-Goog-Meeting-Debugid, X-Goog-Meeting-Token, X-Client-Data, X-Sfdc-Authorization, MIME-Version, Content-Transfer-Encoding, X-Earth-Engine-App-ID-Token, X-Earth-Engine-Computation-Profile, X-Earth-Engine-Computation-Profiling, X-Play-Console-Experiments-Override, X-Play-Console-Session-Id
access-control-allow-methods: GET,OPTIONS
p3p: CP="This is not a P3P policy! See http://www.google.com/support/accounts/answer/151657?hl=en for more info."
location: https://docs.google.com/nonceSigner?nonce=gfn3ca1a61dru&continue=https://doc-0s-3s-docs.googleusercontent.com/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom/f32ua6bkbk5eirm90s927rf367krpvg7/1586342175000/16108136141151180509/00777619999987158088Z/1DIi4JBVXA3kihcTWr55paCt5aZyEVl83?e%3Ddownload&hash=1k1d6r1hhsa4jfe3hjrufgc4ubq64j5c
date: Wed, 08 Apr 2020 10:36:40 GMT
expires: Wed, 08 Apr 2020 10:36:40 GMT
cache-control: private, max-age=0
content-length: 0
server: UploadServer
set-cookie: AUTH_s4jj9vs5ngh61o5ikf7veu7s22i9i9m4_nonce=gfn3ca1a61dru; Domain=doc-0s-3s-docs.googleusercontent.com; Expires=Wed, 08-Apr-2020 10:46:40 GMT; Path=/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom; Secure; SameSite=none; HttpOnly
content-type: text/html; charset=UTF-8
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000

HTTP/2 302 
content-type: application/binary
cache-control: no-cache, no-store, max-age=0, must-revalidate
pragma: no-cache
expires: Mon, 01 Jan 1990 00:00:00 GMT
date: Wed, 08 Apr 2020 10:36:40 GMT
location: https://doc-0s-3s-docs.googleusercontent.com/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom/f32ua6bkbk5eirm90s927rf367krpvg7/1586342175000/16108136141151180509/00777619999987158088Z/1DIi4JBVXA3kihcTWr55paCt5aZyEVl83?e=download&nonce=gfn3ca1a61dru&user=*&hash=5qputqjvetp2sv0vb1nrahgkgqtpjsji
strict-transport-security: max-age=31536000
content-security-policy: script-src 'nonce-n0vUOmMB/KnN6AWZ2b6/zw' 'unsafe-inline';object-src 'none';base-uri 'self';report-uri /_/DriveUntrustedContentSignerHttp/cspreport;worker-src 'self'
server: ESF
content-length: 0
x-xss-protection: 0
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000

HTTP/2 302 
x-guploader-uploadid: AEnB2UpV8bKEfjVVQIh0J9pcs_AXziAvTfpuQKR3QZbiFAWZuHzub2u-hMJgJZxV5GX8TyERwG7YDyDJ1T_VrYD7Sy3S-yoMwwtpfxtZvk8Q7Ntfl174EnE
access-control-allow-origin: *
access-control-allow-credentials: false
access-control-allow-headers: Accept, Accept-Language, Authorization, Cache-Control, Content-Disposition, Content-Encoding, Content-Language, Content-Length, Content-MD5, Content-Range, Content-Type, Date, GData-Version, google-cloud-resource-prefix, Host, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, Origin, OriginToken, Pragma, Range, Slug, Transfer-Encoding, Want-Digest, x-chrome-connected, X-ClientDetails, X-Client-Version, X-Firebase-Locale, X-Goog-Firebase-Installations-Auth, X-Firebase-Client, X-Firebase-Client-Log-Type, X-GData-Client, X-GData-Key, X-GoogApps-Allowed-Domains, X-Goog-AdX-Buyer-Impersonation, X-Goog-Api-Client, X-Goog-AuthUser, x-goog-ext-124712974-jspb, x-goog-ext-259736195-jspb, X-Goog-PageId, X-Goog-Encode-Response-If-Executable, X-Goog-Correlation-Id, X-Goog-Request-Info, X-Goog-Request-Reason, X-Goog-Experiments, x-goog-iam-authority-selector, x-goog-iam-authorization-token, X-Goog-Spatula, X-Goog-Travel-Bgr, X-Goog-Travel-Settings, X-Goog-Upload-Command, X-Goog-Upload-Content-Disposition, X-Goog-Upload-Content-Length, X-Goog-Upload-Content-Type, X-Goog-Upload-File-Name, X-Goog-Upload-Header-Content-Length, X-Goog-Upload-Offset, X-Goog-Upload-Protocol, x-goog-user-project, X-Goog-Visitor-Id, X-Goog-FieldMask, X-Google-Project-Override, X-Goog-Api-Key, X-HTTP-Method-Override, X-JavaScript-User-Agent, X-Pan-Versionid, X-Proxied-User-IP, X-Origin, X-Referer, X-Requested-With, X-Stadia-Client-Context, X-Upload-Content-Length, X-Upload-Content-Type, X-Use-HTTP-Status-Code-Override, X-Ios-Bundle-Identifier, X-Android-Package, X-Ariane-Xsrf-Token, X-YouTube-VVT, X-YouTube-Page-CL, X-YouTube-Page-Timestamp, X-Goog-Meeting-Botguardid, X-Goog-Meeting-Debugid, X-Goog-Meeting-Token, X-Client-Data, X-Sfdc-Authorization, MIME-Version, Content-Transfer-Encoding, X-Earth-Engine-App-ID-Token, X-Earth-Engine-Computation-Profile, X-Earth-Engine-Computation-Profiling, X-Play-Console-Experiments-Override, X-Play-Console-Session-Id
access-control-allow-methods: GET,OPTIONS
p3p: CP="This is not a P3P policy! See http://www.google.com/support/accounts/answer/151657?hl=en for more info."
location: https://docs.google.com/nonceSigner?nonce=ak7dsf55goec0&continue=https://doc-0s-3s-docs.googleusercontent.com/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom/f32ua6bkbk5eirm90s927rf367krpvg7/1586342175000/16108136141151180509/00777619999987158088Z/1DIi4JBVXA3kihcTWr55paCt5aZyEVl83?e%3Ddownload%26nonce%3Dgfn3ca1a61dru%26user%3D*%26hash%3D5qputqjvetp2sv0vb1nrahgkgqtpjsji&hash=0uqss73thgrn4uf9tactipiramp9j3qm
date: Wed, 08 Apr 2020 10:36:40 GMT
expires: Wed, 08 Apr 2020 10:36:40 GMT
cache-control: private, max-age=0
content-length: 0
server: UploadServer
set-cookie: AUTH_s4jj9vs5ngh61o5ikf7veu7s22i9i9m4_nonce=ak7dsf55goec0; Domain=doc-0s-3s-docs.googleusercontent.com; Expires=Wed, 08-Apr-2020 10:46:40 GMT; Path=/docs/securesc/jbcj0ghrdn0vtqhv6q8cgd0kg75c5pom; Secure; SameSite=none; HttpOnly
content-type: text/html; charset=UTF-8
alt-svc: quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443"; ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,h3-T050=":443"; ma=2592000

<<< LOOPING >>>
```

</details>

The fix consists in clearing the `.google.com` cookies when extraction is finished

I've tested the source and the derived/processed video formats with this change and now they all work. 