### PR TITLE
Get HD formats for Reel

### DIFF
--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1012,6 +1012,7 @@ class BBCIE(BBCCoUkIE):
                 topic_title = init_data.get('topicTitle')
                 ret = {
                     'title': smp_data.get('title', playlist_id),
+                    'id': version_id,
                     'alt_title': init_data.get('shortTitle'),
                     'thumbnail': image_url.replace('$recipe', 'raw') if image_url else None,
                     'description': smp_data.get('summary') or init_data.get('shortSummary'),
@@ -1025,7 +1026,6 @@ class BBCIE(BBCCoUkIE):
                     formats, subtitles = self._download_media_selector(version_id)
                     self._sort_formats(formats)
                     ret.update({
-                            'id': version_id,
                             'formats': formats,
                             'subtitles': subtitles,
                         })


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---
Per https://github.com/ytdl-org/youtube-dl/issues/21870#issuecomment-789266305, we don't get the highest resolution formats through the `BBCIE` extractor. This patch gets the metadata that is available from the Reel page and then uses the `transparent_url` mechanism to get the formats, which now include 1280x720 as well as the 960x540 and lower available from the BBCIE extractor.
