### PR TITLE
Add --get-uploader option

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --get-id                         Simulate, quiet but print id
     --get-thumbnail                  Simulate, quiet but print thumbnail URL
     --get-description                Simulate, quiet but print video description
+    --get-uploader                   Simulate, quiet but print video uploader
     --get-duration                   Simulate, quiet but print video length
     --get-filename                   Simulate, quiet but print output filename
     --get-format                     Simulate, quiet but print output format

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -155,6 +155,7 @@ class YoutubeDL(object):
     forceid:           Force printing ID.
     forcethumbnail:    Force printing thumbnail URL.
     forcedescription:  Force printing description.
+    forceuploader:     Force printing uploader.
     forcefilename:     Force printing final filename.
     forceduration:     Force printing duration.
     forcejson:         Force printing info_dict as JSON.
@@ -1717,6 +1718,7 @@ class YoutubeDL(object):
                 self.to_stdout(info_dict[field])
 
         print_mandatory('title')
+        print_mandatory('uploader')
         print_mandatory('id')
         if self.params.get('forceurl', False) and not incomplete:
             if info_dict.get('requested_formats') is not None:

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1718,7 +1718,6 @@ class YoutubeDL(object):
                 self.to_stdout(info_dict[field])
 
         print_mandatory('title')
-        print_mandatory('uploader')
         print_mandatory('id')
         if self.params.get('forceurl', False) and not incomplete:
             if info_dict.get('requested_formats') is not None:
@@ -1727,6 +1726,7 @@ class YoutubeDL(object):
             else:
                 # For RTMP URLs, also include the playpath
                 self.to_stdout(info_dict['url'] + info_dict.get('play_path', ''))
+        print_optional('uploader')
         print_optional('thumbnail')
         print_optional('description')
         if self.params.get('forcefilename', False) and filename is not None:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -243,7 +243,7 @@ def _real_main(argv=None):
                      ' file! Use "{0}.%(ext)s" instead of "{0}" as the output'
                      ' template'.format(outtmpl))
 
-    any_getting = opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat or opts.getduration or opts.dumpjson or opts.dump_single_json
+    any_getting = opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getuploader or opts.getfilename or opts.getformat or opts.getduration or opts.dumpjson or opts.dump_single_json
     any_printing = opts.print_json
     download_archive_fn = expand_path(opts.download_archive) if opts.download_archive is not None else opts.download_archive
 
@@ -330,6 +330,7 @@ def _real_main(argv=None):
         'forceid': opts.getid,
         'forcethumbnail': opts.getthumbnail,
         'forcedescription': opts.getdescription,
+        'forceuploader': opts.getuploader,
         'forceduration': opts.getduration,
         'forcefilename': opts.getfilename,
         'forceformat': opts.getformat,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -611,6 +611,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='getdescription', default=False,
         help='Simulate, quiet but print video description')
     verbosity.add_option(
+        '--get-uploader',
+        action='store_true', dest='getuploader', default=False,
+        help='Simulate, quiet but print video uploader')
+    verbosity.add_option(
         '--get-duration',
         action='store_true', dest='getduration', default=False,
         help='Simulate, quiet but print video length')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

This pull request adds a ```--get-uploader``` option, which works the same way as ```--get-title```, ```--get-id```, etc. Honestly I'm surprised that this option didn't already exist so please let me know if I missed something here.
Some examples:
```
$ python -m youtube_dl --get-uploader https://www.youtube.com/watch?v=ktcvWkEVBE0
Wolfgang's Channel
$ python -m youtube_dl --get-uploader https://clips.twitch.tv/EncouragingSmokyMonitorAsianGlow
Raapi
$ python -m youtube_dl --get-uploader https://lbry.tv/@BrodieRobertson:5/arch-linux-will-forever-be-better-after:1
$ # lbry doesn't have an 'uploader' field, so nothing is printed
```