### PR TITLE
[youtube] Fix download of auto-captions when manual subtitles are available

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1519,6 +1519,14 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 if player_response:
                     renderer = player_response['captions']['playerCaptionsTracklistRenderer']
                     base_url = renderer['captionTracks'][0]['baseUrl']
+                    # the first caption track might contain manual
+                    # subtitles not auto-captions (e.g. 2klmuggOElE,
+                    # accessed on 16.04.2020) so we look further in
+                    # captionTracks and select a base_url from an
+                    # explicitly marked asr track if one exists.
+                    for track in renderer['captionTracks'][1:]:
+                        if track.get('kind') == 'asr':
+                            base_url = track['baseUrl']
                     sub_lang_list = []
                     for lang in renderer['translationLanguages']:
                         lang_code = lang.get('languageCode')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

When invoked with `--write-auto-sub` (but without `--write-sub`), youtube-dl should only download automatic captions. However, for some videos with both automatic captions and manual subtitles (e.g. [2klmuggOElE](https://www.youtube.com/watch?v=2klmuggOElE); accessed on 16.04.2020), youtube-dl selects the manual subtitle track regardless.

You can check it by running `python -m youtube_dl --write-auto-sub --sub-lang=en --sub-format=vtt --skip-download https://www.youtube.com/watch?v=2klmuggOElE`: the autogenerated subtitles have `<c>` timestamp markers, whereas the uploaded ones do not.

This commit makes `_get_automatic_captions` select the `renderer['captionTracks']` entry with `'kind' == 'asr'`, if one is available. This is based on the relevant `renderer['captionTracks']` content:
```
[{'languageCode': 'en',
  'vssId': '.en',
  'isTranslatable': True,
  'baseUrl': 'https://www.youtube.com/api/timedtext?v=2klmuggOElE&asr_langs=de,en,es,fr,it,ja,ko,nl,pt,ru&caps=asr&xorp=true&hl=en&ip=0.0.0.0&ipbits=0&expire=1587092575&sparams=ip,ipbits,expire,v,asr_langs,caps,xorp&signature=83FDAEAA57AABEB7B224FA45A11C93F480755E33.39E01E3C076FC344D5B9FC03E3FAAB3A1511B82B&key=yt8&lang=en',
  'name': {'simpleText': 'English'}},
 {'languageCode': 'en',
  'kind': 'asr',
  'name': {'simpleText': 'English (auto-generated)'},
  'baseUrl': 'https://www.youtube.com/api/timedtext?v=2klmuggOElE&asr_langs=de,en,es,fr,it,ja,ko,nl,pt,ru&caps=asr&xorp=true&hl=en&ip=0.0.0.0&ipbits=0&expire=1587092575&sparams=ip,ipbits,expire,v,asr_langs,caps,xorp&signature=83FDAEAA57AABEB7B224FA45A11C93F480755E33.39E01E3C076FC344D5B9FC03E3FAAB3A1511B82B&key=yt8&kind=asr&lang=en',
  'isTranslatable': True,
  'vssId': 'a.en'}]
```
The code before this patch hard-codes always selecting the first entry (in this case, English) whereas with this patch it will select the second one (in this case, English (auto-generated)).

We could have filtered by `vssId.startswith('a.')` but `kind=asr` parameter is the only distinguishing parameter for `baseUrl`'s so I am opting to use that.

Let me know if there are any changes you'd like to see; happy to adjust the patch.