### PR TITLE
[pornhub] extract all formats

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -281,7 +281,7 @@ class PornHubIE(PornHubBaseIE):
 
         def add_video_url(video_url):
             v_url = url_or_none(video_url)
-            if not v_url or not isinstance(v_url, compat_str):
+            if not v_url:
                 return
             if v_url in video_urls_set:
                 return
@@ -289,7 +289,7 @@ class PornHubIE(PornHubBaseIE):
             video_urls_set.add(v_url)
 
         def parse_quality_items(js_str):
-            media_definitions = self._parse_json(js_str, None)
+            media_definitions = self._parse_json(js_str, video_id)
             if isinstance(media_definitions, list):
                 for definition in media_definitions:
                     if not isinstance(definition, dict):
@@ -304,7 +304,7 @@ class PornHubIE(PornHubBaseIE):
                 default=None)
             if js_vars:
                 for key, format_url in js_vars.items():
-                    if key.startswith("qualityItems"):
+                    if key.startswith('qualityItems'):
                         parse_quality_items(format_url)
                     if any(key.startswith(p) for p in FORMAT_PREFIXES):
                         add_video_url(format_url)

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -289,7 +289,9 @@ class PornHubIE(PornHubBaseIE):
             video_urls_set.add(v_url)
 
         def parse_quality_items(js_str):
-            media_definitions = self._parse_json(js_str, video_id)
+            if (url_or_none(js_str)):
+                return js_str
+            media_definitions = self._parse_json(js_str, video_id, fatal=False)
             if isinstance(media_definitions, list):
                 for definition in media_definitions:
                     if not isinstance(definition, dict):
@@ -303,10 +305,8 @@ class PornHubIE(PornHubBaseIE):
                 default=None)
             if js_vars:
                 for key, format_url in js_vars.items():
-                    if key.startswith('qualityItems'):
-                        parse_quality_items(format_url)
                     if any(key.startswith(p) for p in FORMAT_PREFIXES):
-                        add_video_url(format_url)
+                        add_video_url(parse_quality_items(format_url))
             if not video_urls and re.search(
                     r'<[^>]+\bid=["\']lockedPlayer', webpage):
                 raise ExtractorError(

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -297,16 +297,17 @@ class PornHubIE(PornHubBaseIE):
                     add_video_url(definition.get('url'))
 
         if not video_urls:
-            FORMAT_PREFIXES = ('media', 'quality')
+            FORMAT_PREFIXES = ('media', 'quality', 'qualityItems')
             js_vars = extract_js_vars(
                 webpage, r'(var\s+(?:%s)_.+)' % '|'.join(FORMAT_PREFIXES),
                 default=None)
             if js_vars:
                 for key, format_url in js_vars.items():
-                    if key.startswith('qualityItems'):
-                        parse_quality_items(format_url)
                     if any(key.startswith(p) for p in FORMAT_PREFIXES):
-                        add_video_url(format_url)
+                        if key.startswith('qualityItems'):
+                            parse_quality_items(format_url)
+                        else:
+                            add_video_url(format_url)
             if not video_urls and re.search(
                     r'<[^>]+\bid=["\']lockedPlayer', webpage):
                 raise ExtractorError(

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -294,8 +294,7 @@ class PornHubIE(PornHubBaseIE):
                 for definition in media_definitions:
                     if not isinstance(definition, dict):
                         continue
-                    video_url = definition.get('url')
-                    add_video_url(video_url)
+                    add_video_url(definition.get('url'))
 
         if not video_urls:
             FORMAT_PREFIXES = ('media', 'quality')

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -303,11 +303,10 @@ class PornHubIE(PornHubBaseIE):
                 default=None)
             if js_vars:
                 for key, format_url in js_vars.items():
+                    if key.startswith('qualityItems'):
+                        parse_quality_items(format_url)
                     if any(key.startswith(p) for p in FORMAT_PREFIXES):
-                        if key.startswith('qualityItems'):
-                            parse_quality_items(format_url)
-                        else:
-                            add_video_url(format_url)
+                        add_video_url(format_url)
             if not video_urls and re.search(
                     r'<[^>]+\bid=["\']lockedPlayer', webpage):
                 raise ExtractorError(

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -281,12 +281,21 @@ class PornHubIE(PornHubBaseIE):
 
         def add_video_url(video_url):
             v_url = url_or_none(video_url)
-            if not v_url:
+            if not v_url or not isinstance(v_url, compat_str):
                 return
             if v_url in video_urls_set:
                 return
             video_urls.append((v_url, None))
             video_urls_set.add(v_url)
+
+        def parse_quality_items(js_str):
+            media_definitions = self._parse_json(js_str, None)
+            if isinstance(media_definitions, list):
+                for definition in media_definitions:
+                    if not isinstance(definition, dict):
+                        continue
+                    video_url = definition.get('url')
+                    add_video_url(video_url)
 
         if not video_urls:
             FORMAT_PREFIXES = ('media', 'quality')
@@ -295,6 +304,8 @@ class PornHubIE(PornHubBaseIE):
                 default=None)
             if js_vars:
                 for key, format_url in js_vars.items():
+                    if key.startswith("qualityItems"):
+                        parse_quality_items(format_url)
                     if any(key.startswith(p) for p in FORMAT_PREFIXES):
                         add_video_url(format_url)
             if not video_urls and re.search(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As indicated by #27386 some formats were neglected. This PR seeks to rectify this issue by extracting the urls from the json qualityItems which holds the missing 240p quality along with other alternative formats.

closes #27386
