### PR TITLE
[orf] Add Radiothek extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -814,6 +814,7 @@ from .orf import (
     ORFSBGIE,
     ORFTIRIE,
     ORFVBGIE,
+    ORFRadiothekIE,
     ORFIPTVIE,
 )
 from .outsidetv import OutsideTVIE

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -376,6 +376,38 @@ class ORFOE1IE(ORFRadioIE):
     }
 
 
+class ORFRadiothekIE(ORFRadioIE):
+    _VALID_URL = r'https?://radiothek\.orf\.at/(?P<station>\w+)/(?P<date>[0-9]+)/(?P<show>\w+)'
+    IE_NAME = 'orf:radiothek'
+    IE_DESC = 'ORF Radiothek'
+
+    _API_LOOP_MAP = {
+        'fm4': 'fm4',
+        'noe': 'oe2n',
+        'wie': 'oe2w',
+        'bgl': 'oe2b',
+        'ooe': 'oe2o',
+        'stm': 'oe2st',
+        'ktn': 'oe2k',
+        'sbg': 'oe2s',
+        'tir': 'oe2t',
+        'vbg': 'oe2v',
+        'oe3': 'oe3',
+        'oe1': 'oe1',
+    }
+
+    _TEST = {
+        'url': 'https://radiothek.orf.at/fm4/20200513/4UL',
+        'only_matching': True,
+    }
+
+    def _real_extract(self, url):
+        mobj = re.match(self._VALID_URL, url)
+        self._API_STATION = mobj.group('station')
+        self._LOOP_STATION = self._API_LOOP_MAP[mobj.group('station')]
+        return super(ORFRadiothekIE, self)._real_extract(url)
+
+
 class ORFIPTVIE(InfoExtractor):
     IE_NAME = 'orf:iptv'
     IE_DESC = 'iptv.ORF.at'


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

In additon to separate radio station pages, ORF also exposes all its radio stations via a common portal (ORF Radiothek). This PR adds an extractor to handle these alternative URLs.
