### PR TITLE
Add RuTube LiST support

### DIFF
--- a/youtube_dl/extractor/rutube.py
+++ b/youtube_dl/extractor/rutube.py
@@ -18,7 +18,7 @@ from ..utils import (
     try_get,
     unified_timestamp,
     url_or_none,
-)
+    ExtractorError)
 
 
 class RutubeBaseIE(InfoExtractor):
@@ -60,6 +60,39 @@ class RutubeBaseIE(InfoExtractor):
             'is_live': bool_or_none(video.get('is_livestream')),
             'is_club': bool_or_none(video.get('is_club')),
         }
+
+    def _real_initialize(self):
+        self._login()
+
+    def _login(self):
+        username, password = self._get_login_info()
+        if username is None:
+            return
+
+        login = self._download_json(
+            'https://pass.rutube.ru/api/accounts/phone/login/', None,
+            'Logging in', 'Unable to log in',
+            data=json.dumps({
+                'phone': username,
+                'password': password,
+            }).encode(),
+            headers={
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+            expected_status=400
+        )
+        if not login.get('success'):
+            msg = login.get('message')
+            raise ExtractorError(
+                'Unable to log in. %s said: %s' % (self.IE_NAME, msg),
+                expected=True
+            )
+
+        self._download_webpage(
+            'https://rutube.ru/social/auth/rupass/?callback_path=/social/login/rupass/',
+            None, False
+        )
 
     def _download_and_extract_info(self, video_id, query=None):
         return self._extract_info(
@@ -148,33 +181,26 @@ class RutubeIE(RutubeBaseIE):
         query = {}
 
         if info['is_club']:
-            username, password = self._get_login_info()
-            if username is None or password is None:
+            visitor_json, urlh = self._download_webpage_handle(
+                'https://rutube.ru/api/accounts/visitor/', video_id,
+                'Downloading visitor JSON', 'Unable to download visitor JSON'
+            )
+            if not visitor_json:
                 self.raise_login_required()
 
-            login = self._download_json(
-                'https://pass.rutube.ru/api/accounts/phone/login/', video_id, data=json.dumps({
-                    'phone': username,
-                    'password': password,
-                }).encode(),
-                headers={'Content-Type': 'application/json', 'Accept': 'application/json'}
-            )
-            if not login['success']:
-                self.raise_login_required('Invalid login or password')
-
-            self._download_webpage(
-                'https://rutube.ru/social/auth/rupass/?callback_path=/social/login/rupass/', video_id)
-
-            visitor = self._download_json(
-                'https://rutube.ru/api/accounts/visitor/', video_id, 'Downloading visitor JSON',
-                'Unable to download visitor JSON')
-            clubParams = visitor['club_params_encrypted']
+            visitor = self._parse_json(visitor_json, video_id)
+            club_params = visitor['club_params_encrypted']
             ad = self._download_json(
-                'https://mtr.rutube.ru/api/v3/interactive?' + clubParams + '&video_id=' + video_id, video_id,
-                'Downloading AD JSON', 'Unable to download AD JSON')
-            clubToken = ad['award']
-            query['club_token'] = clubToken
-            query['no_404'] = 'true'
+                'https://mtr.rutube.ru/api/v3/interactive?%s&video_id=%s' %
+                (club_params, video_id),
+                video_id, 'Downloading AD JSON', 'Unable to download AD JSON'
+            )
+            club_token = ad['award']
+
+            query.update({
+                'club_token': club_token,
+                'no_404': 'true',
+            })
 
         info['formats'] = self._download_and_extract_formats(video_id, query)
         return info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request adds support for RuTube LiST videos that can only be downloaded when logged in. This closes #24018.

The original research was done by @Gregory-Gerard, but I ported his code to Python, incorporated it into rutube extractor and tried to make it readable and reliable enough.

Both specifying --username/--password and using a cookie jar works.