### PR TITLE
expose release_year for tubi

### DIFF
--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -33,6 +33,16 @@ class TubiTvIE(InfoExtractor):
     }, {
         'url': 'http://tubitv.com/movies/383676/tracker',
         'only_matching': True,
+    }, {
+        'url': 'https://tubitv.com/movies/562717/benji',
+        'info_dict': {
+            'id': '562717',
+            'ext': 'mp4',
+            'title': 'Benji',
+            'description': 'America’s beloved pooch stars in this remastered version of the 1974 hit about a sweet and emotionally smart dog who tries to save two kidnapped kids.',
+            'uploader_id': '300ac2a9d39325a0cf8d7c27f8d01056',
+            'release_year': 1974,
+        },
     }]
 
     def _login(self):
@@ -93,5 +103,5 @@ class TubiTvIE(InfoExtractor):
             'description': video_data.get('description'),
             'duration': int_or_none(video_data.get('duration')),
             'uploader_id': video_data.get('publisher_id'),
-            'release_year': video_data.get('year'),
+            'release_year': int_or_none(video_data.get('year', 0)),
         }

--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -93,4 +93,5 @@ class TubiTvIE(InfoExtractor):
             'description': video_data.get('description'),
             'duration': int_or_none(video_data.get('duration')),
             'uploader_id': video_data.get('publisher_id'),
+            'release_year': video_data.get('year'),
         }

--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -34,14 +34,17 @@ class TubiTvIE(InfoExtractor):
         'url': 'http://tubitv.com/movies/383676/tracker',
         'only_matching': True,
     }, {
-        'url': 'https://tubitv.com/movies/562717/benji',
+        'url': 'https://tubitv.com/movies/560057/penitentiary?start=true',
         'info_dict': {
-            'id': '562717',
+            'id': '560057',
             'ext': 'mp4',
-            'title': 'Benji',
-            'description': 'America’s beloved pooch stars in this remastered version of the 1974 hit about a sweet and emotionally smart dog who tries to save two kidnapped kids.',
-            'uploader_id': '300ac2a9d39325a0cf8d7c27f8d01056',
-            'release_year': 1974,
+            'title': 'Penitentiary',
+            'description': 'md5:8d2fc793a93cc1575ff426fdcb8dd3f9',
+            'uploader_id': 'd8fed30d4f24fcb22ec294421b9defc2',
+            'release_year': 1979,
+        },
+        'params': {
+            'skip_download': True,
         },
     }]
 
@@ -103,5 +106,5 @@ class TubiTvIE(InfoExtractor):
             'description': video_data.get('description'),
             'duration': int_or_none(video_data.get('duration')),
             'uploader_id': video_data.get('publisher_id'),
-            'release_year': int_or_none(video_data.get('year', 0)),
+            'release_year': int_or_none(video_data.get('year')),
         }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Puts the release_year into the extractor data for tubi.
