### PR TITLE
Be more lenient with jwplayer regex: Allow Brackets '(' and ')' in config

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -2699,7 +2699,7 @@ class InfoExtractor(object):
 
     def _find_jwplayer_data(self, webpage, video_id=None, transform_source=js_to_json):
         mobj = re.search(
-            r'(?s)jwplayer\((?P<quote>[\'"])[^\'" ]+(?P=quote)\)(?!</script>).*?\.setup\s*\((?P<options>[^)]+)\)',
+            r'(?s)jwplayer\((?P<quote>[\'"])[^\'" ]+(?P=quote)\)(?!</script>).*?\.setup\s*\(\s*(?P<options>{.*?})\s*\)',
             webpage)
         if mobj:
             try:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This website contains a jwplayer video: https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3

The generic extractor gives this info though:
```
 youtube-dl -vF https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-vF', 'https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3']
[debug] Encodings: locale cp1252, fs utf-8, out utf-8, pref cp1252
[debug] youtube-dl version 2020.11.29
[debug] Python version 3.9.0 (CPython) - Windows-10-10.0.18362-SP0
[debug] exe versions: ffmpeg n4.3.1-20-g8a2acdc6da, ffprobe n4.3.1-20-g8a2acdc6da
[debug] Proxy map: {}
[generic] 73f80093-d3d4-489a-9e2f-2b0bf6a3cae3: Requesting header
WARNING: Falling back on generic information extractor.
[generic] 73f80093-d3d4-489a-9e2f-2b0bf6a3cae3: Downloading webpage
[generic] 73f80093-d3d4-489a-9e2f-2b0bf6a3cae3: Extracting information
ERROR: Unsupported URL: https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3
Traceback (most recent call last):
  File "c:\program files\python39\lib\site-packages\youtube_dl\YoutubeDL.py", line 803, in wrapper
    return func(self, *args, **kwargs)
  File "c:\program files\python39\lib\site-packages\youtube_dl\YoutubeDL.py", line 824, in __extract_info
    ie_result = ie.extract(url)
  File "c:\program files\python39\lib\site-packages\youtube_dl\extractor\common.py", line 532, in extract
    ie_result = self._real_extract(url)
  File "c:\program files\python39\lib\site-packages\youtube_dl\extractor\generic.py", line 3381, in _real_extract
    raise UnsupportedError(url)
youtube_dl.utils.UnsupportedError: Unsupported URL: https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3
```

This is caused by a peculiar config (from the source):
```
                           logo: {
                                file: '/images/watermark-hhu-2.png',
                                link: encodeURI('https://mediathek.hhu.de/watch/73f80093-d3d4-489a-9e2f-2b0bf6a3cae3/'),
                                position: 'top-right',
                                hide: true,
                                margin: 10
                            },
```
As you can see there is call of the JS function [`encodeURI(...)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
This did not work before, as the RegEx excluded round brackets. I added that capability.

Old regex: https://regexr.com/5hdfq
My new regex: https://regexr.com/5hdgi
It will match everything until the first curly brace '}' that is followed by a ')' (with some optional whitespaces in between).