### PR TITLE
[youtube] Extract 'a href' links to YouTube videos

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1227,6 +1227,22 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             'url': 'https://www.youtubekids.com/watch?v=3b8nCWDgZ6Q',
             'only_matching': True,
         },
+        {
+            # A page with a link to a YouTube video
+            'url': 'http://curio.scene.org/demo/monad-macau-exports-atlas/',
+            'info_dict': {
+                'id': 'mVdISz9-iFc',
+                'ext': 'mp4',
+                'upload_date': '20190425',
+                'uploader': 'Demoscene in 23.976 Hertz',
+                'description': 'A 64 kilobyte demo (intro) released at Revision 2019. Reached 3rd place in the 64k Intro Compo. Download and comments: https://www.pouet.net/prod.php?which=80996',
+                'uploader_id': 'UC_Il-swQwhyPXhKyCdRfyXg',
+                'title': 'Atlas by Monad & Macau Exports',
+            },
+            'params': {
+                'skip_download': True,
+            },
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -1600,6 +1616,16 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             class=(?P<q1>[\'"])[^\'"]*\byvii_single_video_player\b[^\'"]*(?P=q1)[^>]+
             data-video_id=(?P<q2>[\'"])([^\'"]+)(?P=q2)''', webpage)
         entries.extend(m[-1] for m in matches)
+
+        # A link to a YouTube video
+        entries.extend(list(map(
+            unescapeHTML,
+            re.findall(r'''(?x)
+                <a [^>]*href=[\'"](
+                    (?:https?:)?//(?:www\.)?youtube(?:-nocookie)?\.com/
+                    [^\'"]+
+                )[\'"]
+            ''', webpage))))
 
         return entries
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
I'd like to use youtube-dl to download new videos from the RSS feed http://curio.scene.org/rss/ .  Each RSS feed item links to a web page that then links to a YouTube video.  youtube-dl correctly parses the RSS feed, but it doesn't recognize the links to the YouTube videos.  This PR enables it to find those links and download the videos from the playlist.