### PR TITLE
Use InitialData variable from JS to get chapter information

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1661,21 +1661,15 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
     def _extract_chapters_from_json(self, webpage, video_id, duration):
         if not webpage:
             return
-        player = self._parse_json(
+        initial_data = self._parse_json(
             self._search_regex(
-                r'RELATED_PLAYER_ARGS["\']\s*:\s*({.+})\s*,?\s*\n', webpage,
+                r'window\["ytInitialData"\] = (.+);\n', webpage,
                 'player args', default='{}'),
             video_id, fatal=False)
-        if not player or not isinstance(player, dict):
-            return
-        watch_next_response = player.get('watch_next_response')
-        if not isinstance(watch_next_response, compat_str):
-            return
-        response = self._parse_json(watch_next_response, video_id, fatal=False)
-        if not response or not isinstance(response, dict):
+        if not initial_data or not isinstance(initial_data, dict):
             return
         chapters_list = try_get(
-            response,
+            initial_data,
             lambda x: x['playerOverlays']
                        ['playerOverlayRenderer']
                        ['decoratedPlayerBarRenderer']


### PR DESCRIPTION
### Pre-pull-request checklist:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### This piece of code is released under [Unlicense](http://unlicense.org/).
- [x] I am the original author of this code and I am willing to release it under [Unlicense](https://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](https://unlicense.org/) (provide reliable evidence)

### What is the purpose of this *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes #26005.

YouTube has probably changed the format of the page, and there's no more `RELATED_PLAYER_ARGS` in the page anymore. Instead, this fix uses the global (window) variable `ytInitialData` which contains a whole lot of information, including chapters in an easily parsable form (maybe this is what `RELATED_PLAYER_ARGS` used to be).

This is not affected by and doesn't affect PR #24848, as this pull request read data from JSON instead of the description (as #24848 does).