### PR TITLE
Removed type ambiguity in one overload of YoutubeDL

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -340,10 +340,8 @@ class YoutubeDL(object):
     _num_downloads = None
     _screen_file = None
 
-    def __init__(self, params=None, auto_init=True):
+    def __init__(self, params={}, auto_init=True):
         """Create a FileDownloader object with the given options."""
-        if params is None:
-            params = {}
         self._ies = []
         self._ies_instances = {}
         self._pps = []


### PR DESCRIPTION
I don't believe there is a difference in functionality with using a set type as a default argument value. But keeping the argument type ambiguous with None isn't necessary.

## Please follow the guide below


### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement (Refactoring)
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Minor refactoring with argument type ambiguity.
