### PR TITLE
[reddit] Add duration to extracted information for posts containing a v.redd.it video

### DIFF
--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -119,7 +119,7 @@ class RedditRIE(InfoExtractor):
 
         duration = None
         if data.get('media') and data['media'].get('reddit_video'):
-            duration = data['media']['reddit_video']['duration']
+            duration = data['media']['reddit_video'].get('duration')
 
         return {
             '_type': 'url_transparent',

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -7,8 +7,8 @@ from ..utils import (
     ExtractorError,
     int_or_none,
     float_or_none,
+    try_get,
     url_or_none,
-    try_get
 )
 
 
@@ -60,11 +60,12 @@ class RedditRIE(InfoExtractor):
             'timestamp': 1501941939,
             'upload_date': '20170805',
             'uploader': 'Antw87',
+            'duration': 12,
             'like_count': int,
             'dislike_count': int,
             'comment_count': int,
             'age_limit': 0,
-            'duration': 12
+
         },
         'params': {
             'format': 'bestvideo',
@@ -125,10 +126,12 @@ class RedditRIE(InfoExtractor):
             'thumbnail': url_or_none(data.get('thumbnail')),
             'timestamp': float_or_none(data.get('created_utc')),
             'uploader': data.get('author'),
+            'duration': int_or_none(try_get(
+                data,
+                (lambda x: x['media']['reddit_video']['duration'],
+                 lambda x: x['media']['secure_media']['duration']))),
             'like_count': int_or_none(data.get('ups')),
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),
             'age_limit': age_limit,
-            'duration': int_or_none(try_get(data,
-                                            lambda x: x['media']['reddit_video']['duration']))
         }

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -65,7 +65,6 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int,
             'comment_count': int,
             'age_limit': 0,
-
         },
         'params': {
             'format': 'bestvideo',

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -129,6 +129,6 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),
             'age_limit': age_limit,
-            'duration': int_or_none(try_get(data, 
-                lambda x: x['media']['reddit_video']['duration']))
+            'duration': int_or_none(try_get(data,
+                                            lambda x: x['media']['reddit_video']['duration']))
         }

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -132,5 +132,5 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),
             'age_limit': age_limit,
-            'duration': duration
+            'duration': int_or_none(duration)
         }

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -8,6 +8,7 @@ from ..utils import (
     int_or_none,
     float_or_none,
     url_or_none,
+    try_get
 )
 
 
@@ -117,10 +118,6 @@ class RedditRIE(InfoExtractor):
         else:
             age_limit = None
 
-        duration = None
-        if data.get('media') and data['media'].get('reddit_video'):
-            duration = data['media']['reddit_video'].get('duration')
-
         return {
             '_type': 'url_transparent',
             'url': video_url,
@@ -132,5 +129,6 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),
             'age_limit': age_limit,
-            'duration': int_or_none(duration)
+            'duration': int_or_none(try_get(data, 
+                lambda x: x['media']['reddit_video']['duration']))
         }

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -63,6 +63,7 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int,
             'comment_count': int,
             'age_limit': 0,
+            'duration': 12
         },
         'params': {
             'format': 'bestvideo',
@@ -116,6 +117,10 @@ class RedditRIE(InfoExtractor):
         else:
             age_limit = None
 
+        duration = None
+        if data.get('media') and data['media'].get('reddit_video'):
+            duration = data['media']['reddit_video']['duration']
+
         return {
             '_type': 'url_transparent',
             'url': video_url,
@@ -127,4 +132,5 @@ class RedditRIE(InfoExtractor):
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),
             'age_limit': age_limit,
+            'duration': duration
         }

--- a/youtube_dl/extractor/reddit.py
+++ b/youtube_dl/extractor/reddit.py
@@ -128,7 +128,7 @@ class RedditRIE(InfoExtractor):
             'duration': int_or_none(try_get(
                 data,
                 (lambda x: x['media']['reddit_video']['duration'],
-                 lambda x: x['media']['secure_media']['duration']))),
+                 lambda x: x['secure_media']['reddit_video']['duration']))),
             'like_count': int_or_none(data.get('ups')),
             'dislike_count': int_or_none(data.get('downs')),
             'comment_count': int_or_none(data.get('num_comments')),


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Previously, the Reddit extractor would not provide video duration for post videos served through v.redd.it, though this information is provided by the Reddit post API. This change includes the duration key of the API response in the video's extracted information when present. I also added duration to the existing test's info_dict for coverage.