### PR TITLE
[Pluralsight] multiple subtitles download (fix #13990)

### DIFF
--- a/youtube_dl/extractor/pluralsight.py
+++ b/youtube_dl/extractor/pluralsight.py
@@ -422,9 +422,9 @@ query viewClip {
             clip.get('duration')) or parse_duration(clip.get('formattedDuration'))
 
         available_languages = [language['code'] for language in course['translationLanguages']]
-        requested_languages = self._downloader.params['subtitleslangs']
 
-        languages_to_retrieve = set(available_languages).intersection(requested_languages)
+        languages_to_retrieve = available_languages if self._downloader.params['allsubtitles'] \
+            else set(available_languages).intersection(self._downloader.params['subtitleslangs'])
 
         subtitles = self.extract_subtitles(
             author, clip_idx, clip.get('clipId'), languages_to_retrieve, name, duration, display_id)

--- a/youtube_dl/extractor/pluralsight.py
+++ b/youtube_dl/extractor/pluralsight.py
@@ -241,7 +241,7 @@ query viewClip {
                 return [{'ext': 'json', 'data': json.dumps(captions), },
                         {'ext': 'srt', 'data': self._convert_subtitles(duration, captions), }]
 
-        return {language: _get_captions_for_language(language) for language in languages}
+        return dict((language, _get_captions_for_language(language)) for language in languages)
 
     @staticmethod
     def _convert_subtitles(duration, subs):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request solves https://github.com/ytdl-org/youtube-dl/issues/13990 issue, so it enables downloading multiple subtitles on pluralsight by running:
```shell
$ youtube-dl PLURALSIGHT_COURSE_URL -u "USERNAME" -p "PASSWORD" --write-sub --sub-lang en,es
```

Also to retrieve all available subtitles by running:
```shell
$ youtube-dl PLURALSIGHT_COURSE_URL -u "USERNAME" -p "PASSWORD" --all-subs
```
