### PR TITLE
[hse24] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -444,6 +444,7 @@ from .hrti import (
     HRTiIE,
     HRTiPlaylistIE,
 )
+from .hse24 import HSE24IE
 from .huajiao import HuajiaoIE
 from .huffpost import HuffPostIE
 from .hungama import (

--- a/youtube_dl/extractor/hse24.py
+++ b/youtube_dl/extractor/hse24.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from time import mktime, strptime
+
+
+class HSE24IE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?hse24\.de/dpl/(?:p/product|c/tv-shows)?/(?P<id>[0-9]+)'
+    _GEO_COUNTRIES = ['DE']
+    _TESTS = [{
+        'url': 'https://www.hse24.de/dpl/c/tv-shows/476357',
+        'info_dict': {
+            'id': '476357',
+            'ext': 'mp4',
+            'title': 'Jürgen Hirsch Schuhe zum Wohlfühlen',
+            'timestamp': 1604926800,
+            'upload_date': '20201109',
+            'channel': 'HSE24EXTRA',
+            'uploader': 'Daniela Elger'
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }, {
+        'url': 'https://www.hse24.de/dpl/p/product/408630',
+        'info_dict': {
+            'id': '408630',
+            'ext': 'mp4',
+            'title': 'Hose im Ponte-Mix',
+            'timestamp': 1603058400,
+            'upload_date': '20201018',
+            'channel': 'HSE24',
+            'uploader': 'Judith Williams'
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        json_str = self._html_search_regex(r'window\.__REDUX_DATA__ = ({.*});?', webpage, 'json_str')
+        json_str = json_str.replace('\n', '')
+        json_data = self._parse_json(json_str, video_id)
+
+        formats = []
+        if 'tvShow' in json_data:  # /dpl/c/tv-shows
+            show = json_data['tvShow']['tvShow']
+            title, date, hour, uploader = show['title'], show['date'], show['hour'], show['presenter']
+            channel = self._search_regex(r'tvShow \| ([A-Z0-9]+)_', show['actionFieldText'], video_id)
+            timestamp = mktime(strptime(' '.join((date, hour)), '%Y-%m-%d %H'))
+
+            video = json_data['tvShow']['tvShowVideo']
+            thumbnail = video['poster']
+            sources = video['sources']
+            for src in sources:
+                if src['mimetype'] == 'application/x-mpegURL':
+                    formats.extend(self._extract_m3u8_formats(src['url'], video_id, ext='mp4'))
+        elif 'productDetail' in json_data:  # /dpl/p/product
+            product = json_data['productDetail']['product']
+            title, uploader = product['name']['short'], product['brand']['brandName']
+            channel = 'HSE24'
+            default_time = '2001-01-01T01:01:01+0100'
+            time = product['variants'][0]['price']['validFrom'] if len(product['variants']) > 0 else default_time
+            # python2 compatibility (no %z directive support)
+            time = strptime(time[:-6], '%Y-%m-%dT%H:%M:%S')
+            if time[-6] == '+':
+                time += strptime(time[-6:], '%H:%M')
+            elif time[-6] == '-':
+                time -= strptime(time[-6:], '%H:%M')
+            timestamp = mktime(time)
+
+            for video in json_data['productContent']['productContent']['videos']:
+                thumbnail = video['poster']
+                sources = video['sources']
+                for src in sources:
+                    if src['mimetype'] == 'application/x-mpegURL':
+                        formats.extend(self._extract_m3u8_formats(src['url'], video_id, ext='mp4'))
+                    # elif src['mimetype'] == 'video/mp4':
+                    #     formats.append({'url': src['url']})
+
+        self._sort_formats(formats)
+
+        return {
+            'id': video_id,
+            'title': title,
+            'formats': formats,
+            'timestamp': int(timestamp),
+            'thumbnail': thumbnail,
+            'channel': channel,
+            'uploader': uploader
+        }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Extractor to pull videos from home-shopping site "hse24.de". Both product videos (`/dpl/p/product`) and show recordings (`dpl/c/tv-shows`) are supported. Extractor extracts and lists all available formats (typically low, mid, high resolution/bitrate). Tests passed on Python2.7, Python3.6, Python3.8.