### PR TITLE
fix view_count, ytsearch section

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -3436,8 +3436,8 @@ class YoutubeSearchIE(SearchInfoExtractor, YoutubeBaseInfoExtractor):
                 description = try_get(video, lambda x: x['descriptionSnippet']['runs'][0]['text'], compat_str)
                 duration = parse_duration(try_get(video, lambda x: x['lengthText']['simpleText'], compat_str))
                 view_count_text = try_get(video, lambda x: x['viewCountText']['simpleText'], compat_str) or ''
-                view_count = int_or_none(self._search_regex(
-                    r'^(\d+)', re.sub(r'\s', '', view_count_text),
+                view_count = str_to_int(self._search_regex(
+                    r'^([\d,]+)', re.sub(r'\s', '', view_count_text),
                     'view count', default=None))
                 uploader = try_get(video, lambda x: x['ownerText']['runs'][0]['text'], compat_str)
                 total += 1


### PR DESCRIPTION
Just like in issue #27051, and [this commit](https://github.com/ytdl-org/youtube-dl/commit/284f8306dffb3dbeeca3f99ef4c32ed4fcd571c3).

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:

The changes are minimal, I just copied a small fix from current youtube-dl to a different section.

If any sort of licensing is required for that:
- [X] I am the author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [X] Bug fix

---

### Description of your *pull request* and other information

When using e.g. 

    youtube-dl --flat-playlist --dump-json "ytsearch10:some random search"

the view_count is messed up (usually 1/1000th of what it really is), just like described in  #27051.
The fix is the same as in [this commit](https://github.com/ytdl-org/youtube-dl/commit/284f8306dffb3dbeeca3f99ef4c32ed4fcd571c3), starting on line 3439 of the same file (youtube_dl/extractor/youtube.py).