### PR TITLE
fix exception for kika. this ensures that certain videos can be downl…

### DIFF
--- a/youtube_dl/extractor/mdr.py
+++ b/youtube_dl/extractor/mdr.py
@@ -126,6 +126,9 @@ class MDRIE(InfoExtractor):
                     abr = int_or_none(xpath_text(asset, './bitrateAudio', 'abr'), 1000)
                     filesize = int_or_none(xpath_text(asset, './fileSize', 'file size'))
 
+                    if vbr is None and abr is None:
+                        continue
+
                     f = {
                         'url': video_url,
                         'format_id': '%s-%d' % (media_type, vbr or abr),


### PR DESCRIPTION
…oaded.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
The last PR with the same code changes was marked as invalid, and I do not understand the reason for that.
As I'm new to GitHub and youtube-dl, could you please tell me more details about what is/was wrong with the PR?

Compared to the last PR, I now successfully checked the code with flake8 and give you now a more detailed description:

When trying to download certain videos from KIKA, youtube-dl crashes with an exception, e.g.
youtube-dl.exe https://www.kika.de/zacki-und-die-zoobande/sendungen/sendung123764.html

This fix ensures that at least more videos can now be downloaded successfully from KIKA. 
The fix has no negative side effects as it just prevents a crash of youtube-dl.

