### PR TITLE
Replace all os.remove & os.rename combos with single os.replace (Fix deletion of post-processed videos)

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -85,8 +85,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
             if not self._already_have_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))
-            os.remove(encodeFilename(filename))
-            os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+            os.replace(encodeFilename(temp_filename), encodeFilename(filename))
 
         elif info['ext'] in ['m4a', 'mp4']:
             if not check_executable('AtomicParsley', ['-v']):
@@ -118,8 +117,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             if b'No changes' in stdout:
                 self._downloader.report_warning('The file format doesn\'t support embedding a thumbnail')
             else:
-                os.remove(encodeFilename(filename))
-                os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+                os.replace(encodeFilename(temp_filename), encodeFilename(filename))
         else:
             raise EmbedThumbnailPPError('Only mp3 and m4a/mp4 are supported for thumbnail embedding for now.')
 

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -424,8 +424,7 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
         temp_filename = prepend_extension(filename, 'temp')
         self._downloader.to_screen('[ffmpeg] Embedding subtitles in \'%s\'' % filename)
         self.run_ffmpeg_multiple_files(input_files, temp_filename, opts)
-        os.remove(encodeFilename(filename))
-        os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        os.replace(encodeFilename(temp_filename), encodeFilename(filename))
 
         return sub_filenames, information
 
@@ -509,8 +508,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         self.run_ffmpeg_multiple_files(in_filenames, temp_filename, options)
         if chapters:
             os.remove(metadata_filename)
-        os.remove(encodeFilename(filename))
-        os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        os.replace(encodeFilename(temp_filename), encodeFilename(filename))
         return [], info
 
 
@@ -555,8 +553,7 @@ class FFmpegFixupStretchedPP(FFmpegPostProcessor):
         self._downloader.to_screen('[ffmpeg] Fixing aspect ratio in "%s"' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
 
-        os.remove(encodeFilename(filename))
-        os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        os.replace(encodeFilename(temp_filename), encodeFilename(filename))
 
         return [], info
 
@@ -573,8 +570,7 @@ class FFmpegFixupM4aPP(FFmpegPostProcessor):
         self._downloader.to_screen('[ffmpeg] Correcting container in "%s"' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
 
-        os.remove(encodeFilename(filename))
-        os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        os.replace(encodeFilename(temp_filename), encodeFilename(filename))
 
         return [], info
 
@@ -589,8 +585,7 @@ class FFmpegFixupM3u8PP(FFmpegPostProcessor):
             self._downloader.to_screen('[ffmpeg] Fixing malformed AAC bitstream in "%s"' % filename)
             self.run_ffmpeg(filename, temp_filename, options)
 
-            os.remove(encodeFilename(filename))
-            os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+            os.replace(encodeFilename(temp_filename), encodeFilename(filename))
         return [], info
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request replaces the pattern of os.remove(original filename) then os.rename(temp filename, original filename) to single atomic os.replace(temp_filename, original filename).

The problem I was having was that certain files would download and I'd see a "[ffmpeg] Fixing malformed AAC bitstream in " message. In my file explorer (Dolphin) I could see the thumbnail of the original file appear and disappear at this operation. Youtube-dl would be done processing, but the end result was the downloaded file kept getting deleted!

After digging around, I found that the combo of os.remove followed by os.rename deleted both the original file, as well as the renamed file! This may be particular to my OS/filesystem (Arch Linux, downloading to a ZFS cifs/samba share). This PR fixes the problem and now my downloads now don't disappear. 

I don't fully understand the reason for the bug (atomic operations, race conditions...) but I found a similar bug here https://github.com/zarr-developers/zarr-python/issues/263

> Possible solutions:
> - Execute os.remove(file_path) on Windows only.
> - Use os.replace() instead of os.rename. This breaks Python 2.7 compatibility, though.