### PR TITLE
[Veeps] add extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1281,6 +1281,7 @@ from .ustudio import (
 from .varzesh3 import Varzesh3IE
 from .vbox7 import Vbox7IE
 from .veehd import VeeHDIE
+from .veeps import VeepsIE
 from .veoh import VeohIE
 from .vesti import VestiIE
 from .vevo import (

--- a/youtube_dl/extractor/veeps.py
+++ b/youtube_dl/extractor/veeps.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from ..compat import (
+    compat_str,
+    compat_urllib_parse_urlencode
+)
+
+from .common import InfoExtractor
+
+import re
+
+
+class VeepsIE(InfoExtractor):
+    _VALID_URL = r'https?://(?P<channel>[a-zA-Z0-9]+)\.veeps\.com/stream/(?P<id>[0-9a-f]+)'
+    _CSRF_TOKEN_RE = InfoExtractor._meta_regex('csrf-token')
+    _M3U8_RE = r'<div[^>]+data-react-props=(?:\'|")[^>\'"]*stored_stream_asset&quot;:&quot;(?P<url>[^&>\'"]+)&quot;[^>\'"]*(?:\'|")[^>]*>'
+
+    @classmethod
+    def _match_channel(cls, url):
+        if '_VALID_URL_RE' not in cls.__dict__:
+            cls._VALID_URL_RE = re.compile(cls._VALID_URL)
+        m = cls._VALID_URL_RE.match(url)
+        assert m
+        return compat_str(m.group('channel'))
+
+    def _real_initialize(self):
+        if self._downloader is None:
+            return
+        self._login()
+
+    def _login(self):
+        first_login = self._download_webpage(
+            'https://veeps.com/users/login',
+            None,
+            note='obtaining initial session',
+            errnote='failed to obtain initial session'
+        )
+
+        authenticity_token = re.search(self._CSRF_TOKEN_RE, first_login).group('content')
+        assert authenticity_token is not None
+
+        username, password = self._get_login_info()
+        assert username is not None
+        assert password is not None
+
+        post_data = compat_urllib_parse_urlencode({
+            'authenticity_token': authenticity_token,
+            'user[email]': username,
+            'user[password]': password,
+            'commit': 'Sign+In'
+        }).encode('utf-8')
+
+        self._download_webpage(
+            'https://veeps.com/users/login',
+            None,
+            note='logging in',
+            errnote='failed to login',
+            data=post_data
+        )
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        channel = self._match_channel(url)
+
+        stream_page = self._download_webpage(
+            url,
+            video_id,
+            note='downloading stream page',
+            errnote='failed to download stream page'
+        )
+
+        m3u8_location = re.search(self._M3U8_RE, stream_page).group('url')
+
+        return {
+            'id': video_id,
+            'title': '{} stream - {}'.format(channel, video_id),
+            'formats': self._extract_m3u8_formats(m3u8_location, video_id, ext='mp4')
+        }

--- a/youtube_dl/extractor/veeps.py
+++ b/youtube_dl/extractor/veeps.py
@@ -15,6 +15,7 @@ class VeepsIE(InfoExtractor):
     _VALID_URL = r'https?://(?P<channel>[a-zA-Z0-9]+)\.veeps\.com/stream/(?P<id>[0-9a-f]+)'
     _CSRF_TOKEN_RE = InfoExtractor._meta_regex('csrf-token')
     _M3U8_RE = r'<div[^>]+data-react-props=(?:\'|")[^>\'"]*stored_stream_asset&quot;:&quot;(?P<url>[^&>\'"]+)&quot;[^>\'"]*(?:\'|")[^>]*>'
+    _NETRC_MACHINE = 'veeps'
 
     @classmethod
     def _match_channel(cls, url):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

See issue #25728 
This pull request adds an extractor for veeps.com. veeps.com hosts concert streams in which users can buy tickets and later replay the stream on the website. This extractor handles authentication (via the `--username` and `--password` options) and downloading of streams when the user has purchased tickets. Because this extractor requires authentication and payment, there are currently no test cases written; however, I have tested it and the extractor correctly lists viewable formats and is able to download them and create a viewable stream. For details on how the testing was done, see the attached issue.
URL format that this extractor accepts is `https://[channel].veeps.com/stream/[id]`.

Here's a log from a test:
```
$ python3 -m youtube_dl --username [user's email] --password [user's password] https://brandicarlile.veeps.com/stream/e5ccef3d7eba -F
[Veeps] obtaining initial session
[Veeps] logging in
[Veeps] e5ccef3d7eba: downloading stream page
[Veeps] e5ccef3d7eba: Downloading m3u8 information
[info] Available formats for e5ccef3d7eba:
format code  extension  resolution note
2516         mp4        1280x720   2516k , avc1.640020, mp4a.40.2
1640         mp4        960x540    1640k , avc1.640020, mp4a.40.2
994          mp4        640x360     994k , avc1.64001f, mp4a.40.2
697          mp4        480x270     697k , avc1.64001e, mp4a.40.2 (best)
```
It will download the format specified and concatenate the stream's .ts files, saving a playable .mp4 file.
