### PR TITLE
[common.py] JWPlayer output template sequence improvements for Tele5

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -2733,6 +2733,13 @@ class InfoExtractor(object):
                 'timestamp': int_or_none(video_data.get('pubdate')),
                 'duration': float_or_none(jwplayer_data.get('duration') or video_data.get('duration')),
                 'subtitles': subtitles,
+                'alt_title': clean_html(video_data.get('subtitle')),  # attributes used e.g. by Tele5 ...
+                'genre': clean_html(video_data.get('genre')),
+                'channel': clean_html(video_data.get('category') or video_data.get('channel')),
+                'season_number': int_or_none(video_data.get('season')),
+                'episode_number': int_or_none(video_data.get('episode')),
+                'release_year': int_or_none(video_data.get('releasedate')),
+                'age_limit': int_or_none(video_data.get('age_restriction')),
             }
             # https://github.com/jwplayer/jwplayer/blob/master/src/js/utils/validator.js#L32
             if len(formats) == 1 and re.search(r'^(?:http|//).*(?:youtube\.com|youtu\.be)/.+', formats[0]['url']):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement

---

### Description of your *pull request* and other information

This improvement makes additional attributes of JWPlayer videos available, so that they can be used e.g. in filename templates.
Reason for this improvement was the shift of Tele5.de from nexx to jwplayer platform: For nexx, many attributes were available (nexx.py), but they got lost after shift to jwplayer (missing in function _parse_jwplayer_data() in common.py).
For example, for series many attributes are missing now: series title, season + episode numbers, etc. This improvement makes them available again under their default names (also backward compatible to nexx). Example use case for series:

```
DOS> youtube-dl --output ^
  "%(alt_title)s - %(title)s [S%(season_number)02dE%(episode_number)02d] (%(genre)s-%(channel)s, %(release_year)d).%(ext)s" ^
  https://www.tele5.de/the-quest/
... [JWPlatform] NETANJLd: Downloading JSON metadata
... [download] Destination: The Quest S02E09 - Im Bann des Zauberers [S02E09] (Abenteuer-Serie, 2015).mp4
```
For direct comparison: new vs. old (without this improvement):
- `The Quest S02E09 - Im Bann des Zauberers [S02E09] (Abenteuer-Serie, 2015).mp4`
- `Im Bann des Zauberers.mp4`

Example use case for movies:
```
DOS> youtube-dl --output ^
  "%(title)s (%(genre)s-%(channel)s, %(release_year)d, PG%(age_limit)d).%(ext)s" ^
  https://www.tele5.de/filme/time-trap/
... [JWPlatform] AtmmLdCP: Downloading JSON metadata
... [download] Destination: Time Trap (Science Fiction-Spielfilm, 2017, PG12).mp4
```
For direct comparison: new vs. old (without this improvement):
- `Time Trap (Science Fiction-Spielfilm, 2017, PG12).mp4`
- `Time Trap.mp4`