### PR TITLE
[MediathekViewWeb] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -642,6 +642,10 @@ from .mediasite import (
     MediasiteCatalogIE,
     MediasiteNamedCatalogIE,
 )
+from .mediathekviewweb import (
+    MediathekViewWebSearchIE,
+    MediathekViewWebIE,
+)
 from .medici import MediciIE
 from .megaphone import MegaphoneIE
 from .meipai import MeipaiIE

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -1,0 +1,194 @@
+import datetime
+import itertools
+import json
+import re
+
+from .common import InfoExtractor, SearchInfoExtractor
+from ..compat import compat_urllib_parse_unquote
+from ..utils import ExtractorError, int_or_none
+
+class MediathekViewWebSearchIE(SearchInfoExtractor):
+    IE_NAME = 'mediathekviewweb:search'
+    IE_DESC = 'MediathekViewWeb search'
+    _SEARCH_KEY = 'mvwsearch'
+    _MAX_RESULTS = float('inf')
+    _MAX_RESULTS_PER_PAGE = 50
+    # _GEO_COUNTRIES = ['DE']
+
+    # _TESTS = [{
+    #     'url': 'mvwsearch:tagesschau',
+    #     'info_dict': {
+    #         'title': 'post-avant jazzcore',
+    #     },
+    #     'playlist_count': 15,
+    # }]
+
+    # Map of title affixes indicating video variants.
+    _variants = {
+        'audio_description': '(Audiodeskription)',
+        'sign_language': '(mit Gebärdensprache)',
+    }
+
+    def _build_conditions(self, search):
+        # @note So far, there is no API endpoint to convert a query string into
+        #   a complete query object, as required by the /api/query endpoint.
+        # @see https://github.com/mediathekview/mediathekviewweb/blob/master/client/index.ts#L144
+        #   for parsing the search string into properties.
+        # @see https://github.com/mediathekview/mediathekviewweb/blob/master/client/index.ts#L389
+        #   for converting properties into field queries.
+        filters = {}
+        extra = {}
+        for component in search.lower().split():
+            if len(component) == 0:
+                continue
+
+            field = None
+            operator = component[0:1]
+            value = component[1:]
+            # Extra, non-field settings.
+            if operator == '>':
+                value = int(value.split(',')[0]) * 60
+                extra['duration_min'] = max(extra.get('duration_min', 0), value)
+                continue
+            elif operator == '<':
+                value = int(value.split(',')[0]) * 60
+                extra['duration_max'] = min(extra.get('duration_max', float('inf')), value)
+                continue
+
+            # Field query operators.
+            elif operator == '!':
+                field = 'channel'
+            elif operator == '#':
+                field = 'topic'
+            elif operator == '+':
+                field = 'title'
+            elif operator == '*':
+                field = 'description'
+            else:
+                field = 'topic,title'
+                operator = ''
+                value = component
+
+            if field:
+                # @todo In theory, comma-joined values are for AND queries.
+                #   But so far, each is an AND component, even without comma.
+                filters.setdefault(field, []).append(' '.join(value.split(',')))
+
+        conditions = []
+        for field, keys in filters.items():
+            for query in keys:
+                conditions.append({
+                    'fields': field.split(','),
+                    'query': query,
+                })
+
+        return conditions, extra
+
+    def _extract_playlist_entries(self, results):
+        entries = []
+        for item in results:
+            variant = None
+            for key, value in self._variants.items():
+                if item['title'].find(value) != -1:
+                    variant = key
+
+            formats = []
+            formats.append({
+                'url': item['url_video'],
+                'format': ('medium ' + self._variants[variant]) if variant else None,
+                'format_id': ('medium-' + variant) if variant else 'medium',
+                'language_preference': -10 if variant else 10,
+                'quality': -2,
+                'filesize': item['size'],
+            })
+            if len(item.get('url_video_low', '')) > 0:
+                formats.append({
+                    'url': item['url_video_low'],
+                    'format': ('low ' + self._variants[variant]) if variant else None,
+                    'format_id': ('low-' + variant) if variant else 'low',
+                    'language_preference': -10 if variant else 10,
+                    'quality': -3,
+                })
+            if len(item.get('url_video_hd', '')) > 0:
+                formats.append({
+                    'url': item['url_video_hd'],
+                    'format': ('high ' + self._variants[variant]) if variant else None,
+                    'format_id': ('high-' + variant) if variant else 'high',
+                    'language_preference': -10 if variant else 10,
+                    'quality': -1,
+                })
+            self._sort_formats(formats)
+
+            video = {
+                '_type': 'video',
+                'formats': formats,
+                'id': item['id'],
+                'title': item['title'],
+                'description': item['description'],
+                'series': item['topic'],
+                'channel': item['channel'],
+                'uploader': item['channel'],
+                'duration': int_or_none(item['duration']),
+                'webpage_url': item['url_website'],
+            }
+
+            upload_date = datetime.datetime.utcfromtimestamp(item['timestamp'])
+            video['upload_date'] = upload_date.strftime('%Y%m%d')
+            if item['url_subtitle']:
+                video.setdefault('subtitles', {}).setdefault('de', []).append({
+                    'url': item['url_subtitle'],
+                })
+            entries.append(video)
+
+        return entries
+
+    def _get_n_results(self, query, n):
+        # @todo Add support for everywhere/future options.
+        queries, extra = self._build_conditions(query)
+        queryObject = {
+            'queries': queries,
+            'sortBy': 'timestamp',
+            'sortOrder': 'desc',
+            'future': True,
+            'duration_min': extra.get('duration_min'),
+            'duration_max': extra.get('duration_max'),
+            'offset': 0,
+            'size': min(n, self._MAX_RESULTS_PER_PAGE),
+        }
+
+        entries = []
+        for page_num in itertools.count(1):
+            queryObject.update({'offset': (page_num - 1) * queryObject['size']})
+            results = self._download_json('https://mediathekviewweb.de/api/query', query,
+                note='Fetching page %d' % page_num,
+                data=json.dumps(queryObject).encode('utf-8'),
+                headers={'Content-Type': 'text/plain'})
+            if results['err'] is not None:
+                raise ExtractorError('API returned an error: %s' % results['err'][0])
+
+            meta = results['result']['queryInfo']
+            print(json.dumps(meta))
+
+            entries.extend(self._extract_playlist_entries(results['result']['results']))
+
+            # @todo This returns full pages: 100 results if 51 are requested.
+            if meta['resultCount'] == 0 or meta['resultCount'] + queryObject['offset'] >= n:
+                break
+
+        return self.playlist_result(entries, playlist_title=query)
+
+class MediathekViewWebIE(InfoExtractor):
+    # @see https://github.com/mediathekview/mediathekviewweb
+    IE_NAME = 'mediathekviewweb'
+    _VALID_URL = r'https?://mediathekviewweb\.de/\#query=(?P<id>.+)'
+
+    # @todo Specify test cases.
+
+    def _real_extract(self, url):
+        query = self._match_id(url)
+        search = compat_urllib_parse_unquote(query)
+        return {
+            '_type': 'url',
+            'url': 'mvwsearchall:' + search,
+            'ie_key': 'MediathekViewWebSearch',
+        }

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -25,8 +25,8 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
 
     # Map of title affixes indicating video variants.
     _variants = {
-        'audio_description': '(Audiodeskription)',
-        'sign_language': '(mit Gebärdensprache)',
+        'audio_description': 'Audiodeskription',
+        'sign_language': 'mit Gebärdensprache',
     }
     _future = True
     _everywhere = False
@@ -108,7 +108,7 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
             formats = []
             formats.append({
                 'url': item['url_video'],
-                'format': ('medium ' + self._variants[variant]) if variant else None,
+                'format': ('medium (' + self._variants[variant] + ')') if variant else None,
                 'format_id': ('medium-' + variant) if variant else 'medium',
                 'language_preference': -10 if variant else 10,
                 'quality': -2,
@@ -117,7 +117,7 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
             if len(item.get('url_video_low', '')) > 0:
                 formats.append({
                     'url': item['url_video_low'],
-                    'format': ('low ' + self._variants[variant]) if variant else None,
+                    'format': ('low (' + self._variants[variant] + ')') if variant else None,
                     'format_id': ('low-' + variant) if variant else 'low',
                     'language_preference': -10 if variant else 10,
                     'quality': -3,
@@ -125,7 +125,7 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
             if len(item.get('url_video_hd', '')) > 0:
                 formats.append({
                     'url': item['url_video_hd'],
-                    'format': ('high ' + self._variants[variant]) if variant else None,
+                    'format': ('high (' + self._variants[variant] + ')') if variant else None,
                     'format_id': ('high-' + variant) if variant else 'high',
                     'language_preference': -10 if variant else 10,
                     'quality': -1,

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -26,7 +26,7 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
         {
             # Audio description & common topic.
             'url': 'mvwsearch:#Sendung,Maus Audiodeskription',
-            'info_dict' : {
+            'info_dict': {
                 'title': 'Die Sendung mit der Maus',
             },
             'playlist': [],

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -210,9 +210,9 @@ class MediathekViewWebIE(InfoExtractor):
         if len(query) > 0:
             # Detect global flags, MVW is very strict about accepted values.
             extractor = MediathekViewWebSearchIE(self._downloader)
-            if query.get('everywhere', [])[0] == 'true':
+            if query.get('everywhere', []) == ['true']:
                 extractor._everywhere = True
-            if query.get('future', [])[0] == 'false':
+            if query.get('future', []) == ['false']:
                 extractor._future = False
             return extractor._real_extract('mvwsearchall:' + search)
 

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -187,7 +187,13 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
             elif meta['resultCount'] == 0:
                 break
 
-        return self.playlist_result(entries, playlist_title=query)
+        common_topic = None
+        if entries:
+            common_topic = entries[0]['series']
+            for entry in entries:
+                common_topic = common_topic if entry['series'] == common_topic else None
+
+        return self.playlist_result(entries, playlist_title=common_topic or query)
 
 
 class MediathekViewWebIE(InfoExtractor):

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -165,14 +165,11 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
                 headers={'Content-Type': 'text/plain'})
             if results['err'] is not None:
                 raise ExtractorError('API returned an error: %s' % results['err'][0])
-
-            meta = results['result']['queryInfo']
-            print(json.dumps(meta))
-
             entries.extend(self._extract_playlist_entries(results['result']['results']))
 
+            meta = results['result']['queryInfo']
             # @todo This returns full pages: 100 results if 51 are requested.
-            if meta['resultCount'] == 0 or meta['resultCount'] + queryObject['offset'] >= n:
+            if len(entries) >= n or meta['resultCount'] == 0:
                 break
 
         return self.playlist_result(entries, playlist_title=query)
@@ -183,7 +180,6 @@ class MediathekViewWebIE(InfoExtractor):
     _VALID_URL = r'https?://mediathekviewweb\.de/\#query=(?P<id>.+)'
 
     # @todo Specify test cases.
-
     def _real_extract(self, url):
         query = self._match_id(url)
         search = compat_urllib_parse_unquote(query)

--- a/youtube_dl/extractor/mediathekviewweb.py
+++ b/youtube_dl/extractor/mediathekviewweb.py
@@ -13,15 +13,43 @@ class MediathekViewWebSearchIE(SearchInfoExtractor):
     _SEARCH_KEY = 'mvwsearch'
     _MAX_RESULTS = float('inf')
     _MAX_RESULTS_PER_PAGE = 50
-    # _GEO_COUNTRIES = ['DE']
 
-    # _TESTS = [{
-    #     'url': 'mvwsearch:tagesschau',
-    #     'info_dict': {
-    #         'title': 'post-avant jazzcore',
-    #     },
-    #     'playlist_count': 15,
-    # }]
+    _TESTS = [
+        {
+            'url': 'mvwsearchall:sandmännchen !kika',
+            'info_dict': {
+                'title': 'Unser Sandmännchen',
+            },
+            'playlist': [],
+            'playlist_count': 7,
+        },
+        {
+            # Audio description & common topic.
+            'url': 'mvwsearch:#Sendung,Maus Audiodeskription',
+            'info_dict' : {
+                'title': 'Die Sendung mit der Maus',
+            },
+            'playlist': [],
+            'playlist_count': 1,
+            'params': {
+                'format': 'medium-audio_description',
+                'skip_download': True,
+            }
+        },
+        {
+            # Sign language.
+            'url': 'mvwsearchall:!ard #Tagesschau Gebärdensprache',
+            'info_dict': {
+                'title': '!ard #Tagesschau Gebärdensprache',
+            },
+            'playlist': [],
+            'playlist_mincount': 365,
+            'params': {
+                'format': 'medium-sign_language',
+                'skip_download': True,
+            },
+        },
+    ]
 
     # Map of title affixes indicating video variants.
     _variants = {
@@ -201,9 +229,32 @@ class MediathekViewWebIE(InfoExtractor):
     IE_NAME = 'mediathekviewweb'
     _VALID_URL = r'https?://mediathekviewweb\.de/\#query=(?P<id>.+)'
 
-    # @todo Specify test cases.
-    # https://mediathekviewweb.de/#query=%23tagesschau%20%3E5&everywhere=true&future=false
-    # & und ! #: https://mediathekviewweb.de/#query=%26%20und%20!%20%23
+    _TESTS = [
+        {
+            # Test for everywhere.
+            'url': 'https://mediathekviewweb.de/#query=!ard%20%23Tagesschau%2020%2CUhr&everywhere=true',
+            'info_dict': {
+                'title': '!ard #Tagesschau 20,Uhr',
+            },
+            # Without everywhere, there are <100 results.
+            'playlist_mincount': 365,
+            'params': {
+                'skip_download': True,
+            },
+        },
+        {
+            # Test for non-future videos.
+            'url': 'https://mediathekviewweb.de/#query=%23sport%2Cim%2Costen%20biathlon&future=false',
+            'info_dict': {
+                'title': 'Sport im Osten',
+            },
+            # Future yields 4 results instead.
+            'playlist_maxcount': 2,
+            'params': {
+                'skip_download': True,
+            },
+        },
+    ]
 
     def _real_extract(self, url):
         query_hash = self._match_id(url)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

[MediathekView](https://mediathekview.de/) ([GitHub](https://github.com/mediathekview/MediathekView)) is a free tool to browse the online media libraries from german public broadcasters, such as ARD, MDR, KiKa and so on ([full list](https://mediathekviewweb.de/api/channels)). There is also an [online tool](https://mediathekviewweb.de/) (MediathekViewWeb, short MVW) by the [same creators](https://github.com/mediathekview), which provides the API used by this extrator. 
Many items are already accessible using existing extractors, such as WDR, MDR or ARD and ZDF. However, MVW combines these and allows for filtering by channel, title, topic/series, description and duration - across channels. Results also include videos with accessibility aids, such as audio description or sign language, as well as subtitles (depending on the video). 

While the service has encountered legal issues before, they have been dropped or were solved by mutual agreement. A recent one (07/2020) is documented [on their page](https://mediathekview.de/news/abmahnung_mediathekview/):
> Abschließend möchten wir nochmals betonen, dass wir nur Links zu Filmen zur Verfügung stellen, welche auch von den jeweiligen Mediatheken angeboten werden. An dieser Praxis wird sich auch in Zukunft nichts ändern. Wir werden auch weiterhin keine anderweitigen Links zu etwaigen Filmen anbieten und auch wie gehabt im Forum Verstöße gegen diese Regeln ahnden.

The MR provides a) a search-type extractor named `mvwsearch` and b) an url-based extractor to support the flags "everywhere" and "non-future".
Videos come in `medium` quality, though `low`/`high` quality versions may also be available. Accessibility variants use a format suffix to allow direct querying for these variants, e.g. `-f 'best[format_id$="-sign_language"]'` or `-f 'high-audio_description'`. Similarly, it is possible to explicitly exclude these variants.

Example use cases:
- Get all videos of "Sesamstraße" series which include audio descriptions:  
  `mvwsearchall:!kika #Sesamstraße Audiodeskription`
- Get all videos of "Die Sendung mit der Maus" series which include sign language:  
  `mvwsearchall:#Sendung,Maus Gebärdensprache`
- Get already aired movies:
  `https://mediathekviewweb.de/#query=%23film&future=false`

The extractor is especially easy to use, as the query results can be first tested and fine-tuned on the https://mediathekviewweb.de website. Using youtube-dl's `--match-title` and `--reject-title` parameter allows further fine-tuning, since MWV searches are case insensitive and have several characters unsupported during search (e.g. `.` or `!`).