### PR TITLE
set mtime for fragmented videos (such as DASH)

### DIFF
--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -116,6 +116,10 @@ class FragmentFD(FileDownloader):
         finally:
             if self.__do_ytdl_file(ctx):
                 self._write_ytdl_file(ctx)
+            try:
+                os.utime(ctx['tmpfilename'], (time.time(), os.stat(ctx['fragment_filename_sanitized']).st_mtime))
+            except Exception:
+                pass
             if not self.params.get('keep_fragments', False):
                 os.remove(encodeFilename(ctx['fragment_filename_sanitized']))
             del ctx['fragment_filename_sanitized']

--- a/youtube_dl/downloader/fragment.py
+++ b/youtube_dl/downloader/fragment.py
@@ -116,10 +116,7 @@ class FragmentFD(FileDownloader):
         finally:
             if self.__do_ytdl_file(ctx):
                 self._write_ytdl_file(ctx)
-            try:
-                os.utime(ctx['tmpfilename'], (time.time(), os.stat(ctx['fragment_filename_sanitized']).st_mtime))
-            except Exception:
-                pass
+            self.mtime = os.stat(ctx['fragment_filename_sanitized']).st_mtime
             if not self.params.get('keep_fragments', False):
                 os.remove(encodeFilename(ctx['fragment_filename_sanitized']))
             del ctx['fragment_filename_sanitized']
@@ -263,6 +260,12 @@ class FragmentFD(FileDownloader):
         else:
             self.try_rename(ctx['tmpfilename'], ctx['filename'])
             downloaded_bytes = os.path.getsize(encodeFilename(ctx['filename']))
+
+        if self.mtime:
+            try:
+                os.utime(ctx['filename'], (time.time(), self.mtime))
+            except Exception:
+                pass
 
         self._hook_progress({
             'downloaded_bytes': downloaded_bytes,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

set mtime for fragmented videos (such as DASH)
 - it is set to the mtime of the last fragment uploaded

See issue #18384.
