### PR TITLE
Update video_id regexp to account for recent abc.com changes (fixes #25197 and #25207)

### DIFF
--- a/youtube_dl/extractor/go.py
+++ b/youtube_dl/extractor/go.py
@@ -138,7 +138,7 @@ class GoIE(AdobePassIE):
                     # from http://freeform.go.com/shows/shadowhunters/episodes/season-2/1-this-guilty-blood
                     r'data-video-id=["\']*(VDKA\w+)',
                     # https://abc.com/shows/the-rookie/episode-guide/season-02/03-the-bet
-                    r'\b(?:video)?id["\']\s*:\s*["\'](VDKA\w+)'
+                    r'\bvideoIdCode["\']\s*:\s*["\'](vdka\w+)'
                 ), webpage, 'video id', default=video_id)
             if not site_info:
                 brand = self._search_regex(

--- a/youtube_dl/extractor/go.py
+++ b/youtube_dl/extractor/go.py
@@ -138,7 +138,9 @@ class GoIE(AdobePassIE):
                     # from http://freeform.go.com/shows/shadowhunters/episodes/season-2/1-this-guilty-blood
                     r'data-video-id=["\']*(VDKA\w+)',
                     # https://abc.com/shows/the-rookie/episode-guide/season-02/03-the-bet
-                    r'\bvideoIdCode["\']\s*:\s*["\'](vdka\w+)'
+                    r'\bvideoIdCode["\']\s*:\s*["\'](vdka\w+)',
+                    # Deprecated  fallback pattern
+                    r'\b(?:video)?id["\']\s*:\s*["\'](VDKA\w+)'
                 ), webpage, 'video id', default=video_id)
             if not site_info:
                 brand = self._search_regex(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request fixes #25197 and #25207 by accounting for the new changes on abc.com&mdash;first noticed on Wednesday, May 6. Now, the unique video ID can be found by searching for videoIdCode; note that only one instance will be found), potentially avoiding any false positives, e.g., other video IDs referenced on the page.

The solution was to change the regexp on line 141 and simplifying it for the new name on the video's source. The Rookie video in the examples dictionary can be used to verify the new changes.