### PR TITLE
[weibo] Add fallback if first pattern fail

### DIFF
--- a/youtube_dl/extractor/weibo.py
+++ b/youtube_dl/extractor/weibo.py
@@ -73,8 +73,18 @@ class WeiboIE(InfoExtractor):
             webpage = self._download_webpage(
                 url, video_id, note='Revisiting webpage')
 
-        title = self._html_search_regex(
-            r'<title>(.+?)</title>', webpage, 'title')
+        def search_title(webpage):
+            # This may fail if page title contains a line breaks
+            # See #25401
+            title = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'title', default=None)
+
+            if title is None:
+                # Fallback if first pattern fail
+                title = self._search_regex(r'(?:\$CONFIG\[\'title_value\'\]=\'(.+?)\';)', webpage, 'title')
+
+            return title
+
+        title = search_title(webpage)
 
         video_formats = compat_parse_qs(self._search_regex(
             r'video-sources=\\\"(.+?)\"', webpage, 'video_sources'))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
The extractor fail to extract title using current regex because page title contains a line break
see #25401 
this PR provides a fallback if first pattern fail