### PR TITLE
Fix incorrect ANSI sequence for restoring console-window title

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -535,7 +535,7 @@ class YoutubeDL(object):
                 # already of type unicode()
                 ctypes.windll.kernel32.SetConsoleTitleW(ctypes.c_wchar_p(message))
         elif 'TERM' in os.environ:
-            self._write_string('\033]0;%s\007' % message, self._screen_file)
+            self._write_string('\033[0;%s\007' % message, self._screen_file)
 
     def save_console_title(self):
         if not self.params.get('consoletitle', False):


### PR DESCRIPTION
The ANSI terminal sequence is incorrect:

https://github.com/ytdl-org/youtube-dl/blob/b55715934bb7f9474f69b99e4d51cc83dee7cbef/youtube_dl/YoutubeDL.py#L538

It must use the form `\033[` -- with a ***left*** (opening) square bracket... `[` , not the right/closing one.
