### PR TITLE
Accept socks5h:// proxy protocol name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
     --proxy URL                          Use the specified HTTP/HTTPS/SOCKS
                                          proxy. To enable SOCKS proxy, specify a
                                          proper scheme. For example
-                                         socks5://127.0.0.1:1080/. Pass in an
+                                         socks5h://127.0.0.1:1080/. Pass in an
                                          empty string (--proxy "") for direct
                                          connection
     --socket-timeout SECONDS             Time to wait before giving up, in

--- a/test/test_socks.py
+++ b/test/test_socks.py
@@ -113,6 +113,8 @@ class TestSocks(unittest.TestCase):
     def test_socks5(self):
         self.assertTrue(isinstance(self._get_ip('socks5'), compat_str))
 
+    def test_socks5h(self):
+        self.assertTrue(isinstance(self._get_ip('socks5h'), compat_str))
 
 if __name__ == '__main__':
     unittest.main()

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -205,7 +205,7 @@ def parseOpts(overrideArguments=None):
         default=None, metavar='URL',
         help='Use the specified HTTP/HTTPS/SOCKS proxy. To enable '
              'SOCKS proxy, specify a proper scheme. For example '
-             'socks5://127.0.0.1:1080/. Pass in an empty string (--proxy "") '
+             'socks5h://127.0.0.1:1080/. Pass in an empty string (--proxy "") '
              'for direct connection')
     network.add_option(
         '--socket-timeout',

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -76,7 +76,7 @@ def register_socks_protocols():
     # "Register" SOCKS protocols
     # In Python < 2.6.5, urlsplit() suffers from bug https://bugs.python.org/issue7904
     # URLs with protocols not in urlparse.uses_netloc are not handled correctly
-    for scheme in ('socks', 'socks4', 'socks4a', 'socks5'):
+    for scheme in ('socks', 'socks4', 'socks4a', 'socks5', 'socks5h'):
         if scheme not in compat_urlparse.uses_netloc:
             compat_urlparse.uses_netloc.append(scheme)
 
@@ -2673,7 +2673,7 @@ def make_socks_conn_class(base_class, socks_proxy):
         compat_http_client.HTTPConnection, compat_http_client.HTTPSConnection))
 
     url_components = compat_urlparse.urlparse(socks_proxy)
-    if url_components.scheme.lower() == 'socks5':
+    if url_components.scheme.lower() in ('socks5', 'socks5h'):
         socks_type = ProxyType.SOCKS5
     elif url_components.scheme.lower() in ('socks', 'socks4'):
         socks_type = ProxyType.SOCKS4
@@ -5352,7 +5352,7 @@ class PerRequestProxyHandler(compat_urllib_request.ProxyHandler):
 
         if proxy == '__noproxy__':
             return None  # No Proxy
-        if compat_urlparse.urlparse(proxy).scheme.lower() in ('socks', 'socks4', 'socks4a', 'socks5'):
+        if compat_urlparse.urlparse(proxy).scheme.lower() in ('socks', 'socks4', 'socks4a', 'socks5', 'socks5h'):
             req.add_header('Ytdl-socks-proxy', proxy)
             # youtube-dl's http/https handlers do wrapping the socket with socks
             return None


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Closes #22618. Makes youtube-dl recognize the `socks5h` protocol string like cURL does.

Before PR:
```
$ youtube-dl --proxy socks5h://127.0.0.1:9050 --simulate dQw4w9WgXcQ
[youtube] dQw4w9WgXcQ: Downloading webpage
ERROR: Unable to download webpage: <urlopen error Tunnel connection failed: 501 Tor is not an HTTP Proxy> (caused by URLError(OSError('Tunnel connection failed: 501 Tor is not an HTTP Proxy')))
```

After PR:
```
$ youtube-dl --proxy socks5h://127.0.0.1:9050 --simulate dQw4w9WgXcQ
[youtube] dQw4w9WgXcQ: Downloading webpage
```