### PR TITLE
[zdf] complete title for multi episode program

### DIFF
--- a/youtube_dl/extractor/zdf.py
+++ b/youtube_dl/extractor/zdf.py
@@ -110,9 +110,8 @@ class ZDFIE(ZDFBaseIE):
             formats.append(f)
 
     def _extract_entry(self, url, player, content, video_id):
-        title = content.get('title') or content['teaserHeadline']
-
         t = content['mainVideoContent']['http://zdf.de/rels/target']
+        title = (t.get('title') or content.get('title') or content['teaserHeadline']).strip()
 
         ptmd_path = t.get('http://zdf.de/rels/streams/ptmd')
 


### PR DESCRIPTION
### Small metadata extractor fix

The title of this program was not complete:

url: https://www.zdf.de/dokumentation/zdfinfo-doku/china-der-entfesselte-riese-praesident-auf-lebenszeit--100.html  
title extracted: `"China: Präsident auf Lebenszeit "`  
actual title: `"China - Der entfesselte Riese (1/3): Präsident auf Lebenszeit "`  

Besides that the title did not have the white space at the end `.strip()`-ed.
So the result will be like this with the change:
`"China - Der entfesselte Riese (1/3): Präsident auf Lebenszeit"`
