### PR TITLE
Handle different syntax for boolean values in js_to_json

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1000,6 +1000,12 @@ class TestUtil(unittest.TestCase):
         on = js_to_json('{ "040": "040" }')
         self.assertEqual(json.loads(on), {'040': '040'})
 
+        on = js_to_json('{ "defaultQuality":!0}')
+        self.assertEqual(json.loads(on), {'defaultQuality': 'true'})
+
+        on = js_to_json('{ "onFullscreen":!1}')
+        self.assertEqual(json.loads(on), {'onFullscreen': 'false'})
+
     def test_js_to_json_malformed(self):
         self.assertEqual(js_to_json('42a1'), '42"a1"')
         self.assertEqual(js_to_json('42a-1'), '42"a"-1')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4081,6 +4081,11 @@ def js_to_json(code):
         elif v.startswith('/*') or v.startswith('//') or v == ',':
             return ""
 
+        if v == "!0":
+            v = 'true'
+        if v == "!1":
+            v = 'false'
+
         if v[0] in ("'", '"'):
             v = re.sub(r'(?s)\\.|"', lambda m: {
                 '"': '\\"',
@@ -4103,7 +4108,8 @@ def js_to_json(code):
         {comment}|,(?={skip}[\]}}])|
         (?:(?<![0-9])[eE]|[a-df-zA-DF-Z_])[.a-zA-Z_0-9]*|
         \b(?:0[xX][0-9a-fA-F]+|0+[0-7]+)(?:{skip}:)?|
-        [0-9]+(?={skip}:)
+        [0-9]+(?={skip}:)|
+        \![0-1]
         '''.format(comment=COMMENT_RE, skip=SKIP_RE), fix_kv, code)
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I have recently seen XTube using `!0` and `!1` for boolean values in their JSON that is used by youtube-dl to extract the video formats. An example output, cut to the relevant part, can be seen here (for example, see the 'defaultQuality' or 'autoPlay' entries):
```json
{startOffset:0,productUrl:"https://www.xtube.com/video-watch/free-test-video-3-45241311",mainRoll:{mediaDefinition:[{defaultQuality:!1,format:"upsell",quality:1080,videoUrl:""},{defaultQuality:!1,format:"mp4",quality:720,videoUrl:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_720.mp4?ttl=1603474084&hash=59c3703c26f638f050aac583c6179670"},{defaultQuality:!0,format:"mp4",quality:480,videoUrl:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_ultra.mp4?ttl=1603474084&hash=85300389df7ecccfe0286197d1d92ec9"},{defaultQuality:!1,format:"mp4",quality:240,videoUrl:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_high.mp4?ttl=1603474084&hash=eb673f605af4473c2aafd953069cfbca"},{defaultQuality:!1,format:"mp4",quality:180,videoUrl:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_normal.mp4?ttl=1603474084&hash=f217685c9713c1b3c42900df5b6c1fdb"}],poster:"https://cdn1-s-ha-e5.xtube.com/m=eaAaaEFb/videos/202010/16/45241311/xtube_original/3.jpg",format:{1080:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_1080.mp4?ttl=1603474084&hash=7548a2d5139c9e1c802df7f917ad7b66",720:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_720.mp4?ttl=1603474084&hash=59c3703c26f638f050aac583c6179670",480:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_ultra.mp4?ttl=1603474084&hash=85300389df7ecccfe0286197d1d92ec9",240:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_high.mp4?ttl=1603474084&hash=eb673f605af4473c2aafd953069cfbca",180:"https://cdn1-l-hw-e7.xtube.com/videos/202010/16/45241311/xtube_mp4_normal.mp4?ttl=1603474084&hash=f217685c9713c1b3c42900df5b6c1fdb"},videoUrl:"https://www.xtube.com/video-watch/free-test-video-3-45241311",title:"FREE test video 3",duration:306,autoPlay:!0,thumbs:{urlPattern:"https://cdn9-s-hw-e5.xtube.com/m=eGCaiCFb/videos/202010/16/45241311/xtube_timeline/timeline_{3}.jpg",format:"5x5",thumbHeight:"90",thumbWidth:"160",cdnType:"regular",type:"normal",samplingFrequency:6}},features:{themeColor:"#ff0102",shareBar:!1,optionsEnabled:!0,cinema:!0,menuDismissTimer:"4",hideControlsTimeout:"2",showAutoplayOption:!1},embeds:{enabled:!1,logoEnabled:!1,utmRedirect:{logo:!1,relatedBtns:!1,thumbs:!1,videoArea:!1},redirect:{onFullscreen:!1,onMenu:!1,logoUrl:"https://www.xtube.com/video-watch/free-test-video-3-45241311",relatedUrl:"/ajax/media/video/playerMenuData.php?videoId=c1UEe-366-"}},flashSettings:{htmlPauseRoll:!0,htmlPostRoll:!0},menu:{url:"",related:!0,relatedUrl:"/ajax/media/video/playerMenuData.php?videoId=c1UEe-366-"},preroll:{delay:[900,2e3,3e3],forgetUserAfter:86400,onNth:1,skipDelay:5,skippable:1,user_accept_language:"en-US,en;q=0.83",vast:"https://ads.trafficjunky.net/ads?zone_id=2041171&site_id=18",vastSkipDelay:!1}}
```
(aquired by this command:) 
`curl https://www.xtube.com/video-watch/free-test-video-3-45241311 | sed -n 's/.*playerConf=\(.*\),loaderConf.*/\1/p'`

This PR adds an edge-case for this kind of value and replaces it with valid JSON.