### PR TITLE
[ruutu] Accept embedded video URLs

### DIFF
--- a/youtube_dl/extractor/ruutu.py
+++ b/youtube_dl/extractor/ruutu.py
@@ -13,7 +13,7 @@ from ..utils import (
 
 
 class RuutuIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?(?:ruutu|supla)\.fi/(?:video|supla)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?(?:ruutu|supla|static\.nelonenmedia)\.fi/(?:video/|supla/|player/misc/embed_player.html\?nid=)(?P<id>\d+)'
     _TESTS = [
         {
             'url': 'http://www.ruutu.fi/video/2058907',
@@ -72,7 +72,20 @@ class RuutuIE(InfoExtractor):
                 'age_limit': 0,
             },
             'expected_warnings': ['HTTP Error 502: Bad Gateway'],
-        }
+        },
+        # URL from embedded video
+        {
+            'url': 'https://static.nelonenmedia.fi/player/misc/embed_player.html?nid=3618790',
+            'md5': '71cca94775f29ef2fba12af92262647e',
+            'info_dict': {
+                'id': '3618790',
+                'ext': 'mp4',
+                'title': 'Kaukokärry hoitaa intialaisinsinöörin kauppareissut turvallisesti',
+                'thumbnail': r're:^https?://.*\.jpg$',
+                'duration': 77,
+                'age_limit': 0,
+            },
+        },
     ]
 
     def _real_extract(self, url):


### PR DESCRIPTION
#24748  Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Ruutu videos embedded to websites have URLs starting with
static.nelonenmedia.fi. Add support for these.