### PR TITLE
Improve handling of SIGINT to ease shell scripting with ytdl

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -478,7 +478,13 @@ def main(argv=None):
     except SameFileError:
         sys.exit('ERROR: fixed output name but more than one file to download')
     except KeyboardInterrupt:
-        sys.exit('\nERROR: Interrupted by user')
+        print('\nERROR: Interrupted by user')
+        # 'wait and cooperative exit' handling of SIGINT
+        # this signals our parent that we exited because of SIGINT
+        # the compatible parent shell can then stop script execution
+        import signal
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        os.kill(os.getpid(), signal.SIGINT)
 
 
 __all__ = ['main', 'YoutubeDL', 'gen_extractors', 'list_extractors']


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) - Not an extractor
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them - seems to focus on extractors
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED) - i have no idea how to test this programmatically
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8) - no output

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This change allows compatible shells to stop script execution when youtube-dl exited because of a SIGINT (often Ctrl-C).
It enables the user to stop a shell script, which executes youtube-dl.

The behaviour is called "wait and cooperative exit" and described at https://www.cons.org/cracauer/sigint.html

Basically we signal the parent process that we exited because of SIGINT when that is the case.
Compatible shells will then stop script execution as the user apparently wishes so.
This works by resetting the signal handler to default and sending ourselves another SIGINT.

I was told that this behaviour might be part of the POSIX Standard, so it should work on other platforms too.
Worst case is no change to the current behaviour.

I only tested it on Ubuntu 18.04, **please test on Windows and Mac.**

Testcase:
```
python youtube-dl/youtube_dl/__main__.py -o test "https://www.youtube.com/watch?v=3QFVLZ1cnOs"
echo "FAILED - script should have exited on SIGINT"
```
When you interrupt this script, the second line should not be executed with this change.
Previously the shell would continue and you had to spam Ctrl-C to stop it - especially when executing a loop.
