### PR TITLE
[cbsnews] Handle iframes with src (closes #24790)

### DIFF
--- a/youtube_dl/extractor/cbsnews.py
+++ b/youtube_dl/extractor/cbsnews.py
@@ -95,7 +95,8 @@ class CBSNewsIE(CBSIE):
         webpage = self._download_webpage(url, display_id)
 
         entries = []
-        for embed_url in re.findall(r'<iframe[^>]+data-src="(https?://(?:www\.)?cbsnews\.com/embed/video/[^#]*#[^"]+)"', webpage):
+        # This regex is intended to match attributes src and data-src
+        for embed_url in re.findall(r'<iframe[^>]+src="(https?://(?:www\.)?cbsnews\.com/embed/video/[^#]*#[^"]+)"', webpage):
             entries.append(self.url_result(embed_url, CBSNewsEmbedIE.ie_key()))
         if entries:
             return self.playlist_result(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently only iframes with a data-src attribute are recognised by the
extractor, meaning no video is found for the URL in the linked bug
(extraction fails with RegexNotFoundError).

This fix removes "data-" from the regex pattern, meaning both data-src
and src will be matched. Technically something like xyzsrc would be
matched as well, but I do not think this is a problem.
