### PR TITLE
[cloudflarestream] fix JSON parsing of video_id

### DIFF
--- a/youtube_dl/extractor/cloudflarestream.py
+++ b/youtube_dl/extractor/cloudflarestream.py
@@ -30,6 +30,17 @@ class CloudflareStreamIE(InfoExtractor):
             'skip_download': True,
         },
     }, {
+        'url': 'https://embed.videodelivery.net/embed/r4xu.fla9.latest.js?video=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyIn0.eyJzdWIiOiI1ZDViYzM3ZmZjZjU0YzliODJlOTk2ODIzYmZmYmI4MSIsImtpZCI6IjVkNWJjMzdmZmNmNTRjOWI4MmU5OTY4MjNiZmZiYjgxIiwiZXhwIjoiMTYxNzM0NjgwMCIsIm5iZiI6IjE1ODU4MTA4MDAifQ.abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ',
+        'info_dict': {
+            'id': '5d5bc37ffcf54c9b82e996823bffbb81',
+            'ext': 'mp4',
+            'title': '5d5bc37ffcf54c9b82e996823bffbb81',
+        },
+        'params': {
+            'format': 'bestvideo',
+            'skip_download': True,
+        },
+    }, {
         'url': 'https://watch.cloudflarestream.com/9df17203414fd1db3e3ed74abbe936c1',
         'only_matching': True,
     }, {
@@ -53,8 +64,9 @@ class CloudflareStreamIE(InfoExtractor):
         domain = 'bytehighway.net' if 'bytehighway.net/' in url else 'videodelivery.net'
         base_url = 'https://%s/%s/' % (domain, video_id)
         if '.' in video_id:
-            video_id = self._parse_json(base64.urlsafe_b64decode(
-                video_id.split('.')[1]), video_id)['sub']
+            video_id = video_id.split('.')[1] + '===='
+            video_id = self._parse_json(base64.b64decode(
+                video_id), video_id)['sub']
         manifest_base_url = base_url + 'manifest/video.'
 
         formats = self._extract_m3u8_formats(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Sometimes Cloudlare would generate a base64-encoded JSON string with padding character (= "equal sign") missing. Thus when script tries to decode it we get this error on this line: https://github.com/ytdl-org/youtube-dl/blob/00eb865b3c8002f47e73706b54f58feaee0b0ac2/youtube_dl/extractor/cloudflarestream.py#L56
```
TypeError: Incorrect padding
```

This PR adds missing padding characters to the string before decoding it. Unit test case is added as well.
