### PR TITLE
[twitch] Handle new /videos URLs (closes #24263)

### DIFF
--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -438,76 +438,76 @@ class TwitchVideosBaseIE(TwitchPlaylistBaseIE):
 
 class TwitchAllVideosIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:all'
-    _VALID_URL = r'%s/all' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\?filter=all' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive,upload,highlight'
     _PLAYLIST_TYPE = 'all videos'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/all',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=all&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
-        'playlist_mincount': 869,
+        'playlist_mincount': 893,
     }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/all',
+        'url': 'https://m.twitch.tv/spamfish/videos?filter=all&sort=time',
         'only_matching': True,
     }]
 
 
 class TwitchUploadsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:uploads'
-    _VALID_URL = r'%s/uploads' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\?filter=uploads' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'upload'
     _PLAYLIST_TYPE = 'uploads'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/uploads',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=uploads&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
         'playlist_mincount': 0,
     }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/uploads',
+        'url': 'https://m.twitch.tv/spamfish/videos?filter=uploads&sort=time',
         'only_matching': True,
     }]
 
 
 class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:past-broadcasts'
-    _VALID_URL = r'%s/past-broadcasts' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\?filter=archives' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'archive'
     _PLAYLIST_TYPE = 'past broadcasts'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/past-broadcasts',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=archives&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
-        'playlist_mincount': 0,
+        'playlist_mincount': 25,
     }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/past-broadcasts',
+        'url': 'https://m.twitch.tv/spamfish/videos?filter=archives&sort=time',
         'only_matching': True,
     }]
 
 
 class TwitchHighlightsIE(TwitchVideosBaseIE):
     IE_NAME = 'twitch:videos:highlights'
-    _VALID_URL = r'%s/highlights' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
+    _VALID_URL = r'%s\?filter=highlights' % TwitchVideosBaseIE._VALID_URL_VIDEOS_BASE
     _PLAYLIST_PATH = TwitchVideosBaseIE._PLAYLIST_PATH + 'highlight'
     _PLAYLIST_TYPE = 'highlights'
 
     _TESTS = [{
-        'url': 'https://www.twitch.tv/spamfish/videos/highlights',
+        'url': 'https://www.twitch.tv/spamfish/videos?filter=highlights&sort=time',
         'info_dict': {
             'id': 'spamfish',
             'title': 'Spamfish',
         },
-        'playlist_mincount': 805,
+        'playlist_mincount': 867,
     }, {
-        'url': 'https://m.twitch.tv/spamfish/videos/highlights',
+        'url': 'https://m.twitch.tv/spamfish/videos?filter=highlights&sort=time',
         'only_matching': True,
     }]
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Twitch URLs on the path /videos have changed e.g. from
/videos/highlights to /videos?filter=highlights.

I have added support for the new URLs. The old URLs now redirect to the
base videos page, so I have removed support for them.
