### PR TITLE
Update embedthumbnail.py

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -30,6 +30,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
     def run(self, info):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
+        mtime = os.stat(filename).st_mtime
 
         if not info.get('thumbnails'):
             self._downloader.to_screen('[embedthumbnail] There aren\'t any thumbnails to embed')
@@ -123,4 +124,5 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         else:
             raise EmbedThumbnailPPError('Only mp3 and m4a/mp4 are supported for thumbnail embedding for now.')
 
+        self.try_utime(filename, mtime, mtime)
         return [], info


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Running `youtube-dl YE7VzlLtp-4` will create a file with a last modified time of 15 Sep 2018 as expected.

If instead we run`youtube-dl --embed-thumbnail YE7VzlLtp-4` the file created has a last modified time of the current time. 
I believe this is a bug. Please see the screenshot showing this behaviour.
<img width="800" alt="Screen Shot 2020-11-17 at 10 37 10 am" src="https://user-images.githubusercontent.com/15261804/99339299-deb27000-28c0-11eb-8637-5dbf284d3f2d.png">
My edit simply stores the last modified date of the file before renaming it, and uses the already created try_utime() function to apply it to the file.
Please see the screenshot showing that this has the desired effect.
<img width="800" alt="Screen Shot 2020-11-17 at 10 53 38 am" src="https://user-images.githubusercontent.com/15261804/99340552-30f49080-28c3-11eb-8895-64f80864d4ef.png">