### PR TITLE
Add alternative option to the embed-only error

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -601,7 +601,8 @@ class VimeoIE(VimeoBaseInfoExtractor):
                     raise ExtractorError(
                         'Cannot download embed-only video without embedding '
                         'URL. Please call youtube-dl with the URL of the page '
-                        'that embeds this video.',
+                        'that embeds this video, or by passing that to the '
+                        '--referer argument.',
                         expected=True)
             raise
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [ ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

For example, running:

```
youtube-dl https://player.vimeo.com/video/356169265
```

outputs:

> [vimeo] 356169265: Downloading webpage
> ERROR: Cannot download embed-only video without embedding URL. Please call youtube-dl with the URL of the page that embeds this video.

Following the instructions and running:

```
youtube-dl https://www.raywenderlich.com/4720178-ios-accessibility-tutorial-making-custom-controls-accessible
```

outputs:

> [RayWenderlichCourse] 4720178-ios-accessibility-tutorial-making-custom-controls-accessible: Downloading webpage
> [download] Downloading playlist: iOS Accessibility Tutorial: Making Custom Controls Accessible
> [RayWenderlichCourse] playlist iOS Accessibility Tutorial: Making Custom Controls Accessible: Collected 0 video ids (downloading 0 of them)
> [download] Finished downloading playlist: iOS Accessibility Tutorial: Making Custom Controls Accessible

And only this works:

```
youtube-dl https://player.vimeo.com/video/356169265 --referer \
"https://www.raywenderlich.com/4720178-ios-accessibility-tutorial-making-custom-controls-accessible"
```