### PR TITLE
[youtube:tab] make playlist extraction work on youtube-series

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2009,6 +2009,15 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
             'description': 'md5:be97ee0f14ee314f1f002cf187166ee2',
         },
     }, {
+        # playlists, series
+        'url': 'https://www.youtube.com/c/3blue1brown/playlists?view=50&sort=dd&shelf_id=3',
+        'playlist_mincount': 5,
+        'info_dict': {
+            'id': 'UCYO_jab_esuFRV4b17AJtAw',
+            'title': '3Blue1Brown - Playlists',
+            'description': 'md5:e1384e8a133307dd10edee76e875d62f',
+        },
+    }, {
         # playlists, singlepage
         'url': 'https://www.youtube.com/user/ThirstForScience/playlists',
         'playlist_mincount': 4,
@@ -2297,7 +2306,7 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
 
     @staticmethod
     def _extract_grid_item_renderer(item):
-        for item_kind in ('Playlist', 'Video', 'Channel'):
+        for item_kind in ('Playlist', 'Video', 'Channel', 'Show'):
             renderer = item.get('grid%sRenderer' % item_kind)
             if renderer:
                 return renderer
@@ -2330,6 +2339,19 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
                 yield self.url_result(
                     'https://www.youtube.com/channel/%s' % channel_id,
                     ie=YoutubeTabIE.ie_key(), video_title=title)
+            # show
+            if playlist_id is None:  # needs to check for playlist_id, or non-series playlists are recognized twice
+                show_playlist_url = try_get(
+                    renderer, lambda x: x['navigationEndpoint']['commandMetadata']['webCommandMetadata']['url'],
+                    compat_str)
+                if show_playlist_url:
+                    playlist_id = self._search_regex(r'/playlist\?list=([0-9a-zA-Z-_]+)', show_playlist_url,
+                                                     'playlist id', default=None)
+                    if playlist_id:
+                        title = try_get(renderer, lambda x: x['title']['simpleText'], compat_str)
+                        yield self.url_result(
+                            "https://www.youtube.com/playlist?list=%s" % playlist_id,
+                            ie=YoutubeTabIE.ie_key(), video_id=playlist_id, video_title=title)
 
     def _shelf_entries_from_content(self, shelf_renderer):
         content = shelf_renderer.get('content')


### PR DESCRIPTION
fixes #28723

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This provides a fix for #28723 by extending the youtube-extractor with code that recognizes the playlist_id's of youtube-series. See #28723 for an example. That example is also used as test.