### PR TITLE
[vvvvid] fix season title extraction (#27601)

### DIFF
--- a/youtube_dl/extractor/vvvvid.py
+++ b/youtube_dl/extractor/vvvvid.py
@@ -26,6 +26,7 @@ class VVVVIDIE(InfoExtractor):
             'duration': 239,
             'series': '"Perché dovrei guardarlo?" di Dario Moccia',
             'season_id': '437',
+            'season': 'VIDEO',
             'episode': 'Ping Pong',
             'episode_number': 1,
             'episode_id': '3334',
@@ -105,6 +106,19 @@ class VVVVIDIE(InfoExtractor):
             lambda episode: episode.get('video_id') == vid, response))[0]
         title = video_data['title']
         formats = []
+
+        # get season title
+        seasons = self._download_info(
+            show_id, 'seasons/', video_id, fatal=False)
+        season_title = None
+        for season in (seasons or []):
+            for episode in (season.get('episodes') or []):
+                if episode.get('video_id') == vid:
+                    season_title = str_or_none(season.get('name'))
+                    break
+            else:
+                continue
+            break
 
         # vvvvid embed_info decryption algorithm is reverse engineered from function $ds(h) at vvvvid.js
         def ds(h):
@@ -215,6 +229,7 @@ class VVVVIDIE(InfoExtractor):
             'duration': int_or_none(video_data.get('length')),
             'series': video_data.get('show_title'),
             'season_id': season_id,
+            'season': season_title,
             'episode': title,
             'view_count': int_or_none(video_data.get('views')),
             'like_count': int_or_none(video_data.get('video_likes')),

--- a/youtube_dl/extractor/vvvvid.py
+++ b/youtube_dl/extractor/vvvvid.py
@@ -57,6 +57,7 @@ class VVVVIDIE(InfoExtractor):
             'id': 'RzmFKUDOUgw',
             'ext': 'mp4',
             'title': 'Trailer',
+            'season': 'EXTRA',
             'upload_date': '20150906',
             'description': 'md5:a5e802558d35247fee285875328c0b80',
             'uploader_id': 'BandaiVisual',


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement

---

### Description of your *pull request* and other information
fixes #27601

the only place where to find the season "title" is to call the same url used in the playlist extractor and scroll the file looking for the season that the current video beloongs end save the season "title" that way.

It's probably not super efficient or elegant



Or I can extract it in the playlist extractor and use url_transparent to pass it, it's a lot easier and cleaner:

```
'_type': 'url_transparent',
'ie_key': VVVVIDIE.ie_key(),
...
'season': str_or_none(season.get('name'))
```

but if you download the single episode you don't have the 'season title' info available.
