### PR TITLE
Added the ability to extract the cast list for PonHub videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ The basic usage is not to set any template arguments when downloading a single f
  - `playlist_title` (string): Playlist title
  - `playlist_uploader` (string): Full name of the playlist uploader
  - `playlist_uploader_id` (string): Nickname or id of the playlist uploader
+ - `cast` (string): Comma separated list of the video cast, sorted by alphabetical order. Only implemented for Pornhub.
 
 Available for the video that belongs to some logical chapter or section:
 

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -163,6 +163,16 @@ class PornHubIE(PornHubBaseIE):
     }, {
         'url': 'https://www.pornhubpremium.com/view_video.php?viewkey=ph5e4acdae54a82',
         'only_matching': True,
+    }, {
+        'url': 'http://www.pornhub.com/view_video.php?viewkey=648719015',
+        'info_dict': {
+            'cast': "Sunny Leone"
+        }
+    }, {
+        'url': 'https://www.pornhub.com/view_video.php?viewkey=ph5751a6de30963',
+        'info_dict': {
+            'cast': "Crissy Moon, Gigi Rivera, Lizz Tayler, Marco Banderas"
+        }
     }]
 
     @staticmethod
@@ -170,6 +180,10 @@ class PornHubIE(PornHubBaseIE):
         return re.findall(
             r'<iframe[^>]+?src=["\'](?P<url>(?:https?:)?//(?:www\.)?pornhub\.(?:com|net|org)/embed/[\da-z]+)',
             webpage)
+
+    def _extract_cast(self, webpage):
+        # Extract by finding data-mxptext values
+        return ", ".join(sorted(re.findall(r"data-mxptext=\"(.+)\"", webpage)))
 
     def _extract_count(self, pattern, webpage, name):
         return str_to_int(self._search_regex(
@@ -387,6 +401,7 @@ class PornHubIE(PornHubBaseIE):
             'tags': extract_list('tags'),
             'categories': extract_list('categories'),
             'subtitles': subtitles,
+            'cast': self._extract_cast(webpage),
         }, info)
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This pull requests add the feature to extract a list of the pornstars in a PornHub video. 

Names are in a comma separated list, e.g `"Asa Akira, Mia Malkova"`, in alphabetical order, for consistency.

To maintain future compatibility for other, SFW websites, it is listed under `cast`.
This also makes it available in the output filename format by using `%(cast)s`. 

For example, running 

```youtube-dl -j -o "%(uploader)s - %(cast)s - %(title)s.%(ext)s" https://www.pornhub.com/view_video.php\?viewkey\=ph5cf53b0f86e13  | jq '{cast, _filename}'```

will output  

```
{
  "cast": "Mia Malkova",
  "_filename": "RyanCreamer - Mia Malkova - I Cloud Gaze With Mia Malkova.mp4"
}
```

This feature is important for PornHub, as the `uploader` or `channel` field rarely contain all the names of the people in the video.

From a quick search, I could find one issue requesting this: #25317.