### PR TITLE
Initial Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.12 AS builder
+RUN apk add make zip
+WORKDIR /src
+COPY . .
+RUN make youtube-dl
+
+FROM alpine:3.12
+RUN apk --no-cache add python3 ffmpeg \
+  && ln -s /usr/bin/python3 /usr/bin/python
+COPY --from=builder /src/youtube-dl /usr/local/bin/
+WORKDIR /downloads
+USER guest
+ENTRYPOINT ["youtube-dl"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.3'
+services:
+  youtube-dl:
+    build: .
+    volumes:
+      - ./downloads:/downloads
+    command: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"


### PR DESCRIPTION
### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

I recently used youtube-dl within a Docker container to download new entries of a playlist. The Docker images I could find where either out of date or not written for general consumption.

This pull request will make it trivial to create a hook on [Docker Hub](https://hub.docker.com/) which will automatically build a new image each time the GitHub repository is updated.

Additionally it could be expanded to create images tagged with the release version.

For easy of use I've added a docker-compose file. The image can be build and run using the following command.

    mkdir downloads/ && chmod ugo+rw downloads/ && docker-compose build && docker-compose run youtube-dl

Assuming this pull request is approved I'll gladly add a section to the readme file.