### PR TITLE
Clarify meaning of "best" quality (bitrate vs. framerate, etc.) in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,8 @@ You can also use special names to select particular edge case formats:
  - `bestaudio`: Select the best quality audio only-format. May not be available.
  - `worstaudio`: Select the worst quality audio only-format. May not be available.
 
+(Generally, youtube-dl determines which of the available formats is "best" or "worst" by considering the following information, in descending order of importance: the descriptive quality level reported by the website (e. g., "HQ" is better than "SD"); the average bitrate of audio and video; the filesize; the video bitrate; the video height; the video width; the audio bitrate; the video framerate; the approximate filesize; and the order in which the formats are delivered by the website. Depending on the file that is being downloaded and the website from which it is being downloaded, some of this information may not be available to youtube-dl.)
+
 For example, to download the worst quality video-only format you can use `-f worstvideo`.
 
 If you want to download multiple videos and they don't have the same formats available, you can specify the order of preference using slashes. Note that slash is left-associative, i.e. formats on the left hand side are preferred, for example `-f 22/17/18` will download format 22 if it's available, otherwise it will download format 17 if it's available, otherwise it will download format 18 if it's available, otherwise it will complain that no suitable formats are available for download.


### PR DESCRIPTION
Fixes #28307

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- (the other bullet points are not applicable; this is just editing the readme, not actual code)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Clarifies (in the readme, not in any actual code) the method by which "best" or "worst" quality is determined, for users who are confused when the highest-framerate video is not downloaded by default