### PR TITLE
[soundcloud] Reduce pagination limit to fix 502 Bad Gateway errors when listing a user's tracks.

### DIFF
--- a/youtube_dl/extractor/soundcloud.py
+++ b/youtube_dl/extractor/soundcloud.py
@@ -558,8 +558,10 @@ class SoundcloudSetIE(SoundcloudPlaylistBaseIE):
 
 class SoundcloudPagedPlaylistBaseIE(SoundcloudIE):
     def _extract_playlist(self, base_url, playlist_id, playlist_title):
+        # Per the SoundCloud documentation, the maximum limit for a linked partioning query is 200.
+        # https://developers.soundcloud.com/blog/offset-pagination-deprecated
         COMMON_QUERY = {
-            'limit': 80000,
+            'limit': 200,
             'linked_partitioning': '1',
         }
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Per the documentation here https://developers.soundcloud.com/blog/offset-pagination-deprecated the maximum limit value is actually 200, however 2000 seems to work fine. The exact upper limit I found experimentally was 2847 (anything above the returns a 502 Bad Gateway error). I figured 2000 would provide some leeway in case the actual limit comes down again.

This limit was previously modified by b334732709a283a3a284e8835f4473c2a2be2827 after many users reported the 502 errors back in May. It seems to have cropped up again, and reducing the limit further seems to fix the problem. @remitamine might be interested in this since they merged in the last fix.

Before:
```
$ youtube-dl https://soundcloud.com/mediasanctuary
[soundcloud:user] mediasanctuary: Downloading user info
[soundcloud:user] 164222112: Downloading track page 1
ERROR: Unable to download JSON metadata: HTTP Error 502: Bad Gateway (caused by <HTTPError 502: 'Bad Gateway'>); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type  youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

After:
```
$ youtube-dl https://soundcloud.com/mediasanctuary
[soundcloud:user] mediasanctuary: Downloading user info
[soundcloud:user] 164222112: Downloading track page 1
[soundcloud:user] 164222112: Downloading track page 2
[soundcloud:user] 164222112: Downloading track page 3
[soundcloud:user] 164222112: Downloading track page 4
[download] Downloading playlist: MediaSanctuary (All)
[soundcloud:user] playlist MediaSanctuary (All): Collected 4483 video ids (downloading 4483 of them)
[download] Downloading video 1 of 4483
...
```

edit: Reduced limit to 200 to match SoundCloud's documentation.