### PR TITLE
Better extraction for nrk

### DIFF
--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -57,11 +57,12 @@ class NRKBaseIE(InfoExtractor):
         def make_title(t):
             return self._live_title(t) if live else t
 
-        playback_convia = playback_manifest.get('statistics').get('conviva')
-        if playback_convia:
+        playback_convia = (playback_manifest.get('statistics', {}).get('conviva')
+                           if playback_manifest else None)
+        if isinstance(playback_convia, dict):
             streamurl = playback_convia.get('streamUrl', None)
             stream = self._extract_m3u8_formats(streamurl, video_id, 'mp4',
-                'm3u8_native', m3u8_id='hls', fatal=False)
+                                                'm3u8_native', m3u8_id='hls', fatal=False)
             custom = playback_convia.get('custom')
 
             dur = parse_duration(playback_convia.get('duration'))
@@ -170,8 +171,8 @@ class NRKBaseIE(InfoExtractor):
                 programs = self._download_json(
                     'http://%s/programs/%s' % (self._api_host, video_id),
                     video_id, 'Downloading programs manifest JSON', fatal=False)
-                season_number = int_or_none(programs.get('seasonNumber'))
-                episode_number = int_or_none(programs.get('episodeNumber'))
+                season_number = int_or_none(programs.get('seasonNumber')) if programs else None
+                episode_number = int_or_none(programs.get('episodeNumber')) if programs else None
 
         thumbnails = None
         images = data.get('images')

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -148,6 +148,13 @@ class NRKBaseIE(InfoExtractor):
                 EPISODENUM_RE, _season_episode, 'episode number',
                 default=None, group='episode'))
 
+            if not season_number or episode_number:
+                programs = self._download_json(
+                    'http://%s/programs/%s' % (self._api_host, video_id),
+                    video_id, 'Downloading programs manifest JSON')
+                season_number = int_or_none(programs.get('seasonNumber'))
+                episode_number = int_or_none(programs.get('episodeNumber'))
+
         thumbnails = None
         images = data.get('images')
         if images and isinstance(images, dict):

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -66,7 +66,7 @@ class NRKBaseIE(InfoExtractor):
 
                 playback_manifest = self._download_json(
                     'http://%s/playback/manifest/program/%s' % (self._api_host, video_id),
-                    video_id, 'Downloading manifest JSON')
+                    video_id, 'Downloading manifest JSON', fatal=False)
                 streamurl = playback_manifest.get('statistics').get('conviva').get('streamUrl')
                 formats.extend(self._extract_m3u8_formats(
                     streamurl, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False,
@@ -151,7 +151,7 @@ class NRKBaseIE(InfoExtractor):
             if not season_number or episode_number:
                 programs = self._download_json(
                     'http://%s/programs/%s' % (self._api_host, video_id),
-                    video_id, 'Downloading programs manifest JSON')
+                    video_id, 'Downloading programs manifest JSON', fatal=False)
                 season_number = int_or_none(programs.get('seasonNumber'))
                 episode_number = int_or_none(programs.get('episodeNumber'))
 
@@ -178,7 +178,7 @@ class NRKBaseIE(InfoExtractor):
             'categories': [category] if category else None,
             'age_limit': parse_age_limit(data.get('legalAge')),
             'thumbnails': thumbnails,
-            'alt_title':alt_title,
+            'alt_title': alt_title,
         }
 
         vcodec = 'none' if data.get('mediaType') == 'Audio' else None
@@ -366,7 +366,8 @@ class NRKTVIE(NRKBaseIE):
             'id': 'KMTE50001317AA',
             'ext': 'mp4',
             'title': 'Anno 13:30',
-            'description': 'md5:11d9613661a8dbe6f9bef54e3a4cbbfa',
+            'alt_title': 'Anno',
+            'description': 'md5:13735a46076f1ed9310ed13dfd69789f',
             'duration': 2340,
             'series': 'Anno',
             'episode': '13:30',
@@ -407,6 +408,7 @@ class NRKTVEpisodeIE(InfoExtractor):
             'id': 'MUHH36005220BA',
             'ext': 'mp4',
             'title': 'Kro, krig og kjærlighet 2:6',
+            'alt_title': 'Kro, krig og kjærlighet',
             'description': 'md5:b32a7dc0b1ed27c8064f58b97bda4350',
             'duration': 1563,
             'series': 'Hellums kro',

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -427,7 +427,8 @@ class NRKTVEpisodeIE(InfoExtractor):
 
         nrk_id = self._parse_json(
             self._search_regex(JSON_LD_RE, webpage, 'JSON-LD', group='json_ld'),
-            display_id)['@id']
+            display_id).get('@id') or \
+            self._html_search_meta('nrk:program-id', webpage)
 
         assert re.match(NRKTVIE._EPISODE_RE, nrk_id)
         return self.url_result(

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -41,6 +41,7 @@ class NRKBaseIE(InfoExtractor):
             break
 
         title = data.get('fullTitle') or data.get('mainTitle') or data['title']
+        alt_title = data.get('mainTitle')
         video_id = data.get('id') or video_id
 
         entries = []
@@ -170,6 +171,7 @@ class NRKBaseIE(InfoExtractor):
             'categories': [category] if category else None,
             'age_limit': parse_age_limit(data.get('legalAge')),
             'thumbnails': thumbnails,
+            'alt_title':alt_title,
         }
 
         vcodec = 'none' if data.get('mediaType') == 'Audio' else None

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -62,6 +62,14 @@ class NRKBaseIE(InfoExtractor):
                 if not asset_url:
                     continue
                 formats = self._extract_akamai_formats(asset_url, video_id)
+
+                playback_manifest = self._download_json(
+                    'http://%s/playback/manifest/program/%s' % (self._api_host, video_id),
+                    video_id, 'Downloading manifest JSON')
+                streamurl = playback_manifest.get('statistics').get('conviva').get('streamUrl')
+                formats.extend(self._extract_m3u8_formats(
+                    streamurl, video_id, 'mp4', 'm3u8_native', m3u8_id='hls', fatal=False,
+                    errnote='Alternate extractor failed'))
                 if not formats:
                     continue
                 self._sort_formats(formats)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes two open issues for the NRK extractor, #25594 and #24221 as well as providing `alt_title`, useful for shows that does indeed have unique episode names, rather than `<series name> <episode number>:<total episodes in season>`

In order to fully fix 24221 I had to use a additional endpoint to fetch a m3u8 playlist, this seems to be the endpoint which exposes 1080P quality.

Some test maintenance was also done, the description seems to change from time to time. 