### PR TITLE
Add --max-already-downloaded option

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -624,13 +624,6 @@ class YoutubeDL(object):
         error_message = '%s %s' % (_msg_header, message)
         self.trouble(error_message, tb)
 
-    def report_file_already_downloaded(self, file_name):
-        """Report file has already been fully downloaded."""
-        try:
-            self.to_screen('[download] %s has already been downloaded' % file_name)
-        except UnicodeEncodeError:
-            self.to_screen('[download] The file has already been downloaded')
-
     def prepare_filename(self, info_dict):
         """Generate the output filename."""
         try:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -25,9 +25,9 @@ from .utils import (
     decodeOption,
     DEFAULT_OUTTMPL,
     DownloadError,
+    DownloadLimitReached,
     expand_path,
     match_filter_func,
-    MaxDownloadsReached,
     preferredencoding,
     read_batch_urls,
     SameFileError,
@@ -380,6 +380,7 @@ def _real_main(argv=None):
         'matchtitle': decodeOption(opts.matchtitle),
         'rejecttitle': decodeOption(opts.rejecttitle),
         'max_downloads': opts.max_downloads,
+        'max_already_downloaded': opts.max_already_downloaded,
         'prefer_free_formats': opts.prefer_free_formats,
         'verbose': opts.verbose,
         'dump_intermediate_pages': opts.dump_intermediate_pages,
@@ -462,8 +463,8 @@ def _real_main(argv=None):
                 retcode = ydl.download_with_info_file(expand_path(opts.load_info_filename))
             else:
                 retcode = ydl.download(all_urls)
-        except MaxDownloadsReached:
-            ydl.to_screen('--max-download limit reached, aborting.')
+        except DownloadLimitReached as dlr:
+            ydl.to_screen('%s, aborting.' % dlr)
             retcode = 101
 
     sys.exit(retcode)

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -328,7 +328,7 @@ class FileDownloader(object):
 
     def download(self, filename, info_dict):
         """Download to a filename using the info from info_dict
-        Return True on success and False otherwise
+        Return a string describing the result on success and False otherwise
         """
 
         nooverwrites_and_exists = (
@@ -351,7 +351,7 @@ class FileDownloader(object):
                     'status': 'finished',
                     'total_bytes': os.path.getsize(encodeFilename(filename)),
                 })
-                return True
+                return 'already_downloaded'
 
         min_sleep_interval = self.params.get('sleep_interval')
         if min_sleep_interval:
@@ -363,7 +363,10 @@ class FileDownloader(object):
                     else '%.2f' % sleep_interval))
             time.sleep(sleep_interval)
 
-        return self.real_download(filename, info_dict)
+        rv = self.real_download(filename, info_dict)
+        if rv is True:
+            rv = 'ok'
+        return rv
 
     def real_download(self, filename, info_dict):
         """Real download process. Redefine in subclasses."""

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -280,6 +280,10 @@ def parseOpts(overrideArguments=None):
         dest='max_downloads', metavar='NUMBER', type=int, default=None,
         help='Abort after downloading NUMBER files')
     selection.add_option(
+        '--max-already-downloaded',
+        dest='max_already_downloaded', metavar='NUMBER', type=int, default=None,
+        help='Stop after having attempted to download NUMBER previously downloaded files (useful for reverse-chronological playlists)')
+    selection.add_option(
         '--min-filesize',
         metavar='SIZE', dest='min_filesize', default=None,
         help='Do not download any videos smaller than SIZE (e.g. 50k or 44.6m)')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2419,8 +2419,18 @@ class PostProcessingError(YoutubeDLError):
         self.msg = msg
 
 
-class MaxDownloadsReached(YoutubeDLError):
+class DownloadLimitReached(YoutubeDLError):
+    """ Base class for download limit exceptions. """
+    pass
+
+
+class MaxDownloadsReached(DownloadLimitReached):
     """ --max-downloads limit has been reached. """
+    pass
+
+
+class MaxAlreadyDownloadedReached(DownloadLimitReached):
+    """ --max-already-downloaded limit has been reached. """
     pass
 
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
  - 👉   I don't have tests for this yet. I couldn't find a test for `max_downloads` either; any pointers on how to best test this?
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)

### What is the purpose of your *pull request*?

- [x] New feature

---

### Description of your *pull request* and other information

This PR adds a new `--max-already-downloaded` switch, similar to `--max-downloads`, but it only takes into account files that would have been redownloaded.

To facilitate that,

* ⚠️ it minutely changes the API for `FileDownloader.download()` to, instead of True, return a string representing the reason a download succeeded; currently it's either `"ok"` or `"already_downloaded"`. I wouldn't expect any downstream users to use `if ...download() is True`, and strings are truthy anyway, so this should work just fine
* it adds a new super `DownloadLimitReached` exception class from whence `MaxDownloadsReached` and the new `MaxAlreadyDownloadedReached` exceptions are derived, and catches it wherever `MaxDownloadsReached` used to be caught before.
* it adds the new option to the argument parser and plops it into the ytdl instance's `options` as you might expect
* it adds the necessary counter to the ytdl object

As a side effect, it also removes an unused copy of `report_file_already_downloaded`.