### PR TITLE
[Generic] Fix RSS items id missing

### DIFF
--- a/youtube_dl/extractor/generic.py
+++ b/youtube_dl/extractor/generic.py
@@ -2295,6 +2295,7 @@ class GenericIE(InfoExtractor):
             entries.append({
                 '_type': 'url_transparent',
                 'url': next_url,
+                'id': it.find('guid').text,
                 'title': it.find('title').text,
                 'description': xpath_text(it, 'description', default=None),
                 'timestamp': unified_timestamp(


### PR DESCRIPTION
The items "id" on a playlist, from a RSS feed is missing (despite the unit test). I used the tag <guid> ot item's RSS to get this unique value.
Due to this id missed, the download-archive file is not working correctly with RSS feed.

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The items "id" on a playlist, from a RSS feed is missing (despite the unit test). I used the tag <guid> item's RSS to get this unique value.
Due to this id missed, the download-archive file is not working correctly with RSS feed.
I didn't add another unit test because they are already there.