### PR TITLE
WIP: fix for password protected videos

### DIFF
--- a/youtube_dl/extractor/vimeo.py
+++ b/youtube_dl/extractor/vimeo.py
@@ -662,6 +662,10 @@ class VimeoIE(VimeoBaseInfoExtractor):
             token, vuid = self._extract_xsrft_and_vuid(webpage)
             webpage = self._verify_video_password(
                 redirect_url, video_id, video_password, token, vuid)
+            config = self._verify_player_video_password(
+                "https://player.vimeo.com/video/" + video_id, video_id, headers)
+            info = self._parse_config(config, video_id)
+            self._vimeo_sort_formats(info['formats'])
 
         vimeo_config = self._extract_vimeo_config(webpage, video_id, default=None)
         if vimeo_config:


### PR DESCRIPTION
It seems accessing password-protected videos have changed. Checking one from vimeo.com I noticed it was POSTing to player.vimeo.com for check-password and noticed the only codepath doing it in the extractor was not taken.
It also happens for videos already in the tests:

For videos like http://vimeo.com/68375962 we had:
Unable to download JSON metadata: HTTP Error 403: Forbidden

I'm not yet sure if it's required every time or if it should be conditional to some URL match though…