### PR TITLE
[utils] Fix handling of comments in js_to_json

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -926,6 +926,34 @@ class TestUtil(unittest.TestCase):
         inp = '''{segments: [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}'''
         self.assertEqual(js_to_json(inp), '''{"segments": [{"offset":-3.885780586188048e-16,"duration":39.75000000000001}]}''')
 
+        inp = '''{
+            foo: "value",
+            // bar: { nested:'x' },
+            bar: { nested:'x' },
+            chaff: "something"
+        }'''
+        self.assertEqual(js_to_json(inp), '''{
+            "foo": "value",
+
+            "bar": { "nested":"x" },
+            "chaff": "something"
+        }''')
+
+        inp = '''{
+            id: "player_prog",
+            googleCast: true,
+            //extraSettings: { googleCastReceiverAppId:'1A6F2224', skin:'s3',  skinAccentColor: '0073FF'},
+            extraSettings: { googleCastReceiverAppId:'1A6F2224'},
+            mediaType: "video",
+        }'''
+        self.assertEqual(js_to_json(inp), '''{
+            "id": "player_prog",
+            "googleCast": true,
+
+            "extraSettings": { "googleCastReceiverAppId":"1A6F2224"},
+            "mediaType": "video"
+        }''')
+
     def test_js_to_json_edgecases(self):
         on = js_to_json("{abc_def:'1\\'\\\\2\\\\\\'3\"4'}")
         self.assertEqual(json.loads(on), {"abc_def": "1'\\2\\'3\"4"})

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4159,6 +4159,7 @@ def js_to_json(code):
         [0-9]+(?=\s*:)
         ''', fix_kv, code)
 
+
 def qualities(quality_ids):
     """ Get a numeric quality value out of a list of possible values """
     def q(qid):

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4067,18 +4067,22 @@ def strip_jsonp(code):
 
 
 def js_to_json(code):
-    COMMENT_RE = r'/\*(?:(?!\*/).)*?\*/|//[^\n]*'
-    SKIP_RE = r'\s*(?:{comment})?\s*'.format(comment=COMMENT_RE)
     INTEGER_TABLE = (
-        (r'(?s)^(0[xX][0-9a-fA-F]+){skip}:?$'.format(skip=SKIP_RE), 16),
-        (r'(?s)^(0+[0-7]+){skip}:?$'.format(skip=SKIP_RE), 8),
+        (r'(?s)^(0[xX][0-9a-fA-F]+)\s*:?$', 16),
+        (r'(?s)^(0+[0-7]+)\s*:?$', 8),
     )
+
+    # Remove all comments first, including all whitespace leading up to them.
+    # This regular expression is based on this Stack Overflow answer:
+    #   https://stackoverflow.com/a/25735600
+    code = re.sub(r'("(?:[^"\\]|\\[\s\S])*"|\'(?:[^\'\\]|\\[\s\S])*\')|[ \t]*//.*|[ \t]*/\*(?:[^*]|\*(?!/))*\*/',
+                  '\\1', code)
 
     def fix_kv(m):
         v = m.group(0)
         if v in ('true', 'false', 'null'):
             return v
-        elif v.startswith('/*') or v.startswith('//') or v.startswith('!') or v == ',':
+        elif v == ',':
             return ""
 
         if v[0] in ("'", '"'):
@@ -4100,13 +4104,11 @@ def js_to_json(code):
     return re.sub(r'''(?sx)
         "(?:[^"\\]*(?:\\\\|\\['"nurtbfx/\n]))*[^"\\]*"|
         '(?:[^'\\]*(?:\\\\|\\['"nurtbfx/\n]))*[^'\\]*'|
-        {comment}|,(?={skip}[\]}}])|
+        ,(?=\s*[\]}}])|
         (?:(?<![0-9])[eE]|[a-df-zA-DF-Z_])[.a-zA-Z_0-9]*|
-        \b(?:0[xX][0-9a-fA-F]+|0+[0-7]+)(?:{skip}:)?|
-        [0-9]+(?={skip}:)|
-        !+
-        '''.format(comment=COMMENT_RE, skip=SKIP_RE), fix_kv, code)
-
+        \b(?:0[xX][0-9a-fA-F]+|0+[0-7]+)(?:\s*:)?|
+        [0-9]+(?=\s*:)
+        ''', fix_kv, code)
 
 def qualities(quality_ids):
     """ Get a numeric quality value out of a list of possible values """

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4076,7 +4076,7 @@ def js_to_json(code):
     # This regular expression is based on this Stack Overflow answer:
     #   https://stackoverflow.com/a/25735600
     code = re.sub(r'("(?:[^"\\]|\\[\s\S])*"|\'(?:[^\'\\]|\\[\s\S])*\')|[ \t]*//.*|[ \t]*/\*(?:[^*]|\*(?!/))*\*/',
-                  '\\1', code)
+                  lambda m: m.group(1) or '', code)
 
     def fix_kv(m):
         v = m.group(0)

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -4127,6 +4127,9 @@ def js_to_json(code):
     code = re.sub(r'("(?:[^"\\]|\\[\s\S])*"|\'(?:[^\'\\]|\\[\s\S])*\')|[ \t]*//.*|[ \t]*/\*(?:[^*]|\*(?!/))*\*/',
                   lambda m: m.group(1) or '', code)
 
+    # Remove all ! characters
+    code = code.replace('!', '')
+
     def fix_kv(m):
         v = m.group(0)
         if v in ('true', 'false', 'null'):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

`js_to_json()` removes commas that appear right before a comment line, creating invalid JSON.

This pull request fixes this by making the conversion a two-step process. It first removes all comments and then the actual JS to JSON fix-up happens. This also somewhat simplifies the conversion as comment handling is no longer needed in the second step.

Doing it in one step makes it hard to deal properly with both commas right before comments and trailing commas at the end of a dictionary or array. A two-step approach is easy to follow and works.

The regular expression used for comment removal is not thrown off by comments within string literals. It is based on this Stack Overflow answer: https://stackoverflow.com/a/25735600

Additional tests in test/test_utils.py based on issue #23785 are also provided.

Closes #23785.

This Pull Request is a rebase of the PR provided (and approved) at #23877. As such:
Closes #23877 .