### PR TITLE
[xtube] Update cookie name for age verification

### DIFF
--- a/youtube_dl/extractor/xtube.py
+++ b/youtube_dl/extractor/xtube.py
@@ -92,6 +92,7 @@ class XTubeIE(InfoExtractor):
         config = self._parse_json(self._search_regex(
             r'playerConf\s*=\s*({.+?})\s*,\s*\n', webpage, 'config',
             default='{}'), video_id, transform_source=js_to_json, fatal=False)
+        sources = {}
         if config:
             config = config.get('mainRoll')
             if isinstance(config, dict):

--- a/youtube_dl/extractor/xtube.py
+++ b/youtube_dl/extractor/xtube.py
@@ -84,7 +84,7 @@ class XTubeIE(InfoExtractor):
 
         webpage = self._download_webpage(
             url_pattern % video_id, display_id, headers={
-                'Cookie': 'age_verified=1; cookiesAccepted=1',
+                'Cookie': 'AGEGATEPASSED=1; cookiesAccepted=1',
             })
 
         title, thumbnail, duration = [None] * 3

--- a/youtube_dl/extractor/xtube.py
+++ b/youtube_dl/extractor/xtube.py
@@ -175,7 +175,7 @@ class XTubeUserIE(InfoExtractor):
             request = sanitized_Request(
                 'http://www.xtube.com/profile/%s/videos/%d' % (user_id, pagenum),
                 headers={
-                    'Cookie': 'popunder=4',
+                    'Cookie': 'AGEGATEPASSED=1; popunder=4',
                     'X-Requested-With': 'XMLHttpRequest',
                     'Referer': url,
                 })


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR fixes the xtube plugin, currently broken because it doesn't pass the age verification (change in the name of a cookie).

Should fix #25602