### PR TITLE
[MedalTV, GamerDVR, XboxClips/GameClips] Add 2 new extractors and fix 1 extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -606,6 +606,7 @@ from .markiza import (
 from .massengeschmacktv import MassengeschmackTVIE
 from .matchtv import MatchTVIE
 from .mdr import MDRIE
+from .medaltv import MedalTVIE
 from .mediaset import MediasetIE
 from .mediasite import (
     MediasiteIE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -398,6 +398,7 @@ from .fusion import FusionIE
 from .fxnetworks import FXNetworksIE
 from .gaia import GaiaIE
 from .gameinformer import GameInformerIE
+from .gamerdvr import GamerDVRIE
 from .gamespot import GameSpotIE
 from .gamestar import GameStarIE
 from .gaskrank import GaskrankIE

--- a/youtube_dl/extractor/gamerdvr.py
+++ b/youtube_dl/extractor/gamerdvr.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class GamerDVRIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?gamerdvr\.com/gamer/\S+/video/(?P<id>\d+)'
+    _TEST = {
+        'url': 'https://gamerdvr.com/gamer/videogamer3/video/83193307',
+        'md5': 'f747c74fbc7617a70d8c071927623cde',
+        'info_dict': {
+            'id': '83193307',
+            'ext': 'mp4',
+            'title': "videogamer3's Xbox Call of Duty®: Modern Warfare® clip 83193307. Find your Xbox clips on GamerDVR.com",
+            'description': "videogamer3's Xbox Call of Duty®: Modern Warfare® clips and gameplay playing Call of Duty®: Modern Warfare®. All your Xbox clips and screenshots on GamerDVR.com. View, manage, and share easily!",
+            'uploader': 'videogamer3'
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        video_url = self._html_search_regex(
+            r"<source src=\"(\S+)\"", webpage, 'URL')
+        title = self._html_search_regex(
+            r'<title>(.+?)</title>', webpage, 'title', fatal=False)
+        description = self._html_search_regex(
+            r"<meta name=\"description\" content=([\"'])((?:\\\1|.)*?)\1",
+            webpage, 'description', group=2, fatal=False)
+        uploader = self._html_search_regex(
+            r"window\.gamertag = '(.+)';", webpage, 'uploader', fatal=False)
+        return {
+            'id': video_id,
+            'title': title,
+            'description': description,
+            'uploader': uploader,
+            'url': video_url
+        }

--- a/youtube_dl/extractor/medaltv.py
+++ b/youtube_dl/extractor/medaltv.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import ExtractorError
+
+
+class MedalTVIE(InfoExtractor):
+    _VALID_URL = r'(?:https://)?(?:www\.)?medal\.tv(?:/clips)?/(?P<id>[0-9]+)'
+    _TESTS = [{
+        'url': 'https://medal.tv/clips/34934644/3Is9zyGMoBMr',
+        'md5': '7b07b064331b1cf9e8e5c52a06ae68fa',
+        'info_dict': {
+            'id': '34934644',
+            'ext': 'mp4',
+            'title': 'Quad Cold',
+            'description': 'Medal,https://medal.tv/desktop/',
+            'uploader': 'MowgliSB',
+            'timestamp': 1603165266000,
+            'uploader_id': 10619174,
+        }
+    }, {
+        'url': 'https://medal.tv/clips/36787208',
+        'md5': 'b6dc76b78195fff0b4f8bf4a33ec2148',
+        'info_dict': {
+            'id': '36787208',
+            'ext': 'mp4',
+            'title': 'u tk me i tk u bigger',
+            'description': 'Medal,https://medal.tv/desktop/',
+            'uploader': 'Mimicc',
+            'timestamp': 1605580939000,
+            'uploader_id': 5156321,
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        url = 'https://medal.tv/clips/{}'.format(video_id)
+        webpage = self._download_webpage(url, video_id)
+
+        hydration_data = self._search_regex(r'<script>.*hydrationData\s*=\s*({.+?})\s*</script>', webpage, 'hydration data', default='{}')
+        parsed = self._parse_json(hydration_data, video_id, fatal=False)
+
+        author_info = next(iter(parsed['profiles'].values()))
+        clip_info = parsed['clips'][video_id]
+
+        if('error' in clip_info):
+            if(clip_info['error'] == 404):
+                raise ExtractorError('That clip does not exist.', expected=True, video_id=video_id)
+            else:
+                raise ExtractorError('An unknown error occurred ({}).'.format(clip_info['error']), video_id=video_id)
+        source_aspect_ratio = clip_info['sourceWidth'] / clip_info['sourceHeight']
+
+        # ordered from worst to best quality
+        sizes = (144, 240, 360, 480, 720, 1080)
+
+        formats = []
+        thumbnails = []
+
+        for size in sizes:
+            format_key = '{}p'.format(size)
+            video_key = 'contentUrl{}'.format(format_key)
+            thumbnail_key = 'thumbnail{}'.format(format_key)
+
+            # second condition needed as sometimes medal says
+            # they have a format when in fact it is another format
+            if(video_key in clip_info and format_key in clip_info[video_key]):
+                formats.append({
+                    'url': clip_info[video_key],
+                    'format_id': format_key,
+                    'width': round(source_aspect_ratio * size),
+                    'height': size
+                })
+
+            if(thumbnail_key in clip_info and format_key in clip_info[thumbnail_key]):
+                thumbnails.append({
+                    'id': format_key,
+                    'url': clip_info[thumbnail_key],
+                    'width': round(source_aspect_ratio * size),
+                    'height': size
+                })
+
+        formats.append({
+            'url': clip_info['contentUrl'],
+            'format_id': 'source',
+            'width': clip_info['sourceWidth'],
+            'height': clip_info['sourceHeight']
+        })
+
+        return {
+            'id': video_id,
+            'title': clip_info['contentTitle'] if clip_info['hasTitle'] else '',
+
+            'formats': formats,
+            'url': clip_info['contentUrl'],
+
+            'thumbnails': thumbnails,
+            'thumbnail': thumbnails[0]['url'],
+
+            'description': clip_info['contentDescription'],
+
+            # author information
+            'uploader': author_info['displayName'],
+            'timestamp': clip_info['created'],
+            'uploader_id': author_info['id'],
+            'uploader_url': 'https://medal.tv/users/{}'.format(author_info['id']),
+
+            # other clip information
+            'duration': clip_info['videoLengthSeconds'],
+            'view_count': clip_info['views'],
+            'like_count': clip_info['likes'],
+            'comment_count': clip_info['comments']
+        }

--- a/youtube_dl/extractor/medaltv.py
+++ b/youtube_dl/extractor/medaltv.py
@@ -17,7 +17,8 @@ class MedalTVIE(InfoExtractor):
             'title': 'Quad Cold',
             'description': 'Medal,https://medal.tv/desktop/',
             'uploader': 'MowgliSB',
-            'timestamp': 1603165266000,
+            'timestamp': 1603165266,
+            'upload_date': '20201020',
             'uploader_id': 10619174,
         }
     }, {
@@ -29,7 +30,8 @@ class MedalTVIE(InfoExtractor):
             'title': 'u tk me i tk u bigger',
             'description': 'Medal,https://medal.tv/desktop/',
             'uploader': 'Mimicc',
-            'timestamp': 1605580939000,
+            'timestamp': 1605580939,
+            'upload_date': '20201117',
             'uploader_id': 5156321,
         }
     }]
@@ -103,7 +105,7 @@ class MedalTVIE(InfoExtractor):
 
             # author information
             'uploader': author_info['displayName'],
-            'timestamp': clip_info['created'],
+            'timestamp': clip_info['created'] / 1000,
             'uploader_id': author_info['id'],
             'uploader_url': 'https://medal.tv/users/{}'.format(author_info['id']),
 

--- a/youtube_dl/extractor/xboxclips.py
+++ b/youtube_dl/extractor/xboxclips.py
@@ -2,52 +2,33 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from ..utils import (
-    int_or_none,
-    parse_filesize,
-    unified_strdate,
-)
 
 
 class XboxClipsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?xboxclips\.com/(?:video\.php\?.*vid=|[^/]+/)(?P<id>[\w-]{36})'
+    _VALID_URL = r'https?://(?:www\.)?(?:xboxclips\.com|gameclips\.io)/\S+?/(?P<id>[a-zA-Z0-9-]{36})'
     _TEST = {
-        'url': 'http://xboxclips.com/video.php?uid=2533274823424419&gamertag=Iabdulelah&vid=074a69a9-5faf-46aa-b93b-9909c1720325',
-        'md5': 'fbe1ec805e920aeb8eced3c3e657df5d',
+        'url': 'https://xboxclips.com/DeeperGnu613/7936bcb9-83fc-4565-979b-8db96bffa460',
+        'md5': 'e434323563f3ae6f02ab1f5b8f514f28',
         'info_dict': {
-            'id': '074a69a9-5faf-46aa-b93b-9909c1720325',
+            'id': '7936bcb9-83fc-4565-979b-8db96bffa460',
             'ext': 'mp4',
-            'title': 'Iabdulelah playing Titanfall',
-            'filesize_approx': 26800000,
-            'upload_date': '20140807',
-            'duration': 56,
+            'title': 'GameClips.io - DeeperGnu613 playing Forza Horizon 4. Watch more Xbox Clips at GameClips.io',
+            'uploader': 'DeeperGnu613'
         }
     }
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         webpage = self._download_webpage(url, video_id)
-
         video_url = self._html_search_regex(
-            r'>(?:Link|Download): <a[^>]+href="([^"]+)"', webpage, 'video URL')
+            r"<source src=\"(\S+)\"", webpage, 'URL')
         title = self._html_search_regex(
-            r'<title>XboxClips \| ([^<]+)</title>', webpage, 'title')
-        upload_date = unified_strdate(self._html_search_regex(
-            r'>Recorded: ([^<]+)<', webpage, 'upload date', fatal=False))
-        filesize = parse_filesize(self._html_search_regex(
-            r'>Size: ([^<]+)<', webpage, 'file size', fatal=False))
-        duration = int_or_none(self._html_search_regex(
-            r'>Duration: (\d+) Seconds<', webpage, 'duration', fatal=False))
-        view_count = int_or_none(self._html_search_regex(
-            r'>Views: (\d+)<', webpage, 'view count', fatal=False))
-
+            r'<title>(.+?)</title>', webpage, 'title', fatal=False)
+        uploader = self._html_search_regex(
+            r'<h3>(.+?)</h3>', webpage, 'uploader', fatal=False)
         return {
             'id': video_id,
-            'url': video_url,
             'title': title,
-            'upload_date': upload_date,
-            'filesize_approx': filesize,
-            'duration': duration,
-            'view_count': view_count,
+            'uploader': uploader,
+            'url': video_url
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Medal TV is a platform for gamers to record and share clips and videos. This is quite a popular site, so it was surprising that there is not an extractor for it yet. Although there is another pull request for Medal TV (https://github.com/ytdl-org/youtube-dl/pull/27118), this extractor provides all available formats (including source). The other pull request only supports 1080p or 720p. This extractor also provides error checking (in case a video does not exist for example). Furthermore, this extractor was tested on 1400 medal clips and every one produced expected behaviour.

GamerDVR is a website which allows users to find their Xbox One (Xbox DVR) game clips. This extractor allows videos to be downloaded from this website.

Lastly, the XboxClips extractor has been updated, because its domain has changed to GameClips.io. However, XboxClips links still work (they redirect to GameClips.io), so both sites are supported in this extractor. 