### PR TITLE
Editing Giantbomb extraction to include /shows/ links

### DIFF
--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -16,7 +16,7 @@ class GiantBombIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?giantbomb\.com/(videos|shows)/(?P<display_id>[^/]+)/(?P<id>\d+-\d+)'
     _TESTS = [{
         'url': 'http://www.giantbomb.com/videos/quick-look-destiny-the-dark-below/2300-9782/',
-        'md5': 'c8ea694254a59246a42831155dec57ac',
+        'md5': '132f5a803e7e0ab0e274d84bda1e77ae',
         'info_dict': {
             'id': '2300-9782',
             'display_id': 'quick-look-destiny-the-dark-below',

--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-
 import re
 import json
 
@@ -29,7 +28,6 @@ class GiantBombIE(InfoExtractor):
     }, {
         'url': 'https://www.giantbomb.com/shows/ben-stranding/2970-20212',
         'only_matching': True,
-        }
     }]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -28,15 +28,7 @@ class GiantBombIE(InfoExtractor):
         }
     }, {
         'url': 'https://www.giantbomb.com/shows/ben-stranding/2970-20212',
-        'md5': '92d94e1d072d559df7e95129315a9870',
-        'info_dict': {
-            'id': '2970-20212',
-            'display_id': 'ben-stranding',
-            'ext': 'mp4',
-            'title': 'Lockdown 2020: Ben Stranding',
-            'description': 'md5:dfe795e0718a65baee2183c107b87478',
-            'duration': 5100,
-            'thumbnail': r're:^https?://.*\.png$',
+        'only_matching': True,
         }
     }]
 

--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class GiantBombIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?giantbomb\.com/(videos|shows)/(?P<display_id>[^/]+)/(?P<id>\d+-\d+)'
+    _VALID_URL = r'https?://(?:www\.)?giantbomb\.com/(?:videos|shows)/(?P<display_id>[^/]+)/(?P<id>\d+-\d+)'
     _TESTS = [{
         'url': 'http://www.giantbomb.com/videos/quick-look-destiny-the-dark-below/2300-9782/',
         'md5': '132f5a803e7e0ab0e274d84bda1e77ae',

--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import re
 import json
 

--- a/youtube_dl/extractor/giantbomb.py
+++ b/youtube_dl/extractor/giantbomb.py
@@ -13,8 +13,8 @@ from ..utils import (
 
 
 class GiantBombIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?giantbomb\.com/videos/(?P<display_id>[^/]+)/(?P<id>\d+-\d+)'
-    _TEST = {
+    _VALID_URL = r'https?://(?:www\.)?giantbomb\.com/(videos|shows)/(?P<display_id>[^/]+)/(?P<id>\d+-\d+)'
+    _TESTS = [{
         'url': 'http://www.giantbomb.com/videos/quick-look-destiny-the-dark-below/2300-9782/',
         'md5': 'c8ea694254a59246a42831155dec57ac',
         'info_dict': {
@@ -26,7 +26,19 @@ class GiantBombIE(InfoExtractor):
             'duration': 2399,
             'thumbnail': r're:^https?://.*\.jpg$',
         }
-    }
+    }, {
+        'url': 'https://www.giantbomb.com/shows/ben-stranding/2970-20212',
+        'md5': '92d94e1d072d559df7e95129315a9870',
+        'info_dict': {
+            'id': '2970-20212',
+            'display_id': 'ben-stranding',
+            'ext': 'mp4',
+            'title': 'Lockdown 2020: Ben Stranding',
+            'description': 'md5:dfe795e0718a65baee2183c107b87478',
+            'duration': 5100,
+            'thumbnail': r're:^https?://.*\.png$',
+        }
+    }]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

A majority of Giantbomb's videos are collected in the form of a "show" so the urls are giantbomb.com/shows/xxxxx rather than the giantbomb.com/videos/xxxxx

The current extractor only supports /videos/ links so I edited the regex to include /shows/ links.

I also edited the existing test that was in the extractor as it was failing due to a bad md5 value, it's possible that some backend changes over at giantbomb caused this to change.
