### PR TITLE
[Feature] Add playlist title video selection option

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -978,7 +978,12 @@ class YoutubeDL(object):
 
             x_forwarded_for = ie_result.get('__x_forwarded_for_ip')
 
+            playlist_title_end = self.params.get('playlisttitleend')
             for i, entry in enumerate(entries, 1):
+                if playlist_title_end is not None:
+                    if entry['title'] == playlist_title_end:
+                        self.to_screen('[download] Stopping at video %s' % (playlist_title_end))
+                        break
                 self.to_screen('[download] Downloading video %s of %s' % (i, n_entries))
                 # This __x_forwarded_for_ip thing is a bit ugly but requires
                 # minimal changes

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -359,6 +359,7 @@ def _real_main(argv=None):
         'progress_with_newline': opts.progress_with_newline,
         'playliststart': opts.playliststart,
         'playlistend': opts.playlistend,
+        'playlisttitleend': opts.playlisttitleend,
         'playlistreverse': opts.playlist_reverse,
         'playlistrandom': opts.playlist_random,
         'noplaylist': opts.noplaylist,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -264,6 +264,10 @@ def parseOpts(overrideArguments=None):
         dest='playlistend', metavar='NUMBER', default=None, type=int,
         help='Playlist video to end at (default is last)')
     selection.add_option(
+        '--playlist-title-end',
+        dest='playlisttitleend', metavar='STRING', default=None, type=str,
+        help='Playlist video title to end at (default is None)')
+    selection.add_option(
         '--playlist-items',
         dest='playlist_items', metavar='ITEM_SPEC', default=None,
         help='Playlist video items to download. Specify indices of the videos in the playlist separated by commas like: "--playlist-items 1,2,5,8" if you want to download videos indexed 1, 2, 5, 8 in the playlist. You can specify range: "--playlist-items 1-3,7,10-13", it will download the videos at index 1, 2, 3, 7, 10, 11, 12 and 13.')


### PR DESCRIPTION
Add --playlist-title-end option to end video selection at a given video's title.

Signed-off-by: Liav Rehana <liavrehana@gmail.com>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

When downloading videos from a playlist, for example the 'Liked Videos' playlist, sometimes we want the video selection to end at a given video by its title, and not by its index. The following Pull Request adds the --playlist-title-end option to end to video selection when reaching a given video's title.
