### PR TITLE
Update api call to v5 spec in TwitchPlaylistBaseIE

### DIFF
--- a/youtube_dl/extractor/screencast.py
+++ b/youtube_dl/extractor/screencast.py
@@ -14,7 +14,7 @@ from ..utils import (
 
 
 class ScreencastIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?screencast\.com/t/(?P<id>[a-zA-Z0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?screencast\.com/(?:t|users/[^/]+/folders/[^/]+/media)/(?P<id>[a-zA-Z0-9\-]+)'
     _API_URL = 'https://www.screencast.com/api/external/oembed?url=%s&format=json'
 
     _TESTS = [{
@@ -60,12 +60,22 @@ class ScreencastIE(InfoExtractor):
     }, {
         'url': 'http://screencast.com/t/aAB3iowa',
         'only_matching': True,
+    }, {
+        'url': 'https://www.screencast.com/users/cindyhailes/folders/Jing/media/c9be177c-5808-4c4f-af56-eadceb3a7c82',
+        'md5': '589d37a28d2add53c8bf16b9126d9dc2',
+        'info_dict': {
+            'id': 'c9be177c-5808-4c4f-af56-eadceb3a7c82',
+            'ext': 'swf',
+            'title': '2020-05-31_1737',
+            'description': 'Shared from Screencast.com',
+            'thumbnail': r're:^https?://.*\.(?:gif|jpg)$',
+        }
     }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        # The info JSON given by the API has a thumbnail URL,
+        # The JSON given by the API has a thumbnail URL,
         # but it's inferior to the webpage's thumbnail.
         # It also has no video description, so we
         # definitely still need to get the webpage.

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -380,11 +380,13 @@ class TwitchPlaylistBaseIE(TwitchBaseIE):
     _PLAYLIST_PATH = 'kraken/channels/%s/videos/?offset=%d&limit=%d'
     _PAGE_LIMIT = 100
 
-    def _extract_playlist(self, channel_id):
+    def _extract_playlist(self, channel_name):
         info = self._call_api(
-            'kraken/channels/%s' % channel_id,
-            channel_id, 'Downloading channel info JSON')
-        channel_name = info.get('display_name') or info.get('name')
+            'kraken/users?login=%s' % channel_name,
+            channel_name, 'Downloading channel info JSON')
+        info = info['users'][0]
+        channel_id = info['_id']
+        channel_name = info.get('display_name') or info.get('name') or channel_name
         entries = []
         offset = 0
         limit = self._PAGE_LIMIT
@@ -444,7 +446,7 @@ class TwitchProfileIE(TwitchPlaylistBaseIE):
     _TESTS = [{
         'url': 'http://www.twitch.tv/vanillatv/profile',
         'info_dict': {
-            'id': 'vanillatv',
+            'id': '22744919',
             'title': 'VanillaTV',
         },
         'playlist_mincount': 412,
@@ -468,7 +470,7 @@ class TwitchAllVideosIE(TwitchVideosBaseIE):
     _TESTS = [{
         'url': 'https://www.twitch.tv/spamfish/videos/all',
         'info_dict': {
-            'id': 'spamfish',
+            'id': '497952',
             'title': 'Spamfish',
         },
         'playlist_mincount': 869,
@@ -487,7 +489,7 @@ class TwitchUploadsIE(TwitchVideosBaseIE):
     _TESTS = [{
         'url': 'https://www.twitch.tv/spamfish/videos/uploads',
         'info_dict': {
-            'id': 'spamfish',
+            'id': '497952',
             'title': 'Spamfish',
         },
         'playlist_mincount': 0,
@@ -506,7 +508,7 @@ class TwitchPastBroadcastsIE(TwitchVideosBaseIE):
     _TESTS = [{
         'url': 'https://www.twitch.tv/spamfish/videos/past-broadcasts',
         'info_dict': {
-            'id': 'spamfish',
+            'id': '497952',
             'title': 'Spamfish',
         },
         'playlist_mincount': 0,
@@ -525,7 +527,7 @@ class TwitchHighlightsIE(TwitchVideosBaseIE):
     _TESTS = [{
         'url': 'https://www.twitch.tv/spamfish/videos/highlights',
         'info_dict': {
-            'id': 'spamfish',
+            'id': '497952',
             'title': 'Spamfish',
         },
         'playlist_mincount': 805,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR closes #25553. The v5 api uses a numerical string for the channel ID instead of the channel name, and to get it you have to request `/kraken/users?login=NAME` instead of `/kraken/channels/NAME`: [v5 docs](https://dev.twitch.tv/docs/v5#translating-from-user-names-to-user-ids).