### PR TITLE
Attempt to fix audio postprocessing bug (#8366)

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -792,7 +792,7 @@ def parseOpts(overrideArguments=None):
         help='Specify audio format: "best", "aac", "flac", "mp3", "m4a", "opus", "vorbis", or "wav"; "%default" by default; No effect without -x')
     postproc.add_option(
         '--audio-quality', metavar='QUALITY',
-        dest='audioquality', default='5',
+        dest='audioquality', default=None,
         help='Specify ffmpeg/avconv audio quality, insert a value between 0 (better) and 9 (worse) for VBR or a specific bitrate like 128K (default %default)')
     postproc.add_option(
         '--recode-video',

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -330,7 +330,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
         # Don't overwrite files if the nopostoverwrites option is active or if
         # ffmpeg would just copy them anyway
-        if (new_path == path and acodec == 'copy') or (self._nopostoverwrites and os.path.exists(encodeFilename(new_path))):
+        if (new_path == path and acodec == 'copy' and not self._configuration_args()) or (self._nopostoverwrites and os.path.exists(encodeFilename(new_path))):
             self._downloader.to_screen('[ffmpeg] Post-process file %s exists, skipping' % new_path)
             return [], information
 

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -274,10 +274,10 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
             raise PostProcessingError('WARNING: unable to obtain file audio codec with ffprobe')
 
         more_opts = []
-        if (self._preferredcodec == 'best' 
-            or (self._preferredquality is None 
+        if (self._preferredcodec == 'best'
+            or (self._preferredquality is None
                 and (self._preferredcodec == filecodec
-                    or (self._preferredcodec == 'm4a' and filecodec == 'aac')))):
+                     or (self._preferredcodec == 'm4a' and filecodec == 'aac')))):
             if filecodec == 'aac' and self._preferredcodec in ['m4a', 'best']:
                 # Lossless, but in another container
                 acodec = 'copy'
@@ -296,22 +296,22 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 acodec = 'libmp3lame'
                 extension = 'mp3'
                 more_opts = []
-                if self._preferredquality is not None:
-                    if int(self._preferredquality) < 10:
-                        more_opts += ['-q:a', self._preferredquality]
-                    else:
-                        more_opts += ['-b:a', self._preferredquality + 'k']
+                self._preferredquality = self._preferredquality if self._preferredquality else "5"
+                if int(self._preferredquality) < 10:
+                    more_opts += ['-q:a', self._preferredquality]
+                else:
+                    more_opts += ['-b:a', self._preferredquality + 'k']
         else:
             # We convert the audio (lossy if codec is lossy)
             acodec = ACODECS[self._preferredcodec]
             extension = self._preferredcodec
             more_opts = []
-            if self._preferredquality is not None:
-                # The opus codec doesn't support the -aq option
-                if int(self._preferredquality) < 10 and extension != 'opus':
-                    more_opts += ['-q:a', self._preferredquality]
-                else:
-                    more_opts += ['-b:a', self._preferredquality + 'k']
+            self._preferredquality = self._preferredquality if self._preferredquality else "5"
+            # The opus codec doesn't support the -aq option
+            if int(self._preferredquality) < 10 and extension != 'opus':
+                more_opts += ['-q:a', self._preferredquality]
+            else:
+                more_opts += ['-b:a', self._preferredquality + 'k']
             if self._preferredcodec == 'aac':
                 more_opts += ['-f', 'adts']
             if self._preferredcodec == 'm4a':
@@ -330,8 +330,7 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
 
         # Don't overwrite files if the nopostoverwrites option is active or if
         # ffmpeg would just copy them anyway
-        if ((new_path == path and acodec == 'copy')
-            or (self._nopostoverwrites and os.path.exists(encodeFilename(new_path)))):
+        if (new_path == path and acodec == 'copy') or (self._nopostoverwrites and os.path.exists(encodeFilename(new_path))):
             self._downloader.to_screen('[ffmpeg] Post-process file %s exists, skipping' % new_path)
             return [], information
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR is an attempt to fix issue #8366, a bug in FFmpegExtractAudioPP post-processor that makes it impossible to use youtube-dl to convert extracted audio to a different bitrate in the same format. 

The current behavior never converts a downloaded audio file if the desired format is the same as the original. However, if a user wants to do other post-processing, like changing the bitrate or mixing down a stereo audio file to mono while retaining the same format, the post-processor may still skip using FFmpeg altogether, or it may override their quality setting.

This PR changes the default value of the --audio-quality option (used only by FFmpegExtractAudioPP) from '5' to None, and only skips re-encoding between the same two formats if the --audio-quality option is None (i.e. the user has not explicitly set the audio quality) and the user has no custom --postprocessor-args. The default behavior (still VBR quality of 5) is now handled within the post-processor itself.  If the new file has the same filename as the old one, it will encode to filename.temp.mp3 and then overwrite the original filename.mp3. 

**I would like feedback on this PR, as I am still not entirely satisfied with it.**

In particular, I am not satisfied with the choice to simply re-encode whenever the user explicitly sets a quality, even if it is better than the current quality. This makes bigger files with quality that is actually worse. Fixing this would I think require mucking around with FFprobe to get the current quality, and even then I don't think it can account for VBR qualities.

I also don't know how overwriting the processed files should interact with the --keep-video (or audio in this case) flag. In the PR, if the new file would have the same name (and --no-post-overwrites is false), the old file is simply overwritten.

**Also:** in the course of writing this I discovered the bug fixed by the unmerged PR #20021. It causes opus files with a VBR quality setting to be encoded at that integer kbps (ie for the default of 5 it will encode at 5kbps). You should merge that PR too (it does conflict somewhat, so I can work on that if you want).

Thanks for all the great work,

- Charlie