### PR TITLE
[postprocessor/embedthumbnail] Fix Youtube's WebP thumbnails by converting them to JPG

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -48,18 +48,19 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             [thumbnail_filename_path, thumbnail_filename_extension] = os.path.splitext(thumbnail_filename)
             if not thumbnail_filename_extension == ".webp":
                 webp_thumbnail_filename = thumbnail_filename_path + ".webp"
-                os.rename(thumbnail_filename, webp_thumbnail_filename)
+                os.rename(encodeFilename(thumbnail_filename), encodeFilename(webp_thumbnail_filename))
                 thumbnail_filename = webp_thumbnail_filename
 
         # If not a jpg or png thumbnail, convert it to jpg using ffmpeg
         if not os.path.splitext(thumbnail_filename)[1].lower() in ['.jpg', '.png']:
             jpg_thumbnail_filename = os.path.splitext(thumbnail_filename)[0] + ".jpg"
+            jpg_thumbnail_filename = os.path.join(os.path.dirname(jpg_thumbnail_filename), os.path.basename(jpg_thumbnail_filename).replace('%', '_'))  # ffmpeg interprets % as image sequence
 
             self._downloader.to_screen('[ffmpeg] Converting thumbnail "%s" to JPEG' % thumbnail_filename)
 
             self.run_ffmpeg(thumbnail_filename, jpg_thumbnail_filename, ['-bsf:v', 'mjpeg2jpeg'])
 
-            os.remove(thumbnail_filename)
+            os.remove(encodeFilename(thumbnail_filename))
             thumbnail_filename = jpg_thumbnail_filename
 
         if info['ext'] == 'mp3':

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -44,12 +44,12 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         #Check for mislabeled webp file
         with open(encodeFilename(thumbnail_filename), "rb") as f:
             b = f.read(16)
-            if b'\x57\x45\x42\x50' in b: #Binary for WEBP
-                [thumbnail_filename_path, thumbnail_filename_extension] = os.path.splitext(thumbnail_filename)
-                if not thumbnail_filename_extension == ".webp":
-                    webp_thumbnail_filename = thumbnail_filename_path + ".webp"
-                    os.rename(thumbnail_filename, webp_thumbnail_filename)
-                    thumbnail_filename = webp_thumbnail_filename
+        if b'\x57\x45\x42\x50' in b: #Binary for WEBP
+            [thumbnail_filename_path, thumbnail_filename_extension] = os.path.splitext(thumbnail_filename)
+            if not thumbnail_filename_extension == ".webp":
+                webp_thumbnail_filename = thumbnail_filename_path + ".webp"
+                os.rename(thumbnail_filename, webp_thumbnail_filename)
+                thumbnail_filename = webp_thumbnail_filename
 
         #If not a jpg or png thumbnail, convert it to jpg using ffmpeg
         if not os.path.splitext(thumbnail_filename)[1].lower() in ['.jpg', '.png']:

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -41,17 +41,17 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 'Skipping embedding the thumbnail because the file is missing.')
             return [], info
 
-        #Check for mislabeled webp file
+        # Check for mislabeled webp file
         with open(encodeFilename(thumbnail_filename), "rb") as f:
             b = f.read(16)
-        if b'\x57\x45\x42\x50' in b: #Binary for WEBP
+        if b'\x57\x45\x42\x50' in b:  # Binary for WEBP
             [thumbnail_filename_path, thumbnail_filename_extension] = os.path.splitext(thumbnail_filename)
             if not thumbnail_filename_extension == ".webp":
                 webp_thumbnail_filename = thumbnail_filename_path + ".webp"
                 os.rename(thumbnail_filename, webp_thumbnail_filename)
                 thumbnail_filename = webp_thumbnail_filename
 
-        #If not a jpg or png thumbnail, convert it to jpg using ffmpeg
+        # If not a jpg or png thumbnail, convert it to jpg using ffmpeg
         if not os.path.splitext(thumbnail_filename)[1].lower() in ['.jpg', '.png']:
             jpg_thumbnail_filename = os.path.splitext(thumbnail_filename)[0] + ".jpg"
 

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -41,6 +41,16 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 'Skipping embedding the thumbnail because the file is missing.')
             return [], info
 
+        if not os.path.splitext(encodeFilename(thumbnail_filename))[1].lower() in ['.jpg', '.png']:
+            jpg_thumbnail_filename = thumbnail_filename + ".jpg"
+
+            self._downloader.to_screen('[ffmpeg] Converting thumbnail "%s" to JPEG' % thumbnail_filename)
+
+            self.run_ffmpeg(thumbnail_filename, jpg_thumbnail_filename, ['-bsf:v', 'mjpeg2jpeg'])
+
+            os.remove(thumbnail_filename)
+            thumbnail_filename = jpg_thumbnail_filename
+
         if info['ext'] == 'mp3':
             options = [
                 '-c', 'copy', '-map', '0', '-map', '1',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This change should fix #25687:
Youtube started using the [WebP](https://en.wikipedia.org/wiki/WebP) image format for thumbnail images. However, both `ffmpeg` and `AtomicParsley` only support the embedding of _JPEG_ and _PNG_ files. Therefore, as @noname8753 suggested, a conversion step was added during which the thumbnail is converted to _JPEG_ using `ffmpeg`.
