### PR TITLE
[bandcamp] fix regexp for JSON matching on bandcamp

### DIFF
--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -33,7 +33,7 @@ class BandcampIE(InfoExtractor):
         'info_dict': {
             'id': '1812978515',
             'ext': 'mp3',
-            'title': "youtube-dl  \"'/\\\u00e4\u21ad - youtube-dl  \"'/\\\u00e4\u21ad - youtube-dl test song \"'/\\\u00e4\u21ad",
+            'title': "youtube-dl  \"'/\\\u00e4\u21ad - youtube-dl test song \"'/\\\u00e4\u21ad",
             'duration': 9.8485,
             'uploader': "youtube-dl  \"'/\\\u00e4\u21ad",
             'timestamp': 1354224127,
@@ -99,7 +99,6 @@ class BandcampIE(InfoExtractor):
             webpage, 'track info', default='{}')
 
         track_info = self._parse_json(trackinfo_block, title)
-
         if track_info:
             file_ = track_info.get('file')
             if isinstance(file_, dict):
@@ -115,7 +114,7 @@ class BandcampIE(InfoExtractor):
                         'acodec': ext,
                         'abr': int_or_none(abr_str),
                     })
-            track = track_info.get('title')
+
             track_id = str_or_none(track_info.get('track_id') or track_info.get('id'))
             track_number = int_or_none(track_info.get('track_num'))
             duration = float_or_none(track_info.get('duration'))
@@ -126,6 +125,7 @@ class BandcampIE(InfoExtractor):
                 webpage, key, default=None, group='value')
             return data.replace(r'\"', '"').replace('\\\\', '\\') if data else data
 
+        track = extract('title')
         artist = extract('artist')
         album = extract('album_title')
         timestamp = unified_timestamp(

--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -316,10 +316,10 @@ class BandcampAlbumIE(InfoExtractor):
             if self._html_search_meta('duration', elem_content, default=None)]
 
         title = self._html_search_regex(
-            r'album_title\s*:\s*"((?:\\.|[^"\\])+?)"',
+            r'album_title\s*(?:&quot;|["\']):\s*(?:&quot;|["\'])((?:\\.|[^"\\])+?)(?:&quot;|["\'])',
             webpage, 'title', fatal=False)
         if title:
-            title = title.replace(r'\"', '"')
+            title = unescapeHTML(title)
         return {
             '_type': 'playlist',
             'uploader_id': uploader_id,

--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -33,8 +33,11 @@ class BandcampIE(InfoExtractor):
         'info_dict': {
             'id': '1812978515',
             'ext': 'mp3',
-            'title': "youtube-dl  \"'/\\\u00e4\u21ad - youtube-dl test song \"'/\\\u00e4\u21ad",
+            'title': "youtube-dl  \\ - youtube-dl  \"'/\\\u00e4\u21ad - youtube-dl test song \"'/\\\u00e4\u21ad",
             'duration': 9.8485,
+            'uploader': 'youtube-dl  \\',
+            'timestamp': 1354224127,
+            'upload_date': '20121129',
         },
         '_skip': 'There is a limit of 200 free downloads / month for the test song'
     }, {

--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -92,10 +92,10 @@ class BandcampIE(InfoExtractor):
 
         formats = []
         trackinfo_block = self._search_regex(
-            r'trackinfo&quot;:\[\s*({.+?})\s*\],&quot;',
+            r'trackinfo(?:["\']|&quot;):\[\s*({.+?})\s*\],(?:["\']|&quot;)',
             webpage, 'track info', default='{}')
-        quoted_json = trackinfo_block.replace('&quot;', '"')
-        track_info = self._parse_json(quoted_json, title)
+        unescaped_json = unescapeHTML(trackinfo_block)
+        track_info = self._parse_json(unescaped_json, title)
         if track_info:
             file_ = track_info.get('file')
             if isinstance(file_, dict):
@@ -118,7 +118,7 @@ class BandcampIE(InfoExtractor):
 
         def extract(key):
             return self._search_regex(
-                r',&quot;%s&quot;:(&quot;)(?P<value>(?:(?!&quot;).)+)&quot;' % key,
+                r',(["\']|&quot;)%s\1:\1(?P<value>(?:(?!\1).)+)\1' % key,
                 webpage, key, default=None, group='value')
 
         artist = extract('artist')

--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -91,10 +91,11 @@ class BandcampIE(InfoExtractor):
         duration = None
 
         formats = []
-        track_info = self._parse_json(
-            self._search_regex(
-                r'trackinfo\s*:\s*\[\s*({.+?})\s*\]\s*,\s*?\n',
-                webpage, 'track info', default='{}'), title)
+        trackinfo_block = self._search_regex(
+            r'trackinfo&quot;:\[\s*({.+?})\s*\],&quot;',
+            webpage, 'track info', default='{}')
+        quoted_json = trackinfo_block.replace('&quot;', '"')
+        track_info = self._parse_json(quoted_json, title)
         if track_info:
             file_ = track_info.get('file')
             if isinstance(file_, dict):
@@ -117,7 +118,7 @@ class BandcampIE(InfoExtractor):
 
         def extract(key):
             return self._search_regex(
-                r'\b%s\s*["\']?\s*:\s*(["\'])(?P<value>(?:(?!\1).)+)\1' % key,
+                r',&quot;%s&quot;:(&quot;)(?P<value>(?:(?!&quot;).)+)&quot;' % key,
                 webpage, key, default=None, group='value')
 
         artist = extract('artist')

--- a/youtube_dl/extractor/bandcamp.py
+++ b/youtube_dl/extractor/bandcamp.py
@@ -128,12 +128,12 @@ class BandcampIE(InfoExtractor):
         release_date = unified_strdate(extract('album_release_date'))
 
         download_link = self._search_regex(
-            r'freeDownloadPage\s*:\s*(["\'])(?P<url>(?:(?!\1).)+)\1', webpage,
+            r'freeDownloadPage(?:["\']|&quot;):\s*(["\']|&quot;)(?P<url>(?:(?!\1).)+)\1', webpage,
             'download link', default=None, group='url')
         if download_link:
             track_id = self._search_regex(
-                r'(?ms)var TralbumData = .*?[{,]\s*id: (?P<id>\d+),?$',
-                webpage, 'track id')
+                r'\?id=(?P<id>\d+)&',
+                download_link, 'track id')
 
             download_webpage = self._download_webpage(
                 download_link, track_id, 'Downloading free downloads page')


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [X] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [X] Bug fix

---

### Description of your *pull request* and other information

Bandcamp changed their JSON format using `&quot;` entities all over, so this tries to match it so that youtube-dl can get the track info and work its magic. This most likely will fix #26681
