### PR TITLE
Don't save fragment files unless --keep-fragments option is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --abort-on-unavailable-fragment  Abort downloading when some fragment is not
                                      available
     --keep-fragments                 Keep downloaded fragments on disk after
-                                     downloading is finished; fragments are
-                                     erased by default
+                                     downloading is finished; fragments are not
+                                     saved by default
     --buffer-size SIZE               Size of download buffer (e.g. 1024 or 16K)
                                      (default is 1024)
     --no-resize-buffer               Do not automatically adjust the buffer

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -473,7 +473,7 @@ def parseOpts(overrideArguments=None):
     downloader.add_option(
         '--keep-fragments',
         action='store_true', dest='keep_fragments', default=False,
-        help='Keep downloaded fragments on disk after downloading is finished; fragments are erased by default')
+        help='Keep downloaded fragments on disk after downloading is finished; fragments are not saved by default')
     downloader.add_option(
         '--buffer-size',
         dest='buffersize', metavar='SIZE', default='1024',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When downloading HLS video, each fragment is saved in a separate file. Once the fragment is complete, this file is read and its contents appended to the final destination (or .part file). Without `--keep-fragments` option, the fragment file is then immediately deleted. This PR avoids creating the fragment file if `--keep-fragments` option was not specified, by holding fragment data only in memory.

