### PR TITLE
[patreon] add support for patreon-hosted video embeds

### DIFF
--- a/youtube_dl/extractor/patreon.py
+++ b/youtube_dl/extractor/patreon.py
@@ -16,6 +16,7 @@ from ..utils import (
 import json
 import re
 
+
 class PatreonIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?patreon\.com/(?:creation\?hid=|posts/(?:[\w-]+-)?)(?P<id>\d+)'
     _TESTS = [{
@@ -150,16 +151,16 @@ class PatreonIE(InfoExtractor):
         if not info.get('url'):
             post_file = attributes['post_file']
             if post_file.get('name') == 'video':
-               # single video embed
-               info.update({
-                   'url': post_file['url']
-               })
+                # single video embed
+                info.update({
+                    'url': post_file['url']
+                })
             else:
-              # video is attached as a file 
-              ext = determine_ext(post_file.get('name'))
-              if ext in KNOWN_EXTENSIONS:
-                  info.update({
-                      'ext': ext,
-                      'url': post_file['url'],
-                  })
+                # video is attached as a file
+                ext = determine_ext(post_file.get('name'))
+                if ext in KNOWN_EXTENSIONS:
+                    info.update({
+                        'ext': ext,
+                        'url': post_file['url'],
+                    })
         return info

--- a/youtube_dl/extractor/patreon.py
+++ b/youtube_dl/extractor/patreon.py
@@ -19,6 +19,7 @@ import re
 
 class PatreonIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?patreon\.com/(?:creation\?hid=|posts/(?:[\w-]+-)?)(?P<id>\d+)'
+    _NETRC_MACHINE = 'patreon'
     _TESTS = [{
         'url': 'http://www.patreon.com/creation?hid=743933',
         'md5': 'e25505eec1053a6e6813b8ed369875cc',
@@ -66,6 +67,11 @@ class PatreonIE(InfoExtractor):
     }, {
         'url': 'https://www.patreon.com/posts/743933',
         'only_matching': True,
+    }, {
+        # embedded patreon-hosted video, paywalled
+        'url': 'https://www.patreon.com/posts/terps-part-1-46181905',
+        'only_matching': True,
+        'skip': 'Patron-only content'
     }]
 
     def _login(self):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x ] Bug fix
- [x ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The current Patreon extractor does not support videos that are embedded/encoded/hosted by Patreon itself. It only supports videos that are attached to posts, like file uploads. Patreon-native videos use a hash check on the CDN URL, requiring the user to log in for paywalled content. I have re-enabled (and updated/fixed) the login code, and added support for these types of embeds.