### PR TITLE
Allow passing different arguments to different postprocessors

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -312,8 +312,9 @@ class YoutubeDL(object):
                        otherwise prefer ffmpeg.
     ffmpeg_location:   Location of the ffmpeg/avconv binary; either the path
                        to the binary or its containing directory.
-    postprocessor_args: A list of additional command-line arguments for the
-                        postprocessor.
+    postprocessor_args: A dictionary of postprocessor names (in lower case) and a list
+                        of additional command-line arguments for the postprocessor.
+                        Use 'default' as the name for arguments to passed to all PP.
 
     The following options are used by the Youtube extractor:
     youtube_include_dash_manifest: If True (default), DASH manifests and related

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -9,6 +9,7 @@ import codecs
 import io
 import os
 import random
+import re
 import sys
 
 
@@ -307,9 +308,19 @@ def _real_main(argv=None):
     external_downloader_args = None
     if opts.external_downloader_args:
         external_downloader_args = compat_shlex_split(opts.external_downloader_args)
-    postprocessor_args = None
-    if opts.postprocessor_args:
-        postprocessor_args = compat_shlex_split(opts.postprocessor_args)
+
+    postprocessor_args = {}
+    if opts.postprocessor_args is not None:
+        for string in opts.postprocessor_args:
+            mobj = re.match(r'(?P<pp>\w+):(?P<args>.*)$', string)
+            if mobj is None:
+                pp_name, pp_args = 'default', string
+            else:
+                pp_name, pp_args = mobj.group('pp').lower(), mobj.group('args')
+            if opts.verbose:
+                write_string('[debug] Adding postprocessor args from command line option %s:%s\n' % (pp_name, pp_args))
+            postprocessor_args[pp_name] = compat_shlex_split(pp_args)
+
     match_filter = (
         None if opts.match_filter is None
         else match_filter_func(opts.match_filter))

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -795,9 +795,14 @@ def parseOpts(overrideArguments=None):
         metavar='FORMAT', dest='recodevideo', default=None,
         help='Encode the video to another format if necessary (currently supported: mp4|flv|ogg|webm|mkv|avi)')
     postproc.add_option(
-        '--postprocessor-args',
-        dest='postprocessor_args', metavar='ARGS',
-        help='Give these arguments to the postprocessor')
+        '--postprocessor-args', metavar='NAME:ARGS',
+        dest='postprocessor_args', action='append',
+        help=(
+            'Give these arguments to the postprocessors. '
+            "Specify the postprocessor name and the arguments separated by a colon ':' "
+            'to give the argument to only the specified postprocessor. Supported names are '
+            'ExtractAudio, VideoConvertor, EmbedSubtitle, Metadata, Merger, FixupStretched, FixupM4a, FixupM3u8, SubtitlesConvertor and Default'
+            '. You can use this option multiple times to give different arguments to different postprocessors'))
     postproc.add_option(
         '-k', '--keep-video',
         action='store_true', dest='keepvideo', default=False,

--- a/youtube_dl/postprocessor/common.py
+++ b/youtube_dl/postprocessor/common.py
@@ -33,6 +33,8 @@ class PostProcessor(object):
 
     def __init__(self, downloader=None):
         self._downloader = downloader
+        if not hasattr(self, 'PP_NAME'):
+            self.PP_NAME = self.__class__.__name__[:-2]
 
     def set_downloader(self, downloader):
         """Sets the downloader for this PP."""
@@ -62,7 +64,10 @@ class PostProcessor(object):
             self._downloader.report_warning(errnote)
 
     def _configuration_args(self, default=[]):
-        return cli_configuration_args(self._downloader.params, 'postprocessor_args', default)
+        args = self._downloader.params.get('postprocessor_args', {})
+        if isinstance(args, list):  # for backward compatibility
+            args = {'default': args}
+        return cli_configuration_args(args, self.PP_NAME.lower(), args.get('default', []))
 
 
 class AudioConversionError(PostProcessingError):

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -23,6 +23,8 @@ class EmbedThumbnailPPError(PostProcessingError):
 
 
 class EmbedThumbnailPP(FFmpegPostProcessor):
+    PP_NAME = 'EmbedThumbnail'
+
     def __init__(self, downloader=None, already_have_thumbnail=False):
         super(EmbedThumbnailPP, self).__init__(downloader)
         self._already_have_thumbnail = already_have_thumbnail

--- a/youtube_dl/postprocessor/execafterdownload.py
+++ b/youtube_dl/postprocessor/execafterdownload.py
@@ -11,6 +11,8 @@ from ..utils import (
 
 
 class ExecAfterDownloadPP(PostProcessor):
+    PP_NAME = 'Exec'
+
     def __init__(self, downloader, exec_cmd):
         super(ExecAfterDownloadPP, self).__init__(downloader)
         self.exec_cmd = exec_cmd

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -53,6 +53,8 @@ class FFmpegPostProcessorError(PostProcessingError):
 
 class FFmpegPostProcessor(PostProcessor):
     def __init__(self, downloader=None):
+        if not hasattr(self, 'PP_NAME'):
+            self.PP_NAME = self.__class__.__name__[6:-2]  # Remove ffmpeg from the front
         PostProcessor.__init__(self, downloader)
         self._determine_executables()
 


### PR DESCRIPTION
Stripped down to minimum required code from:
https://github.com/pukkandan/yt-dlc/commit/1b77b347d422ed70fd833a9f0327ea418ba4919c

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Allow passing different arguments to different postprocessors like this:

    --postprocessor-args "VideoConvertor:-c:v h264_nvenc -preset slow" --postprocessor-args "Metadata:-dn"

For backward compatibility, `--postprocessor-args args` is equivalent to:
    --post-processor-args "default:<args>"

This is a stripped down version of the [full patch](https://github.com/pukkandan/yt-dlc/commit/1b77b347d422ed70fd833a9f0327ea418ba4919c) in hopes that keeping the code to the bare minimum would allow this to be merged quicker

Closes https://github.com/ytdl-org/youtube-dl/issues/27593