### PR TITLE
[test] Rework test_download to allow running all tests of a single extractor

### DIFF
--- a/test/test_download.py
+++ b/test/test_download.py
@@ -61,10 +61,10 @@ def _file_md5(fn):
         return hashlib.md5(f.read()).hexdigest()
 
 
-defs = gettestcases()
+ie_testcases = gettestcases()
 
 
-class TestDownload(unittest.TestCase):
+class BaseDownloadTCase(unittest.TestCase):
     # Parallel testing in nosetests. See
     # http://nose.readthedocs.org/en/latest/doc_tests/test_multiprocess/multiprocess.html
     _multiprocess_shared_ = True
@@ -83,8 +83,9 @@ class TestDownload(unittest.TestCase):
                                strclass(self.__class__),
                                ' [%s]' % add_ie if add_ie else '')
 
-    def setUp(self):
-        self.defs = defs
+
+TestDownload = unittest.TestSuite()
+
 
 # Dynamically generate tests
 
@@ -246,20 +247,42 @@ def generator(test_case, tname):
     return test_template
 
 
+cache = {}
+
 # And add them to TestDownload
-for n, test_case in enumerate(defs):
-    tname = 'test_' + str(test_case['name'])
-    i = 1
-    while hasattr(TestDownload, tname):
-        tname = 'test_%s_%d' % (test_case['name'], i)
+for test_case in ie_testcases:
+    # Get or create a sub-test for the extractor file
+    module_name = test_case.get('module_name', 'unknown').rsplit('.', 1)[-1]  # type: str
+    extractor_file_name = str('test_%s' % module_name)
+    extractor_file_suite = getattr(TestDownload, extractor_file_name, None)
+    if extractor_file_suite is None:
+        extractor_file_suite = type(extractor_file_name, (unittest.TestSuite,), {})()
+        setattr(TestDownload, extractor_file_name, extractor_file_suite)
+        TestDownload.addTest(extractor_file_suite)
+
+    # Get or create a sub-test for the info extractor
+    # This class contains the actual tests
+    extractor_class_name = str('test_%s' % test_case['name'])
+    ExtractorClass = getattr(extractor_file_suite, extractor_class_name, None)
+    if ExtractorClass is None:
+        ExtractorClass = type(extractor_class_name, (BaseDownloadTCase,), {})
+        setattr(extractor_file_suite, extractor_class_name, ExtractorClass)
+
+    i = 0
+    tname = 'test_%d' % i
+    while hasattr(ExtractorClass, tname):
+        tname = 'test_%d' % i
         i += 1
     test_method = generator(test_case, tname)
     test_method.__name__ = str(tname)
     ie_list = test_case.get('add_ie')
     test_method.add_ie = ie_list and ','.join(ie_list)
-    setattr(TestDownload, test_method.__name__, test_method)
-    del test_method
+
+    setattr(ExtractorClass, test_method.__name__, test_method)
+    extractor_file_suite.addTest(ExtractorClass(test_method.__name__))
+
+    del test_method, test_case
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(argv=['TestDownload'])

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -2940,6 +2940,7 @@ class InfoExtractor(object):
             if not include_onlymatching and t.get('only_matching', False):
                 continue
             t['name'] = type(self).__name__[:-len('IE')]
+            t['module_name'] = type(self).__module__
             yield t
 
     def is_suitable(self, age_limit):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The goal is being able to run info extractor tests for only a single provider or extractor.
This makes the test usable when maintaining individual providers.

`python -m unittest test.test_download.TestDownload.test_nrk` runs extractor tests for the contents of `extractor/nrk.py`.
`python -m unittest test.test_download.TestDownload.test_nrk.test_NRKTVEpisode` runs extractor tests for `NRKTVEpisodeIE`.


TODO:
 - [ ] Fix running all extractor tests with `python test/test_download.py`
 - [ ] Update documentation

---

This PR is currently marked as draft because it seems I may have broken running the test with `python test/test_download.py`
As only a single (erroring) test gets ran then.

Reviews are still welcome, both from maintainers and others with knowledge of python's testing features.