### PR TITLE
Switch to TLS for initial webpage request

### DIFF
--- a/youtube_dl/extractor/odnoklassniki.py
+++ b/youtube_dl/extractor/odnoklassniki.py
@@ -35,7 +35,7 @@ class OdnoklassnikiIE(InfoExtractor):
                 '''
     _TESTS = [{
         # metadata in JSON
-        'url': 'http://ok.ru/video/20079905452',
+        'url': 'https://ok.ru/video/20079905452',
         'md5': '0b62089b479e06681abaaca9d204f152',
         'info_dict': {
             'id': '20079905452',
@@ -50,7 +50,7 @@ class OdnoklassnikiIE(InfoExtractor):
         },
     }, {
         # metadataUrl
-        'url': 'http://ok.ru/video/63567059965189-0?fromTime=5',
+        'url': 'https://ok.ru/video/63567059965189-0?fromTime=5',
         'md5': '6ff470ea2dd51d5d18c295a355b0b6bc',
         'info_dict': {
             'id': '63567059965189-0',
@@ -66,7 +66,7 @@ class OdnoklassnikiIE(InfoExtractor):
         },
     }, {
         # YouTube embed (metadataUrl, provider == USER_YOUTUBE)
-        'url': 'http://ok.ru/video/64211978996595-1',
+        'url': 'https://ok.ru/video/64211978996595-1',
         'md5': '2f206894ffb5dbfcce2c5a14b909eea5',
         'info_dict': {
             'id': 'V_VztHT5BzY',
@@ -81,7 +81,7 @@ class OdnoklassnikiIE(InfoExtractor):
         },
     }, {
         # YouTube embed (metadata, provider == USER_YOUTUBE, no metadata.movie.title field)
-        'url': 'http://ok.ru/video/62036049272859-0',
+        'url': 'https://ok.ru/video/62036049272859-0',
         'info_dict': {
             'id': '62036049272859-0',
             'ext': 'mp4',
@@ -97,19 +97,19 @@ class OdnoklassnikiIE(InfoExtractor):
         },
         'skip': 'Video has not been found',
     }, {
-        'url': 'http://ok.ru/web-api/video/moviePlayer/20079905452',
+        'url': 'https://ok.ru/web-api/video/moviePlayer/20079905452',
         'only_matching': True,
     }, {
-        'url': 'http://www.ok.ru/video/20648036891',
+        'url': 'https://www.ok.ru/video/20648036891',
         'only_matching': True,
     }, {
-        'url': 'http://www.ok.ru/videoembed/20648036891',
+        'url': 'https://www.ok.ru/videoembed/20648036891',
         'only_matching': True,
     }, {
-        'url': 'http://m.ok.ru/video/20079905452',
+        'url': 'https://m.ok.ru/video/20079905452',
         'only_matching': True,
     }, {
-        'url': 'http://mobile.ok.ru/video/20079905452',
+        'url': 'https://mobile.ok.ru/video/20079905452',
         'only_matching': True,
     }, {
         'url': 'https://www.ok.ru/live/484531969818',
@@ -137,7 +137,7 @@ class OdnoklassnikiIE(InfoExtractor):
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(
-            'http://ok.ru/video/%s' % video_id, video_id)
+            'https://ok.ru/video/%s' % video_id, video_id)
 
         error = self._search_regex(
             r'[^>]+class="vp_video_stub_txt"[^>]*>([^<]+)<',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Since OK.RU simply redirects to https://ok.ru, and youtube-dl is requesting on port 80 all the time even if you use an https link, it seems sensible to change to TLS exclusively since this will avoid leaking the URL via unencrypted HTTP and also avoid having to wait for youtube-dl to get redirected. 

This comit simply changes all the test URLs to https and specifically changes the self.download_webpage on line 140 to __https__://ok.ru/video/%s from __http__://ok.ru/video/%s

This would fix https://github.com/ytdl-org/youtube-dl/issues/27589