### PR TITLE
[extractor/xtube] add upload_date extracted from thumbnail URL

### DIFF
--- a/youtube_dl/extractor/xtube.py
+++ b/youtube_dl/extractor/xtube.py
@@ -99,6 +99,9 @@ class XTubeIE(InfoExtractor):
                 thumbnail = config.get('poster')
                 duration = int_or_none(config.get('duration'))
                 sources = config.get('sources') or config.get('format')
+                upload_date = self._search_regex(
+                    r'videos/(\d{6}/\d\d)/',
+                    thumbnail, 'upload_date', default='NA').replace('/', '')
 
         if not isinstance(sources, dict):
             sources = self._parse_json(self._search_regex(
@@ -152,6 +155,7 @@ class XTubeIE(InfoExtractor):
             'comment_count': comment_count,
             'age_limit': 18,
             'formats': formats,
+            'upload_date': upload_date,
         }
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The upload date of a video on xtube is embedded in both the video and thumbnail URLs in a funky form "YYYYMM/DD". Since the thumbnail URL is already extracted, this is pretty trivial to turn into YYYYMMDD.