### PR TITLE
[go] Added support for NationalGeographic

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -670,7 +670,6 @@ from .myvi import (
 from .myvidster import MyVidsterIE
 from .nationalgeographic import (
     NationalGeographicVideoIE,
-    NationalGeographicTVIE,
 )
 from .naver import NaverIE
 from .nba import NBAIE

--- a/youtube_dl/extractor/go.py
+++ b/youtube_dl/extractor/go.py
@@ -38,13 +38,17 @@ class GoIE(AdobePassIE):
         'disneynow': {
             'brand': '011',
             'resource_id': 'Disney',
+        },
+        'nationalgeographic': {
+            'brand': '026',
+            'requestor_id': 'dtci',
         }
     }
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
                             (?:(?P<sub_domain>%s)\.)?go|
-                            (?P<sub_domain_2>abc|freeform|disneynow)
+                            (?:www\.)?(?P<sub_domain_2>abc|freeform|disneynow|nationalgeographic)
                         )\.com/
                         (?:
                             (?:[^/]+/)*(?P<id>[Vv][Dd][Kk][Aa]\w+)|
@@ -93,6 +97,19 @@ class GoIE(AdobePassIE):
             'title': 'The Bet',
             'description': 'md5:c66de8ba2e92c6c5c113c3ade84ab404',
             'age_limit': 14,
+        },
+        'params': {
+            'geo_bypass_ip_block': '3.244.239.0/24',
+            # m3u8 download
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://www.nationalgeographic.com/tv/shows/live-free-or-die/episode-guide/season-01/episode-05-butchers-and-builders/vdka10914748',
+        'info_dict': {
+            'id': 'VDKA10914748',
+            'ext': 'mp4',
+            'title': 'Butchers and Builders',
+            'description': 'md5:25b8b04d5c21fbed3644c0c17c3a41df',
         },
         'params': {
             'geo_bypass_ip_block': '3.244.239.0/24',

--- a/youtube_dl/extractor/nationalgeographic.py
+++ b/youtube_dl/extractor/nationalgeographic.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from .fox import FOXIE
 from ..utils import (
     smuggle_url,
     url_basename,
@@ -59,24 +58,3 @@ class NationalGeographicVideoIE(InfoExtractor):
                 {'force_smil_url': True}),
             'id': guid,
         }
-
-
-class NationalGeographicTVIE(FOXIE):
-    _VALID_URL = r'https?://(?:www\.)?nationalgeographic\.com/tv/watch/(?P<id>[\da-fA-F]+)'
-    _TESTS = [{
-        'url': 'https://www.nationalgeographic.com/tv/watch/6a875e6e734b479beda26438c9f21138/',
-        'info_dict': {
-            'id': '6a875e6e734b479beda26438c9f21138',
-            'ext': 'mp4',
-            'title': 'Why Nat Geo? Valley of the Boom',
-            'description': 'The lives of prominent figures in the tech world, including their friendships, rivalries, victories and failures.',
-            'timestamp': 1542662458,
-            'upload_date': '20181119',
-            'age_limit': 14,
-        },
-        'params': {
-            'skip_download': True,
-        },
-    }]
-    _HOME_PAGE_URL = 'https://www.nationalgeographic.com/tv/'
-    _API_KEY = '238bb0a0c2aba67922c48709ce0c06fd'


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
NationalGeographic already has an extractor, but all of the TV shows appear to have been moved to use the Go platform. This PR adds NationalGeographic to the Go extractors to re-allow TV shows to be extracted.

Note that the example episode that has been deleted as part of removing the now obsolete extractor is instead located at hxxps://www.nationalgeographic.com/tv/shows/valley-of-the-boom/video/vdka10919597

Fixes #22820 