### PR TITLE
Remove the continue argument to aria2c when --no-continue is specified

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -183,7 +183,7 @@ class Aria2cFD(ExternalFD):
 
     def _make_cmd(self, tmpfilename, info_dict):
         cmd = [self.exe]
-        cmd += self._valueless_option('-c', 'continuedl')
+        cmd += self._bool_option('--continue', 'continuedl', separator='=')
         cmd += self._configuration_args([
             '--min-split-size', '1M', '--max-connection-per-server', '4'])
         dn = os.path.dirname(tmpfilename)

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -184,6 +184,8 @@ class Aria2cFD(ExternalFD):
     def _make_cmd(self, tmpfilename, info_dict):
         cmd = [self.exe]
         cmd += self._bool_option('--continue', 'continuedl', separator='=')
+        cmd += self._bool_option('--allow-overwrite', 'continuedl', 'false', 'true', separator='=')
+        cmd += self._bool_option('--remove-control-file', 'continuedl', 'false', 'true', separator='=')
         cmd += self._configuration_args([
             '--min-split-size', '1M', '--max-connection-per-server', '4'])
         dn = os.path.dirname(tmpfilename)

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -182,7 +182,8 @@ class Aria2cFD(ExternalFD):
     AVAILABLE_OPT = '-v'
 
     def _make_cmd(self, tmpfilename, info_dict):
-        cmd = [self.exe, '-c']
+        cmd = [self.exe]
+        cmd += self._valueless_option('-c', 'continuedl')
         cmd += self._configuration_args([
             '--min-split-size', '1M', '--max-connection-per-server', '4'])
         dn = os.path.dirname(tmpfilename)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When youtube-dl is launched with `--no-continue` and configured to use aria2 as external downloader, it always passes `-c` (continue) to aria2c. Here is an use case where due to this behavior it won't work:

* Output template is something like `C:/%(title)s.%(ext)s`, which is convenient but prone to duplicate.
* Make sure aria2's `auto-file-renaming` is on (as default).
* Specify `--no-continue` and `--no-part`.
* Download unrelated videos from webpages that share the same title, using generic extractor. Expected result is, all videos are downloaded and auto renamed to different names. Actual result is, only the first video is downloaded.
* I had an issue thread at https://github.com/ytdl-org/youtube-dl/issues/26594 that contains more details.

A good example is the curl handler. It checks the `continuedl` param and put `--continue-at` conditionally:
```
cmd += self._bool_option('--continue-at', 'continuedl', '-', '0')
```
I think all handlers that have continue option should follow the same rule.