### PR TITLE
[youtube] Fix youtube mix playlist extraction (closes #26390)

### DIFF
--- a/test/test_youtube_lists.py
+++ b/test/test_youtube_lists.py
@@ -45,8 +45,8 @@ class TestYoutubeLists(unittest.TestCase):
         result = ie.extract('https://www.youtube.com/watch?v=W01L70IGBgE&index=2&list=RDOQpdSVF_k_w')
         entries = result['entries']
         self.assertTrue(len(entries) >= 50)
-        original_video = entries[0]
-        self.assertEqual(original_video['id'], 'OQpdSVF_k_w')
+        original_video_id = 'OQpdSVF_k_w'
+        self.assertTrue(original_video_id in {entry['id'] for entry in entries})
 
     def test_youtube_toptracks(self):
         print('Skipping: The playlist page gives error 500')

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2781,8 +2781,7 @@ class YoutubePlaylistIE(YoutubePlaylistBaseInfoExtractor):
             webpage = self._download_webpage(
                 url, playlist_id, 'Downloading page {0} of Youtube mix'.format(n))
             new_ids = orderedSet(re.findall(
-                r'''(?xs)data-video-username=".*?".*?
-                           href="/watch\?v=([0-9A-Za-z_-]{11})&amp;[^"]*?list=%s''' % re.escape(playlist_id),
+                r'[\'"]/watch\?v=([0-9A-Za-z_-]{11})(?:&amp;|\\u0026)[^"]*?list=%s' % re.escape(playlist_id),
                 webpage))
             # Fetch new pages until all the videos are repeated, it seems that
             # there are always 51 unique videos.


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Youtube changed the html structure of its "youtube mix" playlist pages and the regex was no longer able to extract the video IDs.

I fixed the regex (making it more flexible) and also the unit test of this piece of code, since it was based on the (wrong) assumption that the video that generates the mix playlist is always the first entry in the playlist. 
