### PR TITLE
[YouTube] Add the --page-sleep-interval argument to prevent error 429 on larger archives

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -170,6 +170,9 @@ def _real_main(argv=None):
             parser.error('min sleep interval must be specified, use --min-sleep-interval')
         if opts.max_sleep_interval < opts.sleep_interval:
             parser.error('max sleep interval must be greater than or equal to min sleep interval')
+    if opts.page_sleep_interval is not None:
+        if opts.page_sleep_interval < 0:
+            parser.error('page sleep interval must be positive or 0')
     else:
         opts.max_sleep_interval = opts.sleep_interval
     if opts.ap_mso and opts.ap_mso not in MSO_INFO:
@@ -417,6 +420,7 @@ def _real_main(argv=None):
         'call_home': opts.call_home,
         'sleep_interval': opts.sleep_interval,
         'max_sleep_interval': opts.max_sleep_interval,
+        'page_sleep_interval': opts.page_sleep_interval,
         'external_downloader': opts.external_downloader,
         'list_thumbnails': opts.list_thumbnails,
         'playlist_items': opts.playlist_items,

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -600,6 +600,10 @@ class InfoExtractor(object):
 
         See _download_webpage docstring for arguments specification.
         """
+        page_sleep_interval = self._downloader.params.get('page_sleep_interval')
+        page_sleep_interval = 0 if page_sleep_interval is None else float(page_sleep_interval)
+        time.sleep(page_sleep_interval)
+        
         if note is None:
             self.report_download_webpage(video_id)
         elif note is not False:

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -603,7 +603,7 @@ class InfoExtractor(object):
         page_sleep_interval = self._downloader.params.get('page_sleep_interval')
         page_sleep_interval = 0 if page_sleep_interval is None else float(page_sleep_interval)
         time.sleep(page_sleep_interval)
-        
+
         if note is None:
             self.report_download_webpage(video_id)
         elif note is not False:

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -8,6 +8,7 @@ import os.path
 import random
 import re
 import traceback
+import time
 
 from .common import InfoExtractor, SearchInfoExtractor
 from ..compat import (

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2454,12 +2454,15 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
         if identity_token:
             headers['x-youtube-identity-token'] = identity_token
 
+        page_sleep_interval = self._downloader.params.get('page_sleep_interval')
+        page_sleep_interval = 0 if page_sleep_interval is None else float(page_sleep_interval)
         for page_num in itertools.count(1):
             if not continuation:
                 break
             count = 0
             retries = 3
             while count <= retries:
+                time.sleep(page_sleep_interval)
                 try:
                     # Downloading page may result in intermittent 5xx HTTP error
                     # that is usually worked around with a retry

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -572,6 +572,12 @@ def parseOpts(overrideArguments=None):
             'Upper bound of a range for randomized sleep before each download '
             '(maximum possible number of seconds to sleep). Must only be used '
             'along with --min-sleep-interval.'))
+    workarounds.add_option(
+        '--page-sleep-interval', metavar='SECONDS',
+        dest='page_sleep_interval', type=float,
+        help=(
+            'Number of seconds to sleep before loading a YouTube page '
+            'to prevent 429 on larger downloads. '))
 
     verbosity = optparse.OptionGroup(parser, 'Verbosity / Simulation Options')
     verbosity.add_option(

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -576,8 +576,8 @@ def parseOpts(overrideArguments=None):
         '--page-sleep-interval', metavar='SECONDS',
         dest='page_sleep_interval', type=float,
         help=(
-            'Number of seconds to sleep before loading a YouTube page '
-            'to prevent 429 on larger downloads. '))
+            'Number of seconds to sleep before loading a webpage or YouTube '
+            'page to prevent errors such as 429 on larger downloads. '))
 
     verbosity = optparse.OptionGroup(parser, 'Verbosity / Simulation Options')
     verbosity.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

I noticed that youtube-dl often started giving 429 errors on my archive. After investigating it for a bit, I found that these errors were tripped by youtube-dl loading pages too fast (such as channels and playlists). To fix it, I added a new argument that lets you add a delay to loading pages. I've been running this on my personal archive for a month (0.5s sleep) and I haven't gotten any 429 errors during this time, while before it would sometimes trip the error in mere hours.

I made this argument separate from --sleep-interval as to not break or slow down any existing setups.