### PR TITLE
Fix BBCCoUkIPlayerPlaylistIE

### DIFF
--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1368,7 +1368,7 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             r'<script[^>]+id=(["\'])tvip-script-app-store\1[^>]*>[^<]*_REDUX_STATE__\s*=\s*(?P<json>[^<]+)\s*;\s*<',
             webpage, 'redux state', default='{}', group='json'), playlist_id, fatal=False)
         if redux_state:
-            redux_hdr = redux_state.get('header') or {}                               
+            redux_hdr = redux_state.get('header') or {}
             redux_hdr.update(redux_state.get('page') or {})
             redux_state = redux_hdr
         title = redux_state.get('title') or self._og_search_title(webpage, fatal=False)

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1372,9 +1372,9 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             redux_hdr.update(redux_state.get('page') or {})
             redux_state = redux_hdr
         title = redux_state.get('title') or self._og_search_title(webpage, fatal=False)
-        description = (redux_state.get('description') or 
-                       self._html_search_meta('description', webpage, default=None) or 
-                       self._og_search_description(webpage))
+        description = redux_state.get('description') or \
+                        self._html_search_meta('description', webpage, default=None) or \
+                        self._og_search_description(webpage)
         return title, description
 
 

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1372,7 +1372,9 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             redux_hdr.update(redux_state.get('page') or {})
             redux_state = redux_hdr
         title = redux_state.get('title') or self._og_search_title(webpage, fatal=False)
-        description = redux_state.get('description') or self._og_search_description(webpage)
+        description = (redux_state.get('description') or 
+                       self._html_search_meta('description', webpage, default=None) or 
+                       self._og_search_description(webpage))
         return title, description
 
 

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1373,8 +1373,8 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             redux_state = redux_hdr
         title = redux_state.get('title') or self._og_search_title(webpage, fatal=False)
         description = redux_state.get('description') or \
-                        self._html_search_meta('description', webpage, default=None) or \
-                        self._og_search_description(webpage)
+                      self._html_search_meta('description', webpage, default=None) or \
+                      self._og_search_description(webpage)
         return title, description
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The `BBCCoUkIPlayerPlaylistIE` extractor was failing, whereas `BBCCoUkPlaylistIE` still worked for the same pids: eg, the `_TESTS`.

In the IPlayer series pages, the playlist metadata is now sent in a JSON expression within a <script> element, and this patch extracts the `title` and `description` from it, and modifies the `_VIDEO_ID_TEMPLATE` to match the episode links within the `entities` subobject of the JSON.
