### PR TITLE
[atresplayer] fix auth and extraction, preliminary support for subtitles

### DIFF
--- a/youtube_dl/extractor/atresplayer.py
+++ b/youtube_dl/extractor/atresplayer.py
@@ -9,6 +9,7 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     urlencode_postdata,
+    urljoin,
 )
 
 
@@ -58,7 +59,7 @@ class AtresPlayerIE(InfoExtractor):
             return
 
         self._request_webpage(
-            self._API_BASE + 'login', None, 'Downloading login page')
+            urljoin(self._API_BASE, 'login'), None, 'Downloading login page')
 
         try:
             target_url = self._download_json(
@@ -72,6 +73,7 @@ class AtresPlayerIE(InfoExtractor):
         except ExtractorError as e:
             self._handle_error(e, 400)
 
+        target_url = urljoin('https://account.atresmedia.com', target_url)
         self._request_webpage(target_url, None, 'Following Target URL')
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/atresplayer.py
+++ b/youtube_dl/extractor/atresplayer.py
@@ -6,10 +6,13 @@ import re
 from .common import InfoExtractor
 from ..compat import compat_HTTPError
 from ..utils import (
+    base_url,
     ExtractorError,
     int_or_none,
     urlencode_postdata,
     urljoin,
+    xpath_text,
+    xpath_with_ns,
 )
 
 
@@ -76,6 +79,27 @@ class AtresPlayerIE(InfoExtractor):
         target_url = urljoin('https://account.atresmedia.com', target_url)
         self._request_webpage(target_url, None, 'Following Target URL')
 
+    def _get_mpd_subtitles(self, mpd_xml, mpd_url):
+        subs = {}
+
+        def _add_ns(name):
+            return xpath_with_ns(name, {
+                'mpd': 'urn:mpeg:dash:schema:mpd:2011'
+            })
+
+        text_nodes = mpd_xml.findall(
+            _add_ns('./mpd:Period/mpd:AdaptationSet[@contentType="text"]'))
+        for node in text_nodes:
+            lang = node.attrib['lang']
+            url = xpath_text(
+                node, _add_ns('./mpd:Representation[@mimeType="text/vtt"]/mpd:BaseURL'))
+            if url:
+                subs.update({lang: [{
+                    'ext': 'vtt',
+                    'url': urljoin(mpd_url, url),
+                }]})
+        return subs
+
     def _real_extract(self, url):
         display_id, video_id = re.match(self._VALID_URL, url).groups()
 
@@ -98,6 +122,7 @@ class AtresPlayerIE(InfoExtractor):
         title = episode['titulo']
 
         formats = []
+        subtitles = {}
         for source in episode.get('sources', []):
             src = source.get('src')
             if not src:
@@ -108,8 +133,13 @@ class AtresPlayerIE(InfoExtractor):
                     src, video_id, 'mp4', 'm3u8_native',
                     m3u8_id='hls', fatal=False))
             elif src_type == 'application/dash+xml':
-                formats.extend(self._extract_mpd_formats(
-                    src, video_id, mpd_id='dash', fatal=False))
+                mpd_doc, mpd_handle = self._download_xml_handle(
+                    src, video_id, note='Downloading MPD manifest', fatal=False)
+                if mpd_doc is not None:
+                    mpd_base_url = base_url(mpd_handle.geturl())
+                    subtitles.update(self._get_mpd_subtitles(mpd_doc, mpd_base_url))
+                    formats.extend(self._parse_mpd_formats(
+                        mpd_doc, mpd_id='dash', mpd_base_url=mpd_base_url, mpd_url=src))
         self._sort_formats(formats)
 
         heartbeat = episode.get('heartbeat') or {}
@@ -127,4 +157,5 @@ class AtresPlayerIE(InfoExtractor):
             'channel': get_meta('channel'),
             'season': get_meta('season'),
             'episode_number': int_or_none(get_meta('episodeNumber')),
+            'subtitles': subtitles,
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR tries to address these concerns:
- Authentication started to fail when the target URL became relative. Fixes issue #24462. Improves on PR #24722 by using `urljoin` instead of string concatenation.
- Metadata extraction was broken. Videos could not be downloaded at all. Now, a piece of metadata is scraped from the video page, which allows to locate more metadata and the final URLs in a generic way. Therefore, hardcoded URL segments are avoided. Should work for both full episodes and clips. Fixes issues #24026, #24927 and #26120. Improves on PRs #24722 and #24990.
- Preliminary support for subtitles is added. This improvement was suggested on PR #24990. Subtitles are looked up whenever a MPD document is available. Parsing m3u8 playlists is way more complex and subtitles may span multiple files, so this is still not supported.

I closed PR #23669 myself as I didn't make any progress. Then, the DMCA takedown took me by surprise and I realized I forked from someone else's repo, not from this one, so I abandoned it.

If you want to provide any correction, suggestion or otherwise a helpful comment, it would be very appreciated.