### PR TITLE
[bbc.co.uk] Try all possible mediaselectors even if one succeeds

### DIFF
--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -352,7 +352,7 @@ class BBCCoUkIE(InfoExtractor):
         last_exception = None
         formats = []
         subtitles = []
-        # as some mediaselectors may be parseable but have 
+        # as some mediaselectors may be parseable but have
         # no formats (eg captions only), try all possible
         # mediaselectors
         for mediaselector_url in self._MEDIASELECTOR_URLS:
@@ -366,7 +366,7 @@ class BBCCoUkIE(InfoExtractor):
                     last_exception = e
                     continue
                 self._raise_extractor_error(e)
-        # ignore a trapped exception if formats were found 
+        # ignore a trapped exception if formats were found
         if last_exception and not formats:
             self._raise_extractor_error(last_exception)
         return formats, subtitles

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -350,16 +350,26 @@ class BBCCoUkIE(InfoExtractor):
 
     def _download_media_selector(self, programme_id):
         last_exception = None
+        formats = []
+        subtitles = []
+        # as some mediaselectors may be parseable but have 
+        # no formats (eg captions only), try all possible
+        # mediaselectors
         for mediaselector_url in self._MEDIASELECTOR_URLS:
             try:
-                return self._download_media_selector_url(
+                formatsAndSubtitles = self._download_media_selector_url(
                     mediaselector_url % programme_id, programme_id)
+                formats += formatsAndSubtitles[0]
+                subtitles += formatsAndSubtitles[1]
             except BBCCoUkIE.MediaSelectionError as e:
                 if e.id in ('notukerror', 'geolocation', 'selectionunavailable'):
                     last_exception = e
                     continue
                 self._raise_extractor_error(e)
-        self._raise_extractor_error(last_exception)
+        # ignore a trapped exception if formats were found 
+        if last_exception and not formats:
+            self._raise_extractor_error(last_exception)
+        return formats, subtitles
 
     def _download_media_selector_url(self, url, programme_id=None):
         media_selection = self._download_xml(

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -359,8 +359,12 @@ class BBCCoUkIE(InfoExtractor):
             try:
                 formatsAndSubtitles = self._download_media_selector_url(
                     mediaselector_url % programme_id, programme_id)
-                formats += formatsAndSubtitles[0]
-                subtitles += formatsAndSubtitles[1]
+                # formats should always be set, but just in case
+                if formatsAndSubtitles[0]:
+                    formats += formatsAndSubtitles[0]
+                # subtitles may never be set
+                if formatsAndSubtitles[1]:
+                    subtitles += formatsAndSubtitles[1]
             except BBCCoUkIE.MediaSelectionError as e:
                 if e.id in ('notukerror', 'geolocation', 'selectionunavailable'):
                     last_exception = e

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -351,7 +351,7 @@ class BBCCoUkIE(InfoExtractor):
     def _download_media_selector(self, programme_id):
         last_exception = None
         formats = []
-        subtitles = []
+        subtitles = None
         # as some mediaselectors may be parseable but have
         # no formats (eg captions only), try all possible
         # mediaselectors
@@ -364,12 +364,10 @@ class BBCCoUkIE(InfoExtractor):
                     formats += formatsAndSubtitles[0]
                 # subtitles subtitles (a dict {(lang,sttl)})
                 if formatsAndSubtitles[1]:
-                    if not subtitles:
-                        subtitles = formatsAndSubtitles[1]
-                    else:
+                    if subtitles:
                         # prioritise the first sttl for each lang
                         formatsAndSubtitles[1].update(subtitles)
-                        subtitles = formatsAndSubtitles[1]
+                    subtitles = formatsAndSubtitles[1]
             except BBCCoUkIE.MediaSelectionError as e:
                 if e.id in ('notukerror', 'geolocation', 'selectionunavailable'):
                     last_exception = e

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -359,12 +359,17 @@ class BBCCoUkIE(InfoExtractor):
             try:
                 formatsAndSubtitles = self._download_media_selector_url(
                     mediaselector_url % programme_id, programme_id)
-                # formats should always be set, but just in case
+                # formats (a list) should always be set, but just in case
                 if formatsAndSubtitles[0]:
                     formats += formatsAndSubtitles[0]
-                # subtitles may never be set
+                # subtitles subtitles (a dict {(lang,sttl)})
                 if formatsAndSubtitles[1]:
-                    subtitles += formatsAndSubtitles[1]
+                    if not subtitles:
+                        subtitles = formatsAndSubtitles[1]
+                    else:
+                        # prioritise the first sttl for each lang
+                        formatsAndSubtitles[1].update(subtitles)
+                        subtitles = formatsAndSubtitles[1]
             except BBCCoUkIE.MediaSelectionError as e:
                 if e.id in ('notukerror', 'geolocation', 'selectionunavailable'):
                     last_exception = e


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)
Why isn't there tool for that in the repo? ...
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Some mediaselectors may be parseable but have no formats (eg captions only), eg `https://www.bbc.co.uk/iplayer/episode/b0b3px4q`.

This revision tries all possible mediaselectors and assembles the formats and subtitles found.

If any formats are found, the known exceptions ('notukerror', 'geolocation', 'selectionunavailable') are not propagated.

Should help with #23933.

Is there any need to try to de-duplicate formats?

