### PR TITLE
[egghead] Fixed egghead extractor - API base URL host updated

### DIFF
--- a/youtube_dl/extractor/egghead.py
+++ b/youtube_dl/extractor/egghead.py
@@ -30,7 +30,7 @@ class EggheadCourseIE(InfoExtractor):
         playlist_id = self._match_id(url)
 
         lessons = self._download_json(
-            'https://egghead.io/api/v1/series/%s/lessons' % playlist_id,
+            'https://app.egghead.io/api/v1/series/%s/lessons' % playlist_id,
             playlist_id, 'Downloading course lessons JSON')
 
         entries = []
@@ -45,7 +45,7 @@ class EggheadCourseIE(InfoExtractor):
                 lesson_url, ie=EggheadLessonIE.ie_key(), video_id=lesson_id))
 
         course = self._download_json(
-            'https://egghead.io/api/v1/series/%s' % playlist_id,
+            'https://app.egghead.io/api/v1/series/%s' % playlist_id,
             playlist_id, 'Downloading course JSON', fatal=False) or {}
 
         playlist_id = course.get('id')
@@ -74,7 +74,7 @@ class EggheadLessonIE(InfoExtractor):
             'upload_date': '20161209',
             'duration': 304,
             'view_count': 0,
-            'tags': ['javascript', 'free'],
+            'tags': ['free', 'javascript',],
         },
         'params': {
             'skip_download': True,
@@ -89,7 +89,7 @@ class EggheadLessonIE(InfoExtractor):
         display_id = self._match_id(url)
 
         lesson = self._download_json(
-            'https://egghead.io/api/v1/lessons/%s' % display_id, display_id)
+            'https://app.egghead.io/api/v1/lessons/%s' % display_id, display_id)
 
         lesson_id = compat_str(lesson['id'])
         title = lesson['title']

--- a/youtube_dl/extractor/egghead.py
+++ b/youtube_dl/extractor/egghead.py
@@ -74,7 +74,7 @@ class EggheadLessonIE(InfoExtractor):
             'upload_date': '20161209',
             'duration': 304,
             'view_count': 0,
-            'tags': ['free', 'javascript',],
+            'tags': ['free', 'javascript'],
         },
         'params': {
             'skip_download': True,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

The Egghead extractor was raising the below exception:
`[egghead:course] professor-frisby-introduces-composable-functional-javascript: Downloading course lessons JSON
ERROR: Unable to download JSON metadata: HTTP Error 308: Permanent Redirect (caused by HTTPError()); please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; type youtube-dl -U  to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.`

The base URL in the extractor ('https://egghead.io/api/v1/series/%s/lessons') for fetching the JSON resource for the metadata was outdated. 
I have gone ahead and updated the base URL to point to the updated base URL ('https://app.egghead.io/api/v1/series/%s/lessons'). 