### PR TITLE
Resolve audio/x-wav to "wav" extension, rather than "x-wav" (which ffmpeg does not recognize)

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4173,6 +4173,7 @@ def mimetype2ext(mt):
         # Per RFC 3003, audio/mpeg can be .mp1, .mp2 or .mp3. Here use .mp3 as
         # it's the most popular one
         'audio/mpeg': 'mp3',
+        'audio/x-wav': 'wav',
     }.get(mt)
     if ext is not None:
         return ext


### PR DESCRIPTION
#25938  Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This fixes ffmpeg errors when trying to downloading certain audio files from Soundcloud with the --add-metadata option set. I believe these files were uploaded without an extension, and are being identified as audio/x-wav. However, youtube-dl was downloading them with a "x-wav" extension, which ffmpeg fails to recognize as a valid output format. This change forces the extension to be "wav" which resolves the issue.

An example to reproduce the problem:
```
youtube-dl -o "%(title)s.%(ext)s" --add-metadata https://soundcloud.com/mediasanctuary/1033-jesse-marshall-9-12-2019
```

Before this change:
```
[soundcloud] mediasanctuary/1033-jesse-marshall-9-12-2019: Downloading info JSON
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading webpage
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading JSON metadata
[download] Destination: 10'33' Jesse Marshall 9 - 12 - 2019.x-wav
[download] 100% of 53.24MiB in 00:03
[ffmpeg] Adding metadata to '10'33' Jesse Marshall 9 - 12 - 2019.x-wav'
ERROR: file:10'33' Jesse Marshall 9 - 12 - 2019.temp.x-wav: Invalid argument
```

After this change:
```
[soundcloud] mediasanctuary/1033-jesse-marshall-9-12-2019: Downloading info JSON
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading webpage
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading JSON metadata
[soundcloud] 680239748: Downloading JSON metadata
[download] Destination: 10'33' Jesse Marshall 9 - 12 - 2019.wav
[download] 100% of 53.24MiB in 00:03
[ffmpeg] Adding metadata to '10'33' Jesse Marshall 9 - 12 - 2019.wav'
```


