### PR TITLE
add getformats options,return all formats and callback return

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -276,6 +276,7 @@ class YoutubeDL(object):
                        Actual sleep time will be a random float from range
                        [sleep_interval; max_sleep_interval].
     listformats:       Print an overview of available video formats and exit.
+    getformats:        Get all available video formats and exit.
     list_thumbnails:   Print a table of all thumbnails and exit.
     match_filter:      A function that gets called with the info_dict of
                        every video.
@@ -1645,13 +1646,25 @@ class YoutubeDL(object):
             raise ExtractorError('requested format not available',
                                  expected=True)
 
-        if download:
+        get_func = self.params.get('getformats')
+
+        if download or get_func:
+            new_info_list = []
             if len(formats_to_download) > 1:
                 self.to_screen('[info] %s: downloading video in %s formats' % (info_dict['id'], len(formats_to_download)))
             for format in formats_to_download:
                 new_info = dict(info_dict)
                 new_info.update(format)
-                self.process_info(new_info)
+                new_info_list.append(new_info)
+
+            # get format function return all formats info
+            if get_func:
+                get_func(new_info_list)
+                return info_dict
+
+            if download:
+                for new_info in new_info_list:                
+                    self.process_info(new_info)                                
         # We update the info dict with the best quality format (backwards compatibility)
         info_dict.update(formats_to_download[-1])
         return info_dict

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2358,7 +2358,9 @@ class YoutubeDL(object):
             else:
                 proxies = {'http': opts_proxy, 'https': opts_proxy}
         else:
-            proxies = compat_urllib_request.getproxies()
+            # this `getproxies` call will core in Mac,so ignore it,use empty proxy instead.
+            #proxies = compat_urllib_request.getproxies()
+            proxies = {}
             # Set HTTPS proxy to HTTP one if given (https://github.com/ytdl-org/youtube-dl/issues/805)
             if 'http' in proxies and 'https' not in proxies:
                 proxies['https'] = proxies['http']

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -339,6 +339,7 @@ def _real_main(argv=None):
         'skip_download': opts.skip_download,
         'format': opts.format,
         'listformats': opts.listformats,
+        'getformats': opts.getformats,
         'outtmpl': outtmpl,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -407,6 +407,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='listformats',
         help='List all available formats of requested videos')
     video_format.add_option(
+        '-G', '--get-formats',
+        action='store_true', dest='getformats',
+        help='Get all available formats of requested videos')        
+    video_format.add_option(
         '--youtube-include-dash-manifest',
         action='store_true', dest='youtube_include_dash_manifest', default=True,
         help=optparse.SUPPRESS_HELP)


### PR DESCRIPTION
add 'getformats' option, other python app which use ydl as a module can use this option get all video formats info, the "listformats" option can only print formats basic info,not inculding the download url.