### PR TITLE
Add support for Yle Areena (areena.yle.fi), with yle-dl

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1460,6 +1460,7 @@ from .yapfiles import YapFilesIE
 from .yesjapan import YesJapanIE
 from .yinyuetai import YinYueTaiIE
 from .ynet import YnetIE
+from .yledl import YleDLIE
 from .youjizz import YouJizzIE
 from .youku import (
     YoukuIE,

--- a/youtube_dl/extractor/yledl.py
+++ b/youtube_dl/extractor/yledl.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from __future__ import unicode_literals
+from collections import defaultdict
 import subprocess
 import json
 
@@ -50,9 +51,9 @@ class YleDLIE(InfoExtractor):
             props['description'] = description
 
         ysubs = yledl.get('subtitles', [])
-        subtitles = {}
+        subtitles = defaultdict(list)
         for s in ysubs:
-            subtitles[s['language']] = [{'url': s['url']}]
+            subtitles[s['language']].append({'url': s['url'], 'ext': s['category']})
         props['subtitles'] = subtitles
 
         formats = []

--- a/youtube_dl/extractor/yledl.py
+++ b/youtube_dl/extractor/yledl.py
@@ -54,7 +54,12 @@ class YleDLIE(InfoExtractor):
         subtitles = defaultdict(list)
         for s in ysubs:
             subtitles[s['language']].append({'url': s['url'], 'ext': s['category']})
-        props['subtitles'] = subtitles
+        # Temporary fix for mpv's ytdl_hook
+        subs = {}
+        for lang, slist in subtitles.items():
+            for n, s in enumerate(slist, 1):
+                subs[lang + (str(n) if n > 1 else "")] = [s]
+        props['subtitles'] = subs
 
         formats = []
         for f in yledl.get('flavors', []):

--- a/youtube_dl/extractor/yledl.py
+++ b/youtube_dl/extractor/yledl.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+from __future__ import unicode_literals
+import subprocess
+import json
+
+from .common import InfoExtractor
+
+
+class YleDLIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:areena|arenan).yle.fi/(?P<id>[0-9]-[0-9]+)'
+    _GEO_COUNTRIES = ['FI']
+
+    _TEST = {
+        'url': 'https://areena.yle.fi/1-4256816',
+        'md5': 'b9658c5960a8c2ca4ba8f1b0ff079df2',
+        'info_dict': {
+            'id': '1_iq074q8b',
+            'ext': 'mxf',
+            'title': 'Luottomies | Luottomies jouluspeciaali',
+            'description':
+                'Tommia harmittaa kun sukulaiset ovat tulossa pilaamaan '
+                'mukavan perhejoulun. Muuttuuko mieli isosta yllätyksestä? '
+                'Joulun erikoisjakson on ohjannut Jalmari Helander.',
+            'upload_date': '20171207',
+            'height': 1080,
+            'width': 1920,
+            'fps': 25,
+            'duration': 1302,
+            'timestamp': 1512633989,
+            'extractor': 'Kaltura',
+            'uploader_id': 'ovp@yle.fi',
+            'webpage_url_basename': '1-4256816',
+            'webpage_url': 'https://areena.yle.fi/1-4256816'
+        }
+    }
+
+    def _real_extract(self, url):
+        props = {}
+
+        # Get essential data
+        props['id'] = self._match_id(url)
+
+        cp = subprocess.run(["yle-dl", "-q", "--showmetadata", url], capture_output=True, encoding='utf-8')
+        cp.check_returncode()
+        yledl = json.loads(cp.stdout)[0]
+
+        props['title'] = yledl.get('title', '<none>')
+        description = yledl.get('description', None)
+        if description:
+            props['description'] = description
+
+        ysubs = yledl.get('subtitles', [])
+        subtitles = {}
+        for s in ysubs:
+            subtitles[s['language']] = [{'url': s['url']}]
+        props['subtitles'] = subtitles
+
+        formats = []
+        for f in yledl.get('flavors', []):
+            formats.append({
+                'url': f.get('url', ""),
+                'tbr': f.get('bitrate', None),
+                'width': f.get('width', None),
+                'height': f.get('height', None),
+                'protocol': 'm3u8',
+            })
+        props['formats'] = formats
+
+        return props


### PR DESCRIPTION


### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is an extractor for the areena.yle.fi streaming service of the Finnish public broadcaster Yle, based on the mighty [yle-dl](https://github.com/aajanki/yle-dl) script from @aajanki. There are also other attempts to support Areena in the pull requests, like #5805 and #20274, but they don't seem to work too well.

As this script depends on an external python script, it's unlikely to get merged, but for those who want to stream Areena with mpv, subs and all, this one works.