### PR TITLE
Fix for '--max-downloads' to stop immediately when reaching the limit.

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2002,6 +2002,9 @@ class YoutubeDL(object):
                     self.report_error('postprocessing: %s' % str(err))
                     return
                 self.record_download_archive(info_dict)
+                max_downloads = self.params.get('max_downloads')
+                if max_downloads is not None and self._num_downloads >= int(max_downloads):
+                    raise MaxDownloadsReached()
 
     def download(self, url_list):
         """Download a given list of URLs."""


### PR DESCRIPTION
Currently, the specifying a limit with `--max-downloads` doesn't cause **youtube-dl** to stop right after it has successfully downloaded that number of files.

Instead, it keeps iterating the playlist until another candidate file is found to download, only to then discovers that the limit was previously met. This unnecessary activity can actually take quite a while when a large playlist is already mostly downloaded.

This fix adds an additional tail-check on the `_num_downloads` condition so that it terminates immediately after finishing the last eligible file.