### PR TITLE
Listen to --default-extension for twitch downloads

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -794,7 +794,7 @@ class YoutubeDL(object):
                                     'and will probably not work.')
 
             try:
-                ie_result = ie.extract(url)
+                ie_result = ie.extract(url, self.params['default_extension'])
                 if ie_result is None:  # Finished already (backwards compatibility; listformats and friends should be moved here)
                     break
                 if isinstance(ie_result, list):
@@ -1320,10 +1320,13 @@ class YoutubeDL(object):
                             'Both formats %s and %s are video-only, you must specify "-f video+audio"'
                             % (format_1, format_2))
                         return
-                    output_ext = (
-                        formats_info[0]['ext']
-                        if self.params.get('merge_output_format') is None
-                        else self.params['merge_output_format'])
+                    if self.params.get('merge_output_format') is None:
+                        if self.params.get('default_extension') is None:
+                            output_ext = formats_info[0]['ext']
+                        else:
+                            output_ext = self.params['default_extension']
+                    else:
+                        output_ext = self.params['merge_output_format']
                     return {
                         'requested_formats': formats_info,
                         'format': '%s+%s' % (formats_info[0].get('format'),

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -410,6 +410,7 @@ def _real_main(argv=None):
         'extract_flat': opts.extract_flat,
         'mark_watched': opts.mark_watched,
         'merge_output_format': opts.merge_output_format,
+        'default_extension': opts.default_extension,
         'postprocessors': postprocessors,
         'fixup': opts.fixup,
         'source_address': opts.source_address,

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -521,13 +521,13 @@ class InfoExtractor(object):
                         '[debug] Using fake IP %s (%s) as X-Forwarded-For.'
                         % (self._x_forwarded_for_ip, country.upper()))
 
-    def extract(self, url):
+    def extract(self, url, default_ext='mp4'):
         """Extracts URL information and returns it in list of dicts."""
         try:
             for _ in range(2):
                 try:
                     self.initialize()
-                    ie_result = self._real_extract(url)
+                    ie_result = self._real_extract(url, default_ext)
                     if self._x_forwarded_for_ip:
                         ie_result['__x_forwarded_for_ip'] = self._x_forwarded_for_ip
                     return ie_result
@@ -565,7 +565,7 @@ class InfoExtractor(object):
         """Real initialization process. Redefine in subclasses."""
         pass
 
-    def _real_extract(self, url):
+    def _real_extract(self, url, default_ext='mp4'):
         """Real extraction process. Redefine in subclasses."""
         pass
 

--- a/youtube_dl/extractor/twitch.py
+++ b/youtube_dl/extractor/twitch.py
@@ -222,7 +222,7 @@ class TwitchItemBaseIE(TwitchBaseIE):
             'is_live': is_live,
         }
 
-    def _real_extract(self, url):
+    def _real_extract(self, url, default_ext):
         return self._extract_media(self._match_id(url))
 
 
@@ -332,7 +332,7 @@ class TwitchVodIE(TwitchItemBaseIE):
         'only_matching': True,
     }]
 
-    def _real_extract(self, url):
+    def _real_extract(self, url, default_ext):
         item_id = self._match_id(url)
 
         info = self._download_info(self._ITEM_SHORTCUT, item_id)
@@ -352,7 +352,7 @@ class TwitchVodIE(TwitchItemBaseIE):
                     'nauth': access_token['token'],
                     'nauthsig': access_token['sig'],
                 })),
-            item_id, 'mp4', entry_protocol='m3u8_native')
+            item_id, default_ext, entry_protocol='m3u8_native')
 
         self._prefer_source(formats)
         info['formats'] = formats
@@ -594,7 +594,7 @@ class TwitchStreamIE(TwitchBaseIE):
                     TwitchClipsIE))
                 else super(TwitchStreamIE, cls).suitable(url))
 
-    def _real_extract(self, url):
+    def _real_extract(self, url, default_ext):
         channel_name = self._match_id(url)
 
         access_token = self._call_api(
@@ -634,7 +634,7 @@ class TwitchStreamIE(TwitchBaseIE):
         formats = self._extract_m3u8_formats(
             '%s/api/channel/hls/%s.m3u8?%s'
             % (self._USHER_BASE, channel_name, compat_urllib_parse_urlencode(query)),
-            channel_id, 'mp4')
+            channel_id, default_ext)
         self._prefer_source(formats)
 
         view_count = stream.get('viewers')

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -415,6 +415,10 @@ def parseOpts(overrideArguments=None):
         action='store_false', dest='youtube_include_dash_manifest',
         help='Do not download the DASH manifests and related data on YouTube videos')
     video_format.add_option(
+        '--default-extension',
+        action='store', dest='default_extension', default=None,
+        help='Try providing a different extension to the format processor')
+    video_format.add_option(
         '--merge-output-format',
         action='store', dest='merge_output_format', metavar='FORMAT', default=None,
         help=(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is the twitch extension option described in #25840 .

A `--default-extension` option is added which changes the container format for twitch.  Twitch previously always produced an mp4 file.