### PR TITLE
[peertube] Extract files also from `streamingPlaylists`

### DIFF
--- a/youtube_dl/extractor/peertube.py
+++ b/youtube_dl/extractor/peertube.py
@@ -451,6 +451,18 @@ class PeerTubeIE(InfoExtractor):
             'categories': ['Science & Technology'],
         }
     }, {
+        # Issue #26002
+        'url': 'peertube:spacepub.space:d8943b2d-8280-497b-85ec-bc282ec2afdc',
+        'info_dict': {
+            'id': 'd8943b2d-8280-497b-85ec-bc282ec2afdc',
+            'ext': 'mp4',
+            'title': 'Dot matrix printer shell demo',
+            'uploader_id': '3',
+            'timestamp': 1587401293,
+            'upload_date': '20200420',
+            'uploader': 'Drew DeVault',
+        }
+    }, {
         'url': 'https://peertube.tamanoir.foucry.net/videos/watch/0b04f13d-1e18-4f1d-814e-4979aa7c9c44',
         'only_matching': True,
     }, {
@@ -526,7 +538,15 @@ class PeerTubeIE(InfoExtractor):
         title = video['name']
 
         formats = []
-        for file_ in video['files']:
+        files = video['files']
+        for playlist in video['streamingPlaylists']:
+            if not isinstance(playlist, dict):
+                continue
+            playlist_files = playlist.get('files')
+            if not playlist_files or not isinstance(playlist_files, list):
+                continue
+            files.extend(playlist_files)
+        for file_ in files:
             if not isinstance(file_, dict):
                 continue
             file_url = url_or_none(file_.get('fileUrl'))


### PR DESCRIPTION
As mentioned in #26002 some PeerTube instances respond with a seemingly corrupted video descriptor JSON object and the extractor is unable to determine the available file formats in those cases. Turned out that an empty `"files"` array caused those kind of problems but, fortunately, there are another `"files"` arrays in `"streamingPlaylists"` array which can be used instead.

Here is the corresponding part of the API specification:
https://docs.joinpeertube.org/api-rest-reference.html#tag/Video/paths/~1videos~1%7Bid%7D/get