### PR TITLE
[webarchive] Added new extractor for the web archive (closes #13655)

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1520,6 +1520,7 @@ from .wdr import (
     WDRElefantIE,
     WDRMobileIE,
 )
+from .webarchive import WebArchiveIE
 from .webcaster import (
     WebcasterIE,
     WebcasterFeedIE,

--- a/youtube_dl/extractor/webarchive.py
+++ b/youtube_dl/extractor/webarchive.py
@@ -1,0 +1,54 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class WebArchiveIE(InfoExtractor):
+    _VALID_URL = r'https?:\/\/(?:www\.)?web\.archive\.org\/web\/([0-9]+)\/https?:\/\/(?:www\.)?youtube\.com\/watch\?v=(?P<id>[0-9A-Za-z_-]{1,11})$'
+    _TEST = {
+        'url': 'https://web.archive.org/web/20150415002341/https://www.youtube.com/watch?v=aYAGB11YrSs',
+        'md5': 'ec44dc1177ae37189a8606d4ca1113ae',
+        'info_dict': {
+            'url': 'https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/aYAGB11YrSs',
+            'id': 'aYAGB11YrSs',
+            'ext': 'mp4',
+            'title': 'Team Fortress 2 - Sandviches!',
+            'author': 'Zeurel',
+        }
+    }
+
+    def _real_extract(self, url):
+        # Get video ID and page
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        # Extract title and author
+        title = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'title').strip()
+        author = self._html_search_regex(r'"author":"([a-zA-Z0-9]+)"', webpage, 'author').strip()
+
+        # Parse title
+        if title.endswith(' - YouTube'):
+            title = title[:-10]
+
+        # Use link translator mentioned in https://github.com/ytdl-org/youtube-dl/issues/13655
+        link_stub = "https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/"
+
+        # Extract hash from url
+        hash_idx = url.find("watch?v=") + len("watch?v=")
+        youtube_hash = url[hash_idx:]
+
+        # If there's an ampersand, cut off before it
+        ampersand = youtube_hash.find('&')
+        if ampersand != -1:
+            youtube_hash = youtube_hash[:ampersand]
+
+        # Recreate the fixed pattern url and return
+        reconstructed_url = link_stub + youtube_hash
+        return {
+            'url': reconstructed_url,
+            'id': video_id,
+            'title': title,
+            'author': author,
+            'ext': "mp4"
+        }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Added functionality for downloading YouTube videos from the Web Archive. Resolves issue #13655. Converts provided urls by appending the YouTube ID to https://web.archive.org/web/2oe_/http://wayback-fakeurl.archive.org/yt/ as given in the comments under the original issue.