### PR TITLE
Fix – write debug to stderr, not stdout

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1610,7 +1610,7 @@ class YoutubeDL(object):
         if req_format is None:
             req_format = self._default_format_spec(info_dict, download=download)
             if self.params.get('verbose'):
-                self.to_stdout('[debug] Default format spec: %s' % req_format)
+                self._write_string('[debug] Default format spec: %s' % req_format)
 
         format_selector = self.build_format_selector(req_format)
 


### PR DESCRIPTION
[Most](https://github.com/ytdl-org/youtube-dl/blob/20c50c65566be31607e59d7ca2467c664a29c843/youtube_dl/YoutubeDL.py#L2269) [other](https://github.com/ytdl-org/youtube-dl/blob/20c50c65566be31607e59d7ca2467c664a29c843/youtube_dl/YoutubeDL.py#L2280) [`[debug]`](https://github.com/ytdl-org/youtube-dl/blob/20c50c65566be31607e59d7ca2467c664a29c843/youtube_dl/YoutubeDL.py#L2313) [prints](https://github.com/ytdl-org/youtube-dl/blob/20c50c65566be31607e59d7ca2467c664a29c843/youtube_dl/YoutubeDL.py#L2293) [use](https://github.com/ytdl-org/youtube-dl/blob/20c50c65566be31607e59d7ca2467c664a29c843/youtube_dl/YoutubeDL.py#L2307) this function. This is just a quick fix regarding #14579, as this line gets printed most often, but does not solve the issue overall (just #22593 reveals one more bad usage)