### PR TITLE
Add support for BigBlueButton (BBB) recordings

### DIFF
--- a/youtube_dl/extractor/bbb.py
+++ b/youtube_dl/extractor/bbb.py
@@ -20,13 +20,13 @@ from __future__ import unicode_literals
 from .common import InfoExtractor
 
 from ..utils import (
-    unified_timestamp,
     xpath_text,
     xpath_with_ns,
 )
 
 _s = lambda p: xpath_with_ns(p, {'svg': 'http://www.w3.org/2000/svg'})
 _x = lambda p: xpath_with_ns(p, {'xlink': 'http://www.w3.org/1999/xlink'})
+
 
 class BigBlueButtonIE(InfoExtractor):
     _VALID_URL = r'(?P<website>https?://[^/]+)/playback/presentation/2.0/playback.html\?meetingId=(?P<id>[0-9a-f\-]+)'
@@ -65,7 +65,8 @@ class BigBlueButtonIE(InfoExtractor):
         m = self._VALID_URL_RE.match(url)
         website = m.group('website')
 
-        webpage = self._download_webpage(url, video_id)
+        # We don't parse anything, but make sure it exists
+        self._download_webpage(url, video_id)
 
         # Extract basic metadata (more available in metadata.xml)
         metadata_url = website + '/presentation/' + video_id + '/metadata.xml'
@@ -86,7 +87,7 @@ class BigBlueButtonIE(InfoExtractor):
                 'url': image.text.strip(),
                 'width': image.get('width'),
                 'height': image.get('height')
-                }
+            }
 
         # This code mostly useless unless one know how to process slides
         shapes_url = website + '/presentation/' + video_id + '/shapes.svg'
@@ -102,7 +103,10 @@ class BigBlueButtonIE(InfoExtractor):
         #   for merging its video) - it lacks the slides, unfortunately
         formats = []
 
-        sources = { 'webcams': '/video/webcams.webm', 'deskshare': '/deskshare/deskshare.webm' }
+        sources = {
+            'webcams': '/video/webcams.webm',
+            'deskshare': '/deskshare/deskshare.webm'
+        }
         for format_id, source in sources.items():
             video_url = website + '/presentation/' + video_id + source
             formats.append({
@@ -112,9 +116,8 @@ class BigBlueButtonIE(InfoExtractor):
         self._sort_formats(formats)
 
         return {
-            'id': video_id,
+            'id': id,
             'title': title,
             'formats': formats,
             'timestamp': int(start_time),
-#            'thumbnails': thumbnails
         }

--- a/youtube_dl/extractor/bbb.py
+++ b/youtube_dl/extractor/bbb.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+
+# Extract material from recordings made inside BigBlueButton
+
+# BigBlueButton records multiple videos :
+#  - speaker speech & webcam
+#  - screesharing
+# for slides, annotations, etc. the playback app typically renders them on the fly upon playback
+# so it may not be easy to capture that with youtube-dl
+
+
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+from .openload import PhantomJSwrapper
+
+# TODO : thumbnails
+
+class BigBlueButtonIE(InfoExtractor):
+    _VALID_URL = r'(?P<website>https?://[^/]+)/playback/presentation/2.0/playback.html\?meetingId=(?P<id>[0-9a-f\-]+)'
+    _TEST = {
+        'url': 'https://mybbb.example.com/playback/presentation/2.0/playback.html?meetingId=12345679a50a715e8d6dc692df996dceb8d788f8-1234566973639',
+        'md5': 'TODO: md5 sum of the first 10241 bytes of the video file (use --test)',
+        'info_dict': {
+            'id': '42',
+            'ext': 'mp4',
+            'title': 'Video title goes here',
+            'thumbnail': r're:^https?://.*\.jpg$',
+            # TODO more properties, either as:
+            # * A value
+            # * MD5 checksum; start the string with md5:
+            # * A regular expression; start the string with re:
+            # * Any Python type (for example int or float)
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        m = self._VALID_URL_RE.match(url)
+        website = m.group('website')
+        #print(video_id)
+        print(website)
+
+        webpage = self._download_webpage(url, video_id)
+
+        # print(webpagejs)
+
+        # TODO more code goes here, for example ...
+        #title = self._html_search_regex(r'<h1>(.+?)</h1>', webpage, 'title')
+        title = video_id
+
+        formats = []
+
+        sources = { 'speaker': '/video/webcams.webm', 'slides': '/deskshare/deskshare.webm' }
+        for format_id, source in sources.items():
+            video_url = website + '/presentation/' + video_id + source
+            formats.append({
+                'url': video_url,
+                'format_id': format_id
+            })
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': title,
+            'formats': formats,
+ #           'description': self._og_search_description(webpage),
+#            'uploader': self._search_regex(r'<div[^>]+id="uploader"[^>]*>([^<]+)<', webpage, 'uploader', fatal=False),
+            # TODO more properties (see youtube_dl/extractor/common.py)
+        }
+    

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -81,6 +81,7 @@ from .awaan import (
 from .azmedien import AZMedienIE
 from .baidu import BaiduVideoIE
 from .bandcamp import BandcampIE, BandcampAlbumIE, BandcampWeeklyIE
+from .bbb import BigBlueButtonIE
 from .bbc import (
     BBCCoUkIE,
     BBCCoUkArticleIE,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

BigBlueButton (aka BBB) is a virtual classrooms tool that allows recording the classes. Its recordings playback application doesn't provide a recording download feature, bu default. Hence the potential use for this contribution.

Note that BBB records multiple feeds : speaker audio (and webcam) and screen sharing, while slides aren't recorded in video (later playback of slide images + annotations).

This work is related to https://github.com/trahay/bbb-downloader that was made by my colleague François Trahay.
