### PR TITLE
[nrk] add support for podcast episodes (closes #27634)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -787,6 +787,7 @@ from .npr import NprIE
 from .nrk import (
     NRKIE,
     NRKPlaylistIE,
+    NRKPodcastEpisodeIE,
     NRKSkoleIE,
     NRKTVIE,
     NRKTVDirekteIE,

--- a/youtube_dl/extractor/nrk.py
+++ b/youtube_dl/extractor/nrk.py
@@ -21,7 +21,6 @@ from ..utils import (
     try_get,
     urljoin,
     url_or_none,
-    urljoin,
 )
 
 
@@ -895,7 +894,7 @@ class NRKPodcastEpisodeIE(InfoExtractor):
             if episode_data['episodeId'] == video_id:
                 metadata_url = episode_data['_links']['playback']['href']
                 break
-        if metadata_url == None:
+        if metadata_url is None:
             metadata_url = player['series']['episode']['_links']['playback']['href']
 
         metadata = self._download_json(urljoin(api_host_url, metadata_url), video_id, transform_source=js_to_json)


### PR DESCRIPTION
No support for complete series yet.

Signed-off-by: Moritz Barsnick <barsnick@gmx.net>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This adds support of NRK podcasts to the [nrk] extractor. It does not support series yet, only single episodes.

It has worked fine for me for the last eight weeks, on various podcasts.

Implementation notes:
- ```transform_source=js_to_json``` prevent python for choking on special characters in the JSON embedded in webpages.
- ```.strip()``` is required, as one of the tests actually otherwise delivers a title with leading whitespace.
- I wasn't able to get a thumbnail for one of the tests, therefore the thumbnail metadata code has an ```or None```.