### PR TITLE
Truncate filenames that are too long

### DIFF
--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -363,6 +363,15 @@ class FileDownloader(object):
                     else '%.2f' % sleep_interval))
             time.sleep(sleep_interval)
 
+        # truncate the filename if it's too long
+        # deducting 5 from the name max to accommodate
+        # the ".part" thing at the end
+        max_filelen = os.statvfs('./').f_namemax - 5
+        if len(filename) > max_filelen:
+            self.to_screen("[filename] Too long, truncating")
+            start_char = len(filename) - max_filelen + 1
+            filename = filename[start_char:]
+
         return self.real_download(filename, info_dict)
 
     def real_download(self, filename, info_dict):

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -370,7 +370,7 @@ class FileDownloader(object):
         if len(filename) > max_filelen:
             self.to_screen("[filename] Too long, truncating")
             start_char = len(filename) - max_filelen + 1
-            filename = filename[start_char:]
+            filename = filename[start_char:].strip()
 
         return self.real_download(filename, info_dict)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes issues #7765 and #5908. I had a similar problem when I was trying to download a Twitter video and it tried to set the entire Tweet body as the filename. This does it in the common downloader, and if that doesn't give it _general_ applicability I'd love to hear how I can make it accomplish that.