### PR TITLE
support for radioplay.{no,se} podcasts (closes #27807)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -949,6 +949,7 @@ from .radiode import RadioDeIE
 from .radiojavan import RadioJavanIE
 from .radiobremen import RadioBremenIE
 from .radiofrance import RadioFranceIE
+from .radioplay import RadioplayPodcastIE
 from .rai import (
     RaiPlayIE,
     RaiPlayLiveIE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -592,6 +592,7 @@ from .linkedin import (
     LinkedInLearningCourseIE,
 )
 from .linuxacademy import LinuxAcademyIE
+from .listennow import ListennowIE
 from .litv import LiTVIE
 from .livejournal import LiveJournalIE
 from .liveleak import (

--- a/youtube_dl/extractor/listennow.py
+++ b/youtube_dl/extractor/listennow.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+class ListennowIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:[^\.]+\.)?listennow\.link/(?P<id>\d+)'
+
+    _TEST = {
+        'url': 'https://radionorge.listennow.link/10279676',
+        'info_dict': {
+            'id': '2035659',
+            'ext': 'mp3',
+            'title': 'Best of Høsten 2020',
+            'description': 'md5:701b09a2bcf9a75b6bfd8a27f359dcfa',
+            'timestamp': 1603429200,
+            'upload_date': '20201023',
+        },
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        url = self._search_regex(
+            r'desktopUrl\s*:\s*\'([^\']+)\'', webpage,
+            'redirect', video_id)
+        return self.url_result(url)

--- a/youtube_dl/extractor/radioplay.py
+++ b/youtube_dl/extractor/radioplay.py
@@ -1,0 +1,45 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+from ..utils import (
+    js_to_json,
+    parse_iso8601,
+    unified_strdate,
+)
+
+
+class RadioplayPodcastIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?radioplay\.(?:se|no)/podcast/[^/]+/[^/]+/(?P<id>\d+)'
+
+    _TEST = {
+        'url': 'https://radioplay.se/podcast/lilla-my/lyssna/2001126',
+        'info_dict': {
+            'id': '2001126',
+            'ext': 'mp3',
+            'title': 'Kaktus till läraren',
+            'description': 'Lilla My ska köpa en "blomma" till sin lärare.',
+            'timestamp': 1549898100,
+            'upload_date': '20190211',
+        },
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+        player = self._parse_json(self._search_regex(
+            r'window\.__PRELOADED_STATE__\s*=\s*({.+})', webpage,
+            'player', default='{}'), video_id, transform_source=js_to_json)
+        video_info = player['player']['nowPlaying']
+
+        return {
+            'url': video_info['PodcastExtMediaUrl'],
+            'id': video_id,
+            'title': video_info['PodcastTitle'],
+            'description': video_info.get('PodcastDescription'),
+            'thumbnail': video_info.get('PodcastImageUrl'),
+            'release_date': unified_strdate(video_info.get('PodcastPublishDate')),
+            'timestamp': parse_iso8601(video_info.get('PodcastPublishDate'), ' '),
+            'duration': video_info.get('PodcastDuration'),
+            'channel': player.get('podcastsApi').get('data').get('channel').get('PodcastChannelTitle'),
+        }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

radioplay.{no,se,dk} hosts private Scandinavian radio stations owned by the Bauer Media Group, and their podcasts (some of them top-ranking in the charts).

This PR covers the podcasts provided by radioplay.no and radioplay.se. radioplay.dk is not covered (yet?).

Some of the podcast main pages (see "Complete series" link above in the "Example URLs") have direct links to a redirect site ```listennow.link```. This is covered in this PR by a separate extractor. (I have only found it to redirect to radioplay sites so far.)