### PR TITLE
Remove ERROR: prefix on messages if logger is set

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -614,14 +614,17 @@ class YoutubeDL(object):
 
     def report_error(self, message, tb=None):
         '''
-        Do the same as trouble, but prefixes the message with 'ERROR:', colored
+        Do the same as trouble, but prefixes the message with 'ERROR:' if logger is not set, colored
         in red if stderr is a tty file.
         '''
-        if not self.params.get('no_color') and self._err_file.isatty() and compat_os_name != 'nt':
-            _msg_header = '\033[0;31mERROR:\033[0m'
+        if self.params.get('logger') is not None:
+            error_message = message
         else:
-            _msg_header = 'ERROR:'
-        error_message = '%s %s' % (_msg_header, message)
+            if not self.params.get('no_color') and self._err_file.isatty() and compat_os_name != 'nt':
+                _msg_header = '\033[0;31mERROR:\033[0m'
+            else:
+                _msg_header = 'ERROR:'
+            error_message = '%s %s' % (_msg_header, message)
         self.trouble(error_message, tb)
 
     def report_file_already_downloaded(self, file_name):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently `youtube_dl.YoutubeDL.report_error` prepends all messages  with "ERROR:" which is redundant in the case where an API user specifies a logger.  This results in log messages that look like the following:
```console
ytdl - ERROR - ERROR: dQw4w9WgXca: YouTube said: This video is unavailable.
```
The first ERROR is a result of the logger's settings and the "ERROR:" is a result of `report_error`.  This PR adds a check to see if a logger is specified and, if so, does not prepend the "ERROR:" string.  The proposed new behavior matches the existing `youtube_dl.YoutubeDL.report_warning` behavior.
