### PR TITLE
[XboxClips] Fix extractor (and new domain support)

### DIFF
--- a/youtube_dl/extractor/xboxclips.py
+++ b/youtube_dl/extractor/xboxclips.py
@@ -2,52 +2,42 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from ..utils import (
-    int_or_none,
-    parse_filesize,
-    unified_strdate,
-)
 
 
 class XboxClipsIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?xboxclips\.com/(?:video\.php\?.*vid=|[^/]+/)(?P<id>[\w-]{36})'
-    _TEST = {
-        'url': 'http://xboxclips.com/video.php?uid=2533274823424419&gamertag=Iabdulelah&vid=074a69a9-5faf-46aa-b93b-9909c1720325',
-        'md5': 'fbe1ec805e920aeb8eced3c3e657df5d',
+    _VALID_URL = r'https?://(?:www\.)?(?:xboxclips\.com|gameclips\.io)/\S+?/(?P<id>[a-zA-Z0-9-]{36})'
+    _TESTS = [{
+        'url': 'https://xboxclips.com/DeeperGnu613/7936bcb9-83fc-4565-979b-8db96bffa460',
+        'md5': 'e434323563f3ae6f02ab1f5b8f514f28',
         'info_dict': {
-            'id': '074a69a9-5faf-46aa-b93b-9909c1720325',
+            'id': '7936bcb9-83fc-4565-979b-8db96bffa460',
             'ext': 'mp4',
-            'title': 'Iabdulelah playing Titanfall',
-            'filesize_approx': 26800000,
-            'upload_date': '20140807',
-            'duration': 56,
+            'title': 'GameClips.io - DeeperGnu613 playing Forza Horizon 4. Watch more Xbox Clips at GameClips.io',
+            'uploader': 'DeeperGnu613'
         }
-    }
+    }, {
+        'url': 'https://gameclips.io/Wrecked559/f34f0f4d-65f8-456e-aeaa-7da8a108a658',
+        'md5': '9d50e531a957b2f823720a0c1aefaea4',
+        'info_dict': {
+            'id': 'f34f0f4d-65f8-456e-aeaa-7da8a108a658',
+            'ext': 'mp4',
+            'title': 'GameClips.io - Wrecked559 playing Call of Duty®: Modern Warfare®. Watch more Xbox Clips at GameClips.io',
+            'uploader': 'Wrecked559'
+        }
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
-
         webpage = self._download_webpage(url, video_id)
-
         video_url = self._html_search_regex(
-            r'>(?:Link|Download): <a[^>]+href="([^"]+)"', webpage, 'video URL')
+            r'<source src="(\S+)"', webpage, 'URL')
         title = self._html_search_regex(
-            r'<title>XboxClips \| ([^<]+)</title>', webpage, 'title')
-        upload_date = unified_strdate(self._html_search_regex(
-            r'>Recorded: ([^<]+)<', webpage, 'upload date', fatal=False))
-        filesize = parse_filesize(self._html_search_regex(
-            r'>Size: ([^<]+)<', webpage, 'file size', fatal=False))
-        duration = int_or_none(self._html_search_regex(
-            r'>Duration: (\d+) Seconds<', webpage, 'duration', fatal=False))
-        view_count = int_or_none(self._html_search_regex(
-            r'>Views: (\d+)<', webpage, 'view count', fatal=False))
-
+            r'<title>(.+?)</title>', webpage, 'title', fatal=False)
+        uploader = self._html_search_regex(
+            r'<h3>(.+?)</h3>', webpage, 'uploader', fatal=False)
         return {
             'id': video_id,
-            'url': video_url,
             'title': title,
-            'upload_date': upload_date,
-            'filesize_approx': filesize,
-            'duration': duration,
-            'view_count': view_count,
+            'uploader': uploader,
+            'url': video_url
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

The XboxClips extractor has been updated, because its domain has changed to GameClips.io. However, XboxClips links still work (they redirect to GameClips.io), so both sites are supported in this extractor.