### PR TITLE
rewrite zsh completion generation

### DIFF
--- a/devscripts/zsh-completion.in
+++ b/devscripts/zsh-completion.in
@@ -3,26 +3,8 @@
 __youtube_dl() {
     local curcontext="$curcontext" fileopts diropts cur prev
     typeset -A opt_args
-    fileopts="{{fileopts}}"
-    diropts="{{diropts}}"
-    cur=$words[CURRENT]
-    case $cur in
-        :)
-            _arguments '*: :(::ytfavorites ::ytrecommended ::ytsubscriptions ::ytwatchlater ::ythistory)'
-        ;;
-        *)
-            prev=$words[CURRENT-1]
-            if [[ ${prev} =~ ${fileopts} ]]; then
-                _path_files
-            elif [[ ${prev} =~ ${diropts} ]]; then
-                _path_files -/
-            elif [[ ${prev} == "--recode-video" ]]; then
-                _arguments '*: :(mp4 flv ogg webm mkv)'
-            else
-                _arguments '*: :({{flags}})'
-            fi
-        ;;
-    esac
+    _arguments {{args}} \
+      '*: :(::ytfavorites ::ytrecommended ::ytsubscriptions ::ytwatchlater ::ythistory)'
 }
 
 __youtube_dl

--- a/devscripts/zsh-completion.py
+++ b/devscripts/zsh-completion.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import os
 from os.path import dirname as dirn
 import sys
+import optparse
 
 sys.path.insert(0, dirn(dirn((os.path.abspath(__file__)))))
 import youtube_dl
@@ -15,31 +16,45 @@ ZSH_COMPLETION_TEMPLATE = "devscripts/zsh-completion.in"
 def build_completion(opt_parser):
     opts = [opt for group in opt_parser.option_groups
             for opt in group.option_list]
-    opts_file = [opt for opt in opts if opt.metavar == "FILE"]
-    opts_dir = [opt for opt in opts if opt.metavar == "DIR"]
 
-    fileopts = []
-    for opt in opts_file:
+    # escaping is hard:
+    #  - help may contain colons
+    #  - metavar must have colons : escaped
+    #  - single quotes must be removed
+    #  - help must have square brackets [] escaped
+    def metaparse(opt):
+        if "--recode-video" == opt.get_opt_string():
+            return ":{}:(mp4 flv ogg webm mkv)".format(opt.metavar)
+        if opt.metavar is None:
+            return ""
+        if opt.metavar == "FILE":
+            return ":FILE:_files"
+        if opt.metavar == "DIR":
+            return ":DIR:_directories"
+        else:
+            return ":{}:".format(opt.metavar.replace(":", "\\:"))
+
+    def helpescape(opthelp):
+        if opthelp == optparse.SUPPRESS_HELP:
+            return ""
+        return "[{}]".format(opthelp.replace("'", "\"").replace("]", "\\]").replace("[", "\\["))
+
+    def optionexclude(opt):
+        # When an argument has a long and short version, the arguments entry shall be
+        # _arguments \
+        #   "(-t --thing)"{-t,--thing}"[do things]:WHAT_THING:"
+        # i.e. in parentheses with space the explanation of redundancy and in curly braces
+        # regular shell expansion to create two mostly identical entries.
         if opt._short_opts:
-            fileopts.extend(opt._short_opts)
-        if opt._long_opts:
-            fileopts.extend(opt._long_opts)
+            return "({0} {1})'{{{0},{1}}}'".format(opt._short_opts[0], opt.get_opt_string())
+        return "{}".format(opt.get_opt_string())
 
-    diropts = []
-    for opt in opts_dir:
-        if opt._short_opts:
-            diropts.extend(opt._short_opts)
-        if opt._long_opts:
-            diropts.extend(opt._long_opts)
-
-    flags = [opt.get_opt_string() for opt in opts]
+    mytest = ["'{}{}{}'".format(optionexclude(opt), helpescape(opt.help), metaparse(opt)) for opt in opts]
 
     with open(ZSH_COMPLETION_TEMPLATE) as f:
         template = f.read()
 
-    template = template.replace("{{fileopts}}", "|".join(fileopts))
-    template = template.replace("{{diropts}}", "|".join(diropts))
-    template = template.replace("{{flags}}", " ".join(flags))
+    template = template.replace("{{args}}", " \\\n      ".join(mytest))
 
     with open(ZSH_COMPLETION_FILE, "w") as f:
         f.write(template)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

So far the auto generated youtube-dl.zsh file takes little advantage of zsh's completion infrastructure. This PR changes the generated file to use `_arguments` directly and generate entries like

```
      '(-A --auto-number)'{-A,--auto-number}'' \
       '--write-annotations[Write video annotations to a .annotations.xml file]' \
       '--load-info-json[JSON file containing the video information (created with the "--write-info-json" option)]:FILE:_files' \
       '--cookies[File to read cookies from and dump cookie jar in]:FILE:_files' \
```
This does

 - `'(-A --auto-number)'` : if either `-A` or `--auto-number` are already present on the command line, neither is recommended again. (An option is by default anyway not suggested twice. The parentheses are to also drop the respective other).
  - `[Write video anotations to ...]` These are brief explanation that are shown in the list of completions (such that one doesn't have to switch back and forth between reading the man page and writing the command). It can look (depending on user settings) like that
  ```
  youtube-dl --write-TAB
  user@host:~/coding/youtube-dl > youtube-dl --write-TAB
option:
--write-all-thumbnails  -- Write all thumbnail image formats to disk
--write-annotations     -- Write video annotations to a .annotations.xml file
--write-auto-sub        -- Write automatically generated subtitle file (YouTube only)
--write-description     -- Write video description to a .description file
--write-info-json       -- Write video metadata to a .info.json file
```
 - `:FILE:_files` the trailing colon after the quick help indicates that the flag takes an argument, such that no other flags are suggested until the missing argument to the option is provided The entry between the first and second colon is a help that's maybe shown to the user (depending on settings…) and the zsh completion function after the colon - if given - provides further completion. (The man page zshcompsys explains that one should favour `_files` over `_path_files`, e.g. because a user can better configure their preferences.) If nothing follows the second colon, no automatic completion happens, the user has to type, as in the case of
 ```
       '--external-downloader-args[Give these arguments to the external downloader]:ARGS:' \
```
