### PR TITLE
[downloader/http] Retry download when urlopen times out

### DIFF
--- a/youtube_dl/downloader/http.py
+++ b/youtube_dl/downloader/http.py
@@ -106,7 +106,12 @@ class HttpFD(FileDownloader):
                 set_range(request, range_start, range_end)
             # Establish connection
             try:
-                ctx.data = self.ydl.urlopen(request)
+                try:
+                    ctx.data = self.ydl.urlopen(request)
+                except (compat_urllib_error.URLError, ) as err:
+                    if isinstance(err.reason, socket.timeout):
+                        raise RetryDownload(err)
+                    raise err
                 # When trying to resume, Content-Range HTTP header of response has to be checked
                 # to match the value of requested Range HTTP header. This is due to a webservers
                 # that don't support resuming and serve a whole file with no Content-Range


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When the http downloader's `urlopen` times out, it used to stop the program with the timeout error, disrespecting the user's retry count settings. This fix addresses that, by having a timeout trigger a retry.

I've tested it on Python 2.7.18 and 3.8.2.

While I think the fix is a useful thing to have in general, it addresses a specific issue I have, and described in #25183. That bug, however, was closed as a duplicate without any explanation or reference to a duplicate bug, so I never found out if there was any existing discussion about it.

Many times when the `dash` downloader is used to download youtube videos, my download would time out every 1-3 fragments. This means I would have to re-run the command over and over again.
With the timeout retry fix, the dash fragments that get a timeout are immediately retried, and the download eventually completes without any visible errors, or me having to restart it. (Note that for a smooth download I need to run it with a shortened socket-timeout, because the default of 20 seconds is too much for this particular use-case).