### PR TITLE
[Pinterest] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -843,6 +843,7 @@ from .picarto import (
 )
 from .piksel import PikselIE
 from .pinkbike import PinkbikeIE
+from .pinterest import PinterestIE
 from .pladform import PladformIE
 from .platzi import (
     PlatziIE,

--- a/youtube_dl/extractor/pinterest.py
+++ b/youtube_dl/extractor/pinterest.py
@@ -1,0 +1,64 @@
+# coding: utf-8
+from .common import InfoExtractor
+from ..utils import (
+    js_to_json,
+    str_or_none,
+    try_get,
+    determine_ext,
+)
+
+
+class PinterestIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?pinterest\.com/pin/(?P<id>[0-9]+)'
+    _TEST = {
+        'url': 'https://www.pinterest.com/pin/705939310335590838/',
+        'md5': 'cec64cd13da298ad27e17d0c36ffec7b',
+        'info_dict': {
+            'description': 'Ad: Floating lanterns in the night sky. Launching Sky Lantern. Yee Peng Festival, Loy Krathong celebration.',
+            'ext': 'mp4',
+            'id': '705939310335590838',
+            'title': 'Floating Lanterns in the Night Stock Footage Video (100% Royalty-free) 1021682980 | Shutterstock',
+            'uploader': 'UF | Unique Footages',
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        data = self._parse_video_data(webpage, video_id)
+        formats = self._extract_formats(try_get(data, lambda x: x['videos']['video_list']) or {}, video_id)
+
+        return {
+            'id': video_id,
+            'title': str_or_none(data.get('title')),
+            'description': str_or_none(data.get('closeup_unified_description')),
+            'uploader': try_get(data, lambda x: x['closeup_attribution']['full_name']),
+            'formats': formats,
+        }
+
+    def _parse_video_data(self, webpage, video_id):
+        script = self._search_regex(
+            r'<script[^>]+id=(["\'])initial-state\1[^>]*>(?P<json>[^<]+)',
+            webpage, 'video data', group='json')
+
+        return try_get(self._parse_json(script, video_id, transform_source=js_to_json),
+                       lambda x: x['resourceResponses'][0]['response']['data']) or {}
+
+    def _extract_formats(self, video_list, video_id):
+        formats = []
+        for format_id, format_data in video_list.items():
+            url = format_data.get('url')
+            if 'm3u8' == determine_ext(url):
+                formats.extend(self._extract_m3u8_formats(url, video_id, 'mp4', 'm3u8_native', m3u8_id=format_id))
+            else:
+                formats.append({
+                    'duration': format_data.get('duration'),
+                    'format_id': format_id,
+                    'height': format_data.get('height'),
+                    'thumbnail': format_data.get('thumbnail'),
+                    'url': url,
+                    'width': format_data.get('width'),
+                })
+        self._sort_formats(formats)
+
+        return formats


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Downloading of videos from pinterest.com ( e.g. `https://www.pinterest.com/pin/1234567890/`) is implemented.

Before creation of this PR i have discovered that there is another one PR is created already with similar feature: https://github.com/ytdl-org/youtube-dl/pull/25747
Unfortunately, failed to find this PR before starting working on my extractor.
I would say that my implementation provides an option to choose between different video formats. Also coding conventions are considered - for example, "flexible" regex to parse `<script id="initial-state">` element. Utility functions (`try_get`, `js_to_json` etc) were used as well

