### PR TITLE
[naver] Add support for live videos

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -672,7 +672,10 @@ from .nationalgeographic import (
     NationalGeographicVideoIE,
     NationalGeographicTVIE,
 )
-from .naver import NaverIE
+from .naver import (
+    NaverIE,
+    NaverLiveIE,
+)
 from .nba import NBAIE
 from .nbc import (
     CSNNEIE,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Naver TV offers Live streaming service now. I added support for live videos.
Each method which extracts stream info from VOD url and LIVE url is quite different, so I had to separate the extractor class.

And it seems that there is no geo-restriction on live stream yet. But I'm not sure, if someone has geo-restriction problem, please let me know.

You can check live videos here: [https://tv.naver.com/l/livehome](https://tv.naver.com/l/livehome)
