### PR TITLE
[discoveryplus] Added "it" to match italian domain urls

### DIFF
--- a/youtube_dl/extractor/dplay.py
+++ b/youtube_dl/extractor/dplay.py
@@ -20,7 +20,7 @@ class DPlayIE(InfoExtractor):
             (?:www\.)?(?P<host>d
                 (?:
                     play\.(?P<country>dk|fi|jp|se|no)|
-                    iscoveryplus\.(?P<plus_country>dk|es|fi|it|se|no)
+                    iscoveryplus\.(?P<plus_country>dk|es|fi|it|se|no|it)
                 )
             )|
             (?P<subdomain_country>es|it)\.dplay\.com
@@ -148,6 +148,9 @@ class DPlayIE(InfoExtractor):
         'only_matching': True,
     }, {
         'url': 'https://www.discoveryplus.fi/videot/shifting-gears-with-aaron-kaufman/episode-16',
+        'only_matching': True,
+    }, {
+        'url': 'https://www.discoveryplus.it/programmi/drive-me-crazy/stagione-2-episodio-5-cross-country',
         'only_matching': True,
     }]
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?
- [x] Improvement

---

discoveryplus is now in italy as well so I added the "it" suffix fo match italian domain urls and a test.