### PR TITLE
 [CCMA] Fix CCMA extractor (closes #24347)

### DIFF
--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -88,8 +88,11 @@ class CCMAIE(InfoExtractor):
 
         # utc date is in format YYYY-DD-MM
         data_utc = informacio.get('data_emissio', {}).get('utc')
-        data_iso8601 = data_utc[:5] + data_utc[8:10] + '-' + data_utc[5:7] + data_utc[10:]
-        timestamp = parse_iso8601(data_iso8601)
+        try:
+            data_iso8601 = data_utc[:5] + data_utc[8:10] + '-' + data_utc[5:7] + data_utc[10:]
+            timestamp = parse_iso8601(data_iso8601)
+        except TypeError:
+            timestamp = None
 
         subtitles = {}
         subtitols = media.get('subtitols', [])

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -24,8 +24,8 @@ class CCMAIE(InfoExtractor):
             'ext': 'mp4',
             'title': 'L\'espot de La Marató de TV3',
             'description': 'md5:f12987f320e2f6e988e9908e4fe97765',
-            'timestamp': 1470918540,
-            'upload_date': '20160811',
+            'timestamp': 1478608140,
+            'upload_date': '20161108',
         }
     }, {
         'url': 'http://www.ccma.cat/catradio/alacarta/programa/el-consell-de-savis-analitza-el-derbi/audio/943685/',
@@ -35,8 +35,8 @@ class CCMAIE(InfoExtractor):
             'ext': 'mp3',
             'title': 'El Consell de Savis analitza el derbi',
             'description': 'md5:e2a3648145f3241cb9c6b4b624033e53',
-            'upload_date': '20171205',
-            'timestamp': 1512507300,
+            'upload_date': '20170512',
+            'timestamp': 1494622500,
         }
     }]
 
@@ -74,7 +74,11 @@ class CCMAIE(InfoExtractor):
         title = informacio['titol']
         durada = informacio.get('durada', {})
         duration = int_or_none(durada.get('milisegons'), 1000) or parse_duration(durada.get('text'))
-        timestamp = parse_iso8601(informacio.get('data_emissio', {}).get('utc'))
+
+        # utc date is in format YYYY-DD-MM
+        data_utc = informacio.get('data_emissio', {}).get('utc')
+        data_iso8601 = data_utc[:5] + data_utc[8:10] + '-' + data_utc[5:7] + data_utc[10:]
+        timestamp = parse_iso8601(data_iso8601)
 
         subtitles = {}
         subtitols = media.get('subtitols', {})

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -92,12 +92,15 @@ class CCMAIE(InfoExtractor):
         timestamp = parse_iso8601(data_iso8601)
 
         subtitles = {}
-        subtitols = media.get('subtitols', {})
-        if subtitols:
-            sub_url = subtitols.get('url')
+        subtitols = media.get('subtitols', [])
+        # Single language -> dict; multiple languages -> List[dict]
+        if isinstance(subtitols, dict):
+            subtitols = [subtitols]
+        for st in subtitols:
+            sub_url = st.get('url')
             if sub_url:
                 subtitles.setdefault(
-                    subtitols.get('iso') or subtitols.get('text') or 'ca', []).append({
+                    st.get('iso') or 'ca', []).append({
                         'url': sub_url,
                     })
 

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -38,6 +38,17 @@ class CCMAIE(InfoExtractor):
             'upload_date': '20170512',
             'timestamp': 1494622500,
         }
+    }, {
+        'url': 'http://www.ccma.cat/tv3/alacarta/crims/crims-josep-tallada-lespereu-me-capitol-1/video/6031387/',
+        'md5': 'b43c3d3486f430f3032b5b160d80cbc3',
+        'info_dict': {
+            'id': '6031387',
+            'ext': 'mp4',
+            'title': 'Crims - Josep Talleda, l\'"Espereu-me" (capítol 1)',
+            'description': 'md5:7cbdafb640da9d0d2c0f62bad1e74e60',
+            'timestamp': 1582577700,
+            'upload_date': '20200224',
+        }
     }]
 
     def _real_extract(self, url):

--- a/youtube_dl/extractor/ccma.py
+++ b/youtube_dl/extractor/ccma.py
@@ -103,7 +103,7 @@ class CCMAIE(InfoExtractor):
             sub_url = st.get('url')
             if sub_url:
                 subtitles.setdefault(
-                    st.get('iso') or 'ca', []).append({
+                    st.get('iso') or st.get('text') or 'ca', []).append({
                         'url': sub_url,
                     })
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Fixing two bugs present in CCMA extractor.

1. **Incorrect timestamp**: 

For some reason, provided UTC timestamp does not comply ISO8601, as its format is YYYY-DD-MM instead of expected YYYY-MM-DD.
    
This is made evident in the also provided `"text"` field of emission date object. Example:
```json
    "data_emissio": {
                "text": "14/05/2002�21:39",
                "utc": "2002-14-05T21:39:28+0200"
    }
```

2. **Multiple subtitles support** (#24347)

The extractor used to raise an exception when attempting the download of a URL featuring multiple subtitle languages.

Behavior of the `subtitols` field is:

- When a single language is available, the field is the expected `dict`.

- When multiple languages are available, a `list` of `dict` is provided.

A test is added with an URL featuring multiple subtitles, to ensure no exception is raised during extraction.
