### PR TITLE
[RTV SLO 4D] Add extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1006,6 +1006,7 @@ from .rts import RTSIE
 from .rtve import RTVEALaCartaIE, RTVELiveIE, RTVEInfantilIE, RTVELiveIE, RTVETelevisionIE
 from .rtvnh import RTVNHIE
 from .rtvs import RTVSIE
+from .rtvslo import RTVSLO4DIE
 from .ruhd import RUHDIE
 from .rumble import RumbleEmbedIE
 from .rutube import (

--- a/youtube_dl/extractor/rtvslo.py
+++ b/youtube_dl/extractor/rtvslo.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    unified_timestamp,
+    try_get, ExtractorError
+)
+
+
+class RTVSLO4DIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:4d|www)\.rtvslo\.si/(?:arhiv/.+|embed|4d/arhiv)/(?P<id>\d+)'
+    _TEST = {
+        'url': 'https://4d.rtvslo.si/arhiv/seje-odbora-za-kmetijstvo-gozdarstvo-in-prehrano/174595438',
+        'md5': 'b87e5a65be2365f83eb0d24d44131d0f',
+        'info_dict': {
+            'id': '174595438',
+            'ext': 'mp4',
+            'title': 'Krajčič o tatvini sendviča',
+            'thumbnail': r're:https://img.rtvslo.si/.+\.jpg',
+            'timestamp': 1549999614,
+            'upload_date': '20190212',
+            'duration': 85
+        },
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        embed_url = 'https://4d.rtvslo.si/embed/' + video_id
+        embed_html = self._download_webpage(embed_url, video_id)
+
+        client_id = self._search_regex(r'\[\'client\'\] = "(.+?)";', embed_html, 'clientId')
+
+        info_url = 'https://api.rtvslo.si/ava/getRecordingDrm/' + video_id + '?client_id=' + client_id
+        video_info = self._download_json(info_url, video_id)['response']
+
+        if video_info["mediaType"] != "video":
+            raise ExtractorError("Downloading audio is not implemented for this source yet")
+
+        jwt = video_info['jwt']
+
+        media_info_url = 'https://api.rtvslo.si/ava/getMedia/' + video_id + '?client_id=' + client_id + '&jwt=' + jwt
+        media_info = self._download_json(media_info_url, video_id)['response']
+
+        # TODO: Support for audio-only links (like radio shows)
+        # Instead of HLS, an mp3 URL is provided for those in ".mediaFiles[0].streams.https"
+
+        formats = self._extract_m3u8_formats(
+            media_info['addaptiveMedia']['hls'], video_id, 'mp4',
+            entry_protocol='m3u8_native', m3u8_id='hls')
+
+        return {
+            'id': video_id,
+            'title': video_info['title'],
+            'description': try_get(video_info, 'description'),
+            'thumbnail': video_info.get('thumbnail_sec'),
+            'timestamp': unified_timestamp(video_info['broadcastDate']),
+            'duration': video_info.get('duration'),
+            'formats': formats,
+        }


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR implements an extractor for the [RTV SLO 4D](https://4d.rtvslo.si/) video portal (archive of the Slovenian national broadcaster). The corresponding site request issue is #15590, with #19292 being a duplicate of it (the latter also mentions capodistria.rtvslo.si, but videos are no longer hosted there as they have been migrated to the main portal).

As noted in the code, it does not currently support radio shows, but I will come back and fix that once I can spare the time. In the mean time, I've tested the video support on some 10 videos without issues. 