### PR TITLE
Adding option for hooks after postprocessors to YoutubeDL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ offlinetest: codetest
 		--exclude test_subtitles.py \
 		--exclude test_write_annotations.py \
 		--exclude test_youtube_lists.py \
-		--exclude test_youtube_signature.py
+		--exclude test_youtube_signature.py \
+		--exclude test_post_hooks.py
 
 tar: youtube-dl.tar.gz
 

--- a/devscripts/run_tests.bat
+++ b/devscripts/run_tests.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem Keep this list in sync with the `offlinetest` target in Makefile
-set DOWNLOAD_TESTS="age_restriction^|download^|iqiyi_sdk_interpreter^|socks^|subtitles^|write_annotations^|youtube_lists^|youtube_signature"
+set DOWNLOAD_TESTS="age_restriction^|download^|iqiyi_sdk_interpreter^|socks^|subtitles^|write_annotations^|youtube_lists^|youtube_signature^|post_hooks"
 
 if "%YTDL_TEST_SET%" == "core" (
     set test_set="-I test_("%DOWNLOAD_TESTS%")\.py"

--- a/devscripts/run_tests.sh
+++ b/devscripts/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Keep this list in sync with the `offlinetest` target in Makefile
-DOWNLOAD_TESTS="age_restriction|download|iqiyi_sdk_interpreter|socks|subtitles|write_annotations|youtube_lists|youtube_signature"
+DOWNLOAD_TESTS="age_restriction|download|iqiyi_sdk_interpreter|socks|subtitles|write_annotations|youtube_lists|youtube_signature|post_hooks"
 
 test_set=""
 multiprocess_args=""

--- a/test/test_post_hooks.py
+++ b/test/test_post_hooks.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+from __future__ import unicode_literals
+
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from test.helper import get_params, try_rm
+import youtube_dl.YoutubeDL
+from youtube_dl.utils import DownloadError
+
+class YoutubeDL(youtube_dl.YoutubeDL):
+    def __init__(self, *args, **kwargs):
+        super(YoutubeDL, self).__init__(*args, **kwargs)
+        self.to_stderr = self.to_screen
+
+TEST_ID = 'gr51aVj-mLg'
+EXPECTED_NAME = 'gr51aVj-mLg'
+
+class TestPostHooks(unittest.TestCase):
+    def setUp(self):
+        self.stored_name_1 = None
+        self.stored_name_2 = None
+        self.params = get_params({
+            'skip_download': False,
+            'writeinfojson': False,
+            'quiet': True,
+            'verbose': False,
+            'cachedir': False,
+        })
+        self.files = []
+
+    def test_post_hooks(self):
+        self.params['post_hooks'] = [self.hook_one, self.hook_two]
+        ydl = YoutubeDL(self.params)
+        ydl.download([TEST_ID])
+        self.assertEqual(self.stored_name_1, EXPECTED_NAME, 'Not the expected name from hook 1')
+        self.assertEqual(self.stored_name_2, EXPECTED_NAME, 'Not the expected name from hook 2')
+
+    def test_post_hook_exception(self):
+        self.params['post_hooks'] = [self.hook_three]
+        ydl = YoutubeDL(self.params)
+        self.assertRaises(DownloadError, ydl.download, [TEST_ID])
+
+    def hook_one(self,filename):
+        self.stored_name_1, _ = os.path.splitext(os.path.basename(filename))
+        self.files.append(filename)
+
+    def hook_two(self,filename):
+        self.stored_name_2, _ = os.path.splitext(os.path.basename(filename))
+        self.files.append(filename)
+
+    def hook_three(self,filename):
+        self.files.append(filename)
+        raise Exception('Test exception for \'%s\'' % filename)
+
+    def tearDown(self):
+        for f in self.files:
+            try_rm(f)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_post_hooks.py
+++ b/test/test_post_hooks.py
@@ -11,13 +11,16 @@ from test.helper import get_params, try_rm
 import youtube_dl.YoutubeDL
 from youtube_dl.utils import DownloadError
 
+
 class YoutubeDL(youtube_dl.YoutubeDL):
     def __init__(self, *args, **kwargs):
         super(YoutubeDL, self).__init__(*args, **kwargs)
         self.to_stderr = self.to_screen
 
+
 TEST_ID = 'gr51aVj-mLg'
 EXPECTED_NAME = 'gr51aVj-mLg'
+
 
 class TestPostHooks(unittest.TestCase):
     def setUp(self):
@@ -44,21 +47,22 @@ class TestPostHooks(unittest.TestCase):
         ydl = YoutubeDL(self.params)
         self.assertRaises(DownloadError, ydl.download, [TEST_ID])
 
-    def hook_one(self,filename):
+    def hook_one(self, filename):
         self.stored_name_1, _ = os.path.splitext(os.path.basename(filename))
         self.files.append(filename)
 
-    def hook_two(self,filename):
+    def hook_two(self, filename):
         self.stored_name_2, _ = os.path.splitext(os.path.basename(filename))
         self.files.append(filename)
 
-    def hook_three(self,filename):
+    def hook_three(self, filename):
         self.files.append(filename)
         raise Exception('Test exception for \'%s\'' % filename)
 
     def tearDown(self):
         for f in self.files:
             try_rm(f)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -231,6 +231,9 @@ class YoutubeDL(object):
                                youtube_dl/postprocessor/__init__.py for a list.
                        as well as any further keyword arguments for the
                        postprocessor.
+    post_hooks:        A list of functions that get called as the final step
+                       for each video file, after all postprocessors have been
+                       called. The filename will be passed as the only argument.
     progress_hooks:    A list of functions that get called on download
                        progress, with a dictionary with the entries
                        * status: One of "downloading", "error", or "finished".
@@ -347,6 +350,7 @@ class YoutubeDL(object):
         self._ies = []
         self._ies_instances = {}
         self._pps = []
+        self._post_hooks = []
         self._progress_hooks = []
         self._download_retcode = 0
         self._num_downloads = 0
@@ -429,6 +433,9 @@ class YoutubeDL(object):
             pp = pp_class(self, **compat_kwargs(pp_def))
             self.add_post_processor(pp)
 
+        for ph in self.params.get('post_hooks', []):
+            self.add_post_hook(ph)
+
         for ph in self.params.get('progress_hooks', []):
             self.add_progress_hook(ph)
 
@@ -480,6 +487,10 @@ class YoutubeDL(object):
         """Add a PostProcessor object to the end of the chain."""
         self._pps.append(pp)
         pp.set_downloader(self)
+
+    def add_post_hook(self, ph):
+        """Add the post hook"""
+        self._post_hooks.append(ph)
 
     def add_progress_hook(self, ph):
         """Add the progress hook (currently only for the file downloader)"""
@@ -2010,6 +2021,12 @@ class YoutubeDL(object):
                     self.post_process(filename, info_dict)
                 except (PostProcessingError) as err:
                     self.report_error('postprocessing: %s' % str(err))
+                    return
+                try:
+                    for ph in self._post_hooks:
+                        ph(filename)
+                except Exception as err:
+                    self.report_error('post hooks: %s' % str(err))
                     return
                 self.record_download_archive(info_dict)
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This pull request adds an option called `post_hooks` to [`youtube_dl/YoutubeDL.py`](https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/YoutubeDL.py#L137-L312). The option takes a list of callable functions. The functions will be called as almost the last step in the download process, after all postprocessors are done. They have to accept the filename as an argument.
Additionally, a test for the post hooks functionality is added in this pull requests. As the test contains downloads, it is added to the respective lists in the `Makefile` and the `run_tests` scripts.