### PR TITLE
Support multiple subs per language code

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -247,6 +247,8 @@ class InfoExtractor(object):
                     entry and one of:
                         * "data": The subtitles file contents
                         * "url": A URL pointing to the subtitles file
+                        * "name": (optional) Name or description of the subtitles, used
+                          when there are more than one subtitles file for this language
                     "ext" will be calculated from URL if missing
     automatic_captions: Like 'subtitles', used by the YoutubeIE for
                     automatically generated captions

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1448,18 +1448,21 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         for track in subs_doc.findall('track'):
             lang = track.attrib['lang_code']
             if lang in sub_lang_list:
-                continue
-            sub_formats = []
+                sub_formats = sub_lang_list[lang]
+            else:
+                sub_formats = []
             for ext in self._SUBTITLE_FORMATS:
+                name = track.attrib['name']
                 params = compat_urllib_parse_urlencode({
                     'lang': lang,
                     'v': video_id,
                     'fmt': ext,
-                    'name': track.attrib['name'].encode('utf-8'),
+                    'name': name.encode('utf-8'),
                 })
                 sub_formats.append({
                     'url': 'https://www.youtube.com/api/timedtext?' + params,
                     'ext': ext,
+                    'name': name,
                 })
             sub_lang_list[lang] = sub_formats
         if not sub_lang_list:

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -3002,8 +3002,8 @@ def determine_ext(url, default_ext='unknown_video'):
         return default_ext
 
 
-def subtitles_filename(filename, sub_lang, sub_format, expected_real_ext=None):
-    return replace_extension(filename, sub_lang + '.' + sub_format, expected_real_ext)
+def subtitles_filename(filename, sub_lang, sub_name, sub_format, expected_real_ext=None):
+    return replace_extension(filename, (sub_name + '.' if sub_name else '') + sub_lang + '.' + sub_format, expected_real_ext)
 
 
 def date_from_str(date_str):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixes #21164

Adds 'name' key to the subtitle part of the info_dict from the youtube extractor and documents it in extractor/common.py for other extractors.

Adds a new column 'name' to --list-subs output. Here's the output for the video from #21164:

```
$ youtube-dl --list-subs https://www.youtube.com/watch?v=jc5DlOkOcU4
[youtube] jc5DlOkOcU4: Downloading webpage
[youtube] jc5DlOkOcU4: Looking for automatic captions
Available automatic captions for jc5DlOkOcU4:
Language  name formats
[...]
Available subtitles for jc5DlOkOcU4:
Language  name                 formats
en                             vtt, ttml, srv3, srv2, srv1
en        Japanese Translation vtt, ttml, srv3, srv2, srv1
ja        和訳のみ                 vtt, ttml, srv3, srv2, srv1
ko                             vtt, ttml, srv3, srv2, srv1
pt                             vtt, ttml, srv3, srv2, srv1
es                             vtt, ttml, srv3, srv2, srv1
```

Writes all the subtitle files for a given lang with a different 'name' with --write-sub --sub-lang foo, adds 'name' as a component to the output file name before the language code:
```
$ youtube-dl --write-sub --skip-download --sub-lang en  https://www.youtube.com/watch?v=jc5DlOkOcU4
[youtube] jc5DlOkOcU4: Downloading webpage
[info] Writing video subtitles to: M2 - Complete Works _ MY LIFE IN GAMING-jc5DlOkOcU4.en.vtt
[info] Writing video subtitles to: M2 - Complete Works _ MY LIFE IN GAMING-jc5DlOkOcU4.Japanese Translation.en.vtt
```

The ffmpeg postprocessing functions are modified to work with more than one subtitle per language, but they are untested.

Tests likely do not pass with these changes, I'll fix them if this PR has a change of being merged.
