### PR TITLE
[bbc] Fix BBCCoUkIPlayerPlaylistIE

### DIFF
--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1318,7 +1318,7 @@ class BBCCoUkPlaylistBaseIE(InfoExtractor):
             if single_page:
                 return
             next_page = self._search_regex(
-                r'<li[^>]+class=(["\'])pagination_+next\1[^>]*>\s*<a[^>]+href=(["\'])(?P<url>(?:(?!\2).)+)\2',
+                r'(?:<li[^>]+class=(["\'])pagination_+next\1[^>]*>\s*<a|<a[^>]+\baria-label=(["\'])Next Page\2)[^>]+href=(["\'])(?P<url>(?:(?!\3).)+)\3',
                 webpage, 'next page url', default=None, group='url')
             if not next_page:
                 break
@@ -1374,6 +1374,15 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             'description': 'A trusted GP sees her charmed life explode when she suspects her husband of an affair.',
         },
         'playlist_mincount': 10,
+    }, {
+        # Playlist with more than one page
+        'url': 'https://www.bbc.co.uk/iplayer/episodes/m0004c4v/beechgrove',
+        'info_dict': {
+            'id': 'm0004c4v',
+            'title': 'Beechgrove',
+            'description': 'Gardening show that celebrates Scottish horticulture and growing conditions.',
+        },
+        'playlist_mincount': 37,
     }]
 
     def _entries(self, webpage, url, playlist_id):

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1318,7 +1318,7 @@ class BBCCoUkPlaylistBaseIE(InfoExtractor):
             if single_page:
                 return
             next_page = self._search_regex(
-                r'<li[^>]+class=(["\'])pagination_+next\1[^>]*><a[^>]+href=(["\'])(?P<url>(?:(?!\2).)+)\2',
+                r'<li[^>]+class=(["\'])pagination_+next\1[^>]*>\s*<a[^>]+href=(["\'])(?P<url>(?:(?!\2).)+)\2',
                 webpage, 'next page url', default=None, group='url')
             if not next_page:
                 break

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1344,6 +1344,9 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
     _VALID_URL = r'https?://(?:www\.)?bbc\.co\.uk/iplayer/(?:episodes|group)/(?P<id>%s)' % BBCCoUkIE._ID_REGEX
     _URL_TEMPLATE = 'http://www.bbc.co.uk/iplayer/episode/%s'
     _VIDEO_ID_TEMPLATE = r'"href":\s*"/iplayer/episode/(%s)/'
+    _SERIES_ID_TEMPLATE = '/iplayer/episodes/%s/.+[?&]seriesId=(%s)'
+    _SERIES_URL_TEMPLATE = 'http://www.bbc.co.uk/programmes/%s/episodes/player'
+
     _TESTS = [{
         'url': 'http://www.bbc.co.uk/iplayer/episodes/b05rcz9v',
         'info_dict': {
@@ -1362,7 +1365,22 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
             'description': 'md5:8b60017680e9f3115e79e0c20697a585',
         },
         'playlist_mincount': 10,
+    }, {
+        # Playlist with more than one series/season
+        'url': 'https://www.bbc.co.uk/iplayer/episodes/b094m5t9/doctor-foster',
+        'info_dict': {
+            'id': 'b094m5t9',
+            'title': 'Doctor Foster',
+            'description': 'A trusted GP sees her charmed life explode when she suspects her husband of an affair.',
+        },
+        'playlist_mincount': 10,
     }]
+
+    def _entries(self, webpage, url, playlist_id):
+        for entry in super(BBCCoUkIPlayerPlaylistIE, self)._entries(webpage, url, playlist_id):
+            yield entry
+        for series_id in re.findall(self._SERIES_ID_TEMPLATE % (playlist_id, BBCCoUkIE._ID_REGEX), webpage):
+            yield self.url_result(self._SERIES_URL_TEMPLATE % series_id)
 
     def _extract_title_and_description(self, webpage):
         redux_state = self._parse_json(self._html_search_regex(

--- a/youtube_dl/extractor/bbc.py
+++ b/youtube_dl/extractor/bbc.py
@@ -1359,7 +1359,7 @@ class BBCCoUkIPlayerPlaylistIE(BBCCoUkPlaylistBaseIE):
         'info_dict': {
             'id': 'p02tcc32',
             'title': 'Bohemian Icons',
-            'description': 'md5:683e901041b2fe9ba596f2ab04c4dbe7',
+            'description': 'md5:8b60017680e9f3115e79e0c20697a585',
         },
         'playlist_mincount': 10,
     }]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The `BBCCoUkIPlayerPlaylistIE` extractor was failing, whereas `BBCCoUkPlaylistIE` still worked for the same pids: eg, the `_TESTS`.

In the iPlayer series pages, the playlist metadata is now sent in a JSON expression within a <script> element, and this patch extracts the `title` and `description` from it, and modifies the `_VIDEO_ID_TEMPLATE` to match the episode links within the `entities` subobject of the JSON.

Also, the regex used to get the next page link for `BBCCoUkPlaylistBaseIE` didn't allow for a newline that is now sent between tags.

For multi-series iPlayer playlists, each series page is also processed.

For multi-page iPlayer playlists, the pagination regex is extended to match the "Next Page" link on these pages.