### PR TITLE
[WIP] [tele5] Fix extractor and add playlist support

### DIFF
--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -24,15 +24,15 @@ class Tele5IE(InfoExtractor):
             'id': 'XSWj0xbO',
             'ext': 'mp4',
             # fun fact: upload_date is not visible on the web page for this video
-            'upload_date': '20200326', # this is a re-upload
+            'upload_date': '20200326',  # this is a re-upload
             'timestamp': 1585190811,
             'duration': 8701.0,
             'title': 'SchleFaZ: Der Polyp - Die Bestie mit den Todesarmen (ab 13.04.2018)',
             'description': 'SchleFaZ: Der Polyp - Die Bestie mit den Todesarmen (ab 13.04.2018)'
         },
         'params': {
-            'skip_download': True
-        }
+            'skip_download': True,
+        },
     }, {
         'url': 'https://www.tele5.de/filme/schlefaz-dragon-crusaders/',
         'info_dict': {
@@ -45,8 +45,8 @@ class Tele5IE(InfoExtractor):
             'description': 'Drachenzähmen schlecht gemacht! Oliver Kalkofe und Peter Rütten knöpfen sich mit "SchleFaZ: Dragon Crusaders" eine wahrhaft verhext-verflixte Drachen-Sause vor. Statt großer Kampf, großer Krampf. Nicht nur in den Füßen, die einem bei dem müden Fantasy-Abenteuer garantiert einschlafen!'
         },
         'params': {
-            'skip_download': True
-        }
+            'skip_download': True,
+        },
     }, {
         # TODO: 400 Bad Request error on webpage, remove this test? (they might fix it eventually)
         'url': 'https://www.tele5.de/video-clip/?ve_id=1609440',
@@ -87,8 +87,8 @@ class Tele5IE(InfoExtractor):
             def extract_id(pattern, name, default=NO_DEFAULT):
                 return self._html_search_regex(
                     (r'id\s*=\s*["\']video-player["\'][^>]+data-id\s*=\s*["\'](%s)' % pattern,
-                    r'\s+id\s*=\s*["\']player_(%s)' % pattern,
-                    r'\bdata-id\s*=\s*["\'](%s)' % pattern), webpage, name,
+                     r'\s+id\s*=\s*["\']player_(%s)' % pattern,
+                     r'\bdata-id\s*=\s*["\'](%s)' % pattern), webpage, name,
                     default=default)
 
             if not jwplatform_id:
@@ -105,8 +105,8 @@ class Tele5IE(InfoExtractor):
                 media, lambda x: x['playlist'][0]['nexx_id'], compat_str)
 
             # TODO: nexx offers more formats, but fails (404) on some videos
-            #if nexx_id:
-                #return nexx_result(nexx_id)
+            # if nexx_id:
+            #    return nexx_result(nexx_id)
 
         return self.url_result(
             'jwplatform:%s' % jwplatform_id, ie=JWPlatformIE.ie_key(),

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -91,6 +91,19 @@ class Tele5IE(InfoExtractor):
             media = self._download_json(
                 'https://cdn.jwplayer.com/v2/media/' + jwplatform_id,
                 display_id)
+
+            m3u8_url = try_get(
+                media, lambda x: x['playlist'][0]['sources'][0]['file'], compat_str)
+
+            if m3u8_url:
+                formats = self._extract_m3u8_formats(m3u8_url, jwplatform_id, 'mp4', fatal=False)
+                return {
+                    'id': '%s' % jwplatform_id,
+                    'title': try_get(media, lambda x: x['title'], compat_str),
+                    # TODO: description, thumbnail, duration
+                    'formats': formats
+                }
+
             nexx_id = try_get(
                 media, lambda x: x['playlist'][0]['nexx_id'], compat_str)
 

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -56,6 +56,21 @@ class Tele5IE(InfoExtractor):
         },
         'playlist_count': 6,
     }, {
+        'url': 'https://www.tele5.de/kalkofes-welt/best-of-clips/worst-of-internet/?ve_id=dm2hJgJp',
+        'info_dict': {
+            'id': 'dm2hJgJp',
+            'ext': 'mp4',
+            'title': 'Freshtorge - Sandra trifft Frau Merkel',
+            'upload_date': '20200326',
+            'description': 'Freshtorge - Sandra trifft Frau Merkel',
+            'timestamp': 1585185161,
+            'duration': 170.0,
+        },
+        'params': {
+            'noplaylist': True,
+            'skip_download': True,
+        },
+    }, {
         'url': 'https://www.tele5.de/filme/making-of/avengers-endgame/',
         'only_matching': True,
     }, {
@@ -66,7 +81,6 @@ class Tele5IE(InfoExtractor):
     def _real_extract(self, url):
         url, smuggled_data = unsmuggle_url(url, {})
 
-        # TODO: do we really need this?
         qs = compat_urlparse.parse_qs(compat_urlparse.urlparse(url).query)
         video_id = (qs.get('vid') or qs.get('ve_id') or [None])[0]
 

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -92,7 +92,7 @@ class Tele5IE(InfoExtractor):
             webpage = self._download_webpage(url, display_id)
 
             if not smuggled_data.get('force_singlevideo', False):
-                # TODO: user now has to specify --no-playlist every time (bad)
+                # TODO: user now has to specify --no-playlist every time (annoying and not expected)
                 if not self._downloader.params.get('noplaylist'):
                     # TODO: use something other than a regex?
                     urls = re.findall('href="([^"]+)"\\s+class="special-video__link(?: video-teaser__link)?"', webpage, re.MULTILINE)
@@ -105,6 +105,7 @@ class Tele5IE(InfoExtractor):
                                 'https://tele5.de%s' % url,
                                 {'force_singlevideo': True}),
                         })
+                    # TODO: use something other than a regex?
                     title = self._html_search_regex("<h1>([^<]+)</h1>", webpage, 'playlist title')
                     return self.playlist_result(entries, playlist_title=title)
 

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -106,8 +106,9 @@ class Tele5IE(InfoExtractor):
                                 {'force_singlevideo': True}),
                         })
                     # TODO: use something other than a regex?
-                    title = self._html_search_regex("<h1>([^<]+)</h1>", webpage, 'playlist title')
-                    return self.playlist_result(entries, playlist_title=title)
+                    title = re.search("<h1>([^<]+)</h1>", webpage, 0)
+                    if title:
+                        return self.playlist_result(entries, playlist_title=title.group(1))
 
             def extract_id(pattern, name, default=NO_DEFAULT):
                 return self._html_search_regex(

--- a/youtube_dl/extractor/tele5.py
+++ b/youtube_dl/extractor/tele5.py
@@ -91,16 +91,16 @@ class Tele5IE(InfoExtractor):
                      r'\bdata-id\s*=\s*["\'](%s)' % pattern), webpage, name,
                     default=default)
 
-            if not jwplatform_id:
-                jwplatform_id = extract_id(JWPLATFORM_ID_RE, 'jwplatform id')
             nexx_id = extract_id(NEXX_ID_RE, 'nexx id', default=None)
             if nexx_id:
                 return nexx_result(nexx_id)
 
+            if not jwplatform_id:
+                jwplatform_id = extract_id(JWPLATFORM_ID_RE, 'jwplatform id')
+
             media = self._download_json(
                 'https://cdn.jwplayer.com/v2/media/' + jwplatform_id,
                 display_id)
-
             nexx_id = try_get(
                 media, lambda x: x['playlist'][0]['nexx_id'], compat_str)
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests: there are none
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement

---

### Description of your *pull request* and other information

This patch is **WIP**. Tests are updated. Playlist support is added.
Nexx downloading is disabled (this is the WIP part) because I do not know to try another extractor in this extractor. Some videos can be downloaded using the nexx extractor, some fail and can instead be downloaded using the JW player method. And I would prefer extracting the playlist metadata out of the HTML using something that isn't a regex, but I was unable to find any utility function that parses the webpage into a searchable structure.
(commits will be squashed once the patch is done)