### PR TITLE
[ruutu] Add support for supla.fi/audio/* URLs

### DIFF
--- a/youtube_dl/extractor/ruutu.py
+++ b/youtube_dl/extractor/ruutu.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class RuutuIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:ruutu|supla)\.fi/(?:video|supla)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:ruutu|supla)\.fi/(?:video|supla|audio)/(?P<id>\d+)'
     _TESTS = [
         {
             'url': 'http://www.ruutu.fi/video/2058907',
@@ -42,7 +42,7 @@ class RuutuIE(InfoExtractor):
             },
         },
         {
-            'url': 'http://www.supla.fi/supla/2231370',
+            'url': 'http://www.supla.fi/audio/2231370',
             'md5': 'df14e782d49a2c0df03d3be2a54ef949',
             'info_dict': {
                 'id': '2231370',
@@ -61,7 +61,7 @@ class RuutuIE(InfoExtractor):
         },
         {
             # audio podcast
-            'url': 'https://www.supla.fi/supla/3382410',
+            'url': 'https://www.supla.fi/audio/3382410',
             'md5': 'b9d7155fed37b2ebf6021d74c4b8e908',
             'info_dict': {
                 'id': '3382410',
@@ -71,7 +71,11 @@ class RuutuIE(InfoExtractor):
                 'thumbnail': r're:^https?://.*\.jpg$',
                 'age_limit': 0,
             },
-            'expected_warnings': ['HTTP Error 502: Bad Gateway'],
+            'expected_warnings': [
+                'HTTP Error 400: Bad Request',
+                'HTTP Error 403: Forbidden',
+                'HTTP Error 502: Bad Gateway'
+            ],
         }
     ]
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Adds support for URLs of form http://supla.fi/audio/[id] which is now the default for audio.
