### PR TITLE
Added Feature to Download Youtube Profile Photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          url,ffmpeg,httpie,wget
     --external-downloader-args ARGS      Give these arguments to the external
                                          downloader
+    --profile-picture True               Allows user to download profile picture
+                                         of user who uploaded video
 
 ## Filesystem Options:
     -a, --batch-file FILE                File containing URLs to download ('-'

--- a/test/test_download_profile_photo.py
+++ b/test/test_download_profile_photo.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Allow direct execution
+import os
+import sys
+from pathlib import Path
+import shutil
+import subprocess
+# import unittest
+# sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# from test.helper import (
+#     assertGreaterEqual,
+#     expect_warnings,
+#     get_params,
+#     gettestcases,
+#     expect_info_dict,
+#     try_rm,
+#     report_warning,
+# )
+
+
+# import hashlib
+# import io
+# import json
+# import socket
+
+# import youtube_dl.YoutubeDL
+
+# from youtube_dl.compat import (
+#     compat_http_client,
+#     compat_urllib_error,
+#     compat_HTTPError,
+# )
+# from youtube_dl.utils import (
+#     DownloadError,
+#     ExtractorError,
+#     format_bytes,
+#     UnavailableVideoError,
+# )
+# from youtube_dl.extractor import get_info_extractor
+
+class TestDownloadProfilePhoto():
+    def __init__(self, url, channelName, options = ""):
+        self.correctTests = 0
+        self.totalTests = 5
+
+        self.url = url
+        self.channelName = channelName
+        self.options = options
+        self.dir = Path(os.getcwd())
+        self.parent_dir = self.dir.parent.absolute()
+
+        
+        
+        self. p_folder = os.path.join(self.parent_dir, "profile_pictures")
+
+       
+    def set_url(self, url):
+        self.url = url
+
+    def set_channelName(self, channelName):
+        self.channelName = channelName
+    
+    def set_options(self, options):
+        self.options = options
+
+    def test_download_profile_video(self):
+
+        if os.path.exists(self.p_folder):
+            shutil.rmtree(self.p_folder)
+
+        os.chdir(self.parent_dir)
+        os.system('python3 youtube_dl ' + self.options + ' "' + self.url + '"')
+        os.chdir(self.dir)
+        dir = os.path.join(self.parent_dir, "profile_pictures")
+        
+
+        if os.path.isfile(os.path.join(dir, self.channelName + ".png")):
+            print("Profile Download Test Passed!")
+        elif os.path.isfile(os.path.join(dir, "1.png")):
+            print("Profile Download Test Passed!")
+        else:
+            if len(self.channelName):
+                print("Error: Could not find profile photo")
+                exit(1)
+            else:
+                #If the channelName is not supplied, it should not retrieve a profile picture
+                print("Test case passed!")  
+
+if __name__ == "__main__":
+
+    # Test if profile downloader works correctly on youtube video
+    tester = TestDownloadProfilePhoto("https://www.youtube.com/watch?v=r5mx6JOn7vI", "CryptoRevolution", options = "--profile-picture True")
+    tester.test_download_profile_video()
+    
+    #Testing to make sure no errors for non-youtube sites
+    tester.set_url("https://vimeo.com/4378389")
+    tester.set_channelName("")
+    tester.test_download_profile_video()
+    
+    #Testing to make sure no errors on playlists (download profile photo currently does not work with playlists)
+    tester.set_url("https://www.youtube.com/watch?v=GU0DhAlYCyI&list=PLh9R-kdGXNL4re22eMuWzQkapepohLWEu")
+    tester.set_options("--profile-picture True --yes-playlist")
+    tester.test_download_profile_video()
+
+
+
+
+
+
+
+        
+
+        
+
+

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -46,6 +46,7 @@ from .YoutubeDL import YoutubeDL
 
 
 def _real_main(argv=None):
+
     # Compatibility fixes for Windows
     if sys.platform == 'win32':
         # https://github.com/ytdl-org/youtube-dl/issues/820
@@ -215,7 +216,9 @@ def _real_main(argv=None):
     if opts.convertsubtitles is not None:
         if opts.convertsubtitles not in ['srt', 'vtt', 'ass', 'lrc']:
             parser.error('invalid subtitle format specified')
-
+    if opts.profile_picture is not None:
+        if opts.profile_picture != 'True':
+            parser.error('invalid option for profile picture!')
     if opts.date is not None:
         date = DateRange.day(opts.date)
     else:
@@ -405,6 +408,7 @@ def _real_main(argv=None):
         'debug_printtraffic': opts.debug_printtraffic,
         'prefer_ffmpeg': opts.prefer_ffmpeg,
         'include_ads': opts.include_ads,
+        'profile_picture': opts.profile_picture,
         'default_search': opts.default_search,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,
         'encoding': opts.encoding,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -348,6 +348,10 @@ def parseOpts(overrideArguments=None):
         '--include-ads',
         dest='include_ads', action='store_true',
         help='Download advertisements as well (experimental)')
+    selection.add_option(
+        '--profile-picture',
+        dest='profile_picture',
+        help='Set to True to download profile photo of user')
 
     authentication = optparse.OptionGroup(parser, 'Authentication Options')
     authentication.add_option(

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -39,7 +39,6 @@ import zlib
 from .compat import (
     compat_HTMLParseError,
     compat_HTMLParser,
-    compat_HTTPError,
     compat_basestring,
     compat_chr,
     compat_cookiejar,
@@ -2880,60 +2879,12 @@ class YoutubeDLCookieProcessor(compat_urllib_request.HTTPCookieProcessor):
 
 
 class YoutubeDLRedirectHandler(compat_urllib_request.HTTPRedirectHandler):
-    """YoutubeDL redirect handler
-
-    The code is based on HTTPRedirectHandler implementation from CPython [1].
-
-    This redirect handler solves two issues:
-     - ensures redirect URL is always unicode under python 2
-     - introduces support for experimental HTTP response status code
-       308 Permanent Redirect [2] used by some sites [3]
-
-    1. https://github.com/python/cpython/blob/master/Lib/urllib/request.py
-    2. https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
-    3. https://github.com/ytdl-org/youtube-dl/issues/28768
-    """
-
-    http_error_301 = http_error_303 = http_error_307 = http_error_308 = compat_urllib_request.HTTPRedirectHandler.http_error_302
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        """Return a Request or None in response to a redirect.
-
-        This is called by the http_error_30x methods when a
-        redirection response is received.  If a redirection should
-        take place, return a new Request to allow http_error_30x to
-        perform the redirect.  Otherwise, raise HTTPError if no-one
-        else should try to handle this url.  Return None if you can't
-        but another Handler might.
-        """
-        m = req.get_method()
-        if (not (code in (301, 302, 303, 307, 308) and m in ("GET", "HEAD")
-                 or code in (301, 302, 303) and m == "POST")):
-            raise compat_HTTPError(req.full_url, code, msg, headers, fp)
-        # Strictly (according to RFC 2616), 301 or 302 in response to
-        # a POST MUST NOT cause a redirection without confirmation
-        # from the user (of urllib.request, in this case).  In practice,
-        # essentially all clients do redirect in this case, so we do
-        # the same.
-
-        # On python 2 urlh.geturl() may sometimes return redirect URL
-        # as byte string instead of unicode. This workaround allows
-        # to force it always return unicode.
-        if sys.version_info[0] < 3:
-            newurl = compat_str(newurl)
-
-        # Be conciliant with URIs containing a space.  This is mainly
-        # redundant with the more complete encoding done in http_error_302(),
-        # but it is kept for compatibility with other callers.
-        newurl = newurl.replace(' ', '%20')
-
-        CONTENT_HEADERS = ("content-length", "content-type")
-        # NB: don't use dict comprehension for python 2.6 compatibility
-        newheaders = dict((k, v) for k, v in req.headers.items()
-                          if k.lower() not in CONTENT_HEADERS)
-        return compat_urllib_request.Request(
-            newurl, headers=newheaders, origin_req_host=req.origin_req_host,
-            unverifiable=True)
+    if sys.version_info[0] < 3:
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            # On python 2 urlh.geturl() may sometimes return redirect URL
+            # as byte string instead of unicode. This workaround allows
+            # to force it always return unicode.
+            return compat_urllib_request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, compat_str(newurl))
 
 
 def extract_timezone(date_str):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ X] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [X ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [X ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [X ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ X] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [X ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

Added new option to download the profile photo of the uploader of a youtube video. By using --profile-picture True, the profile photo of the user who uploaded the video will be downloaded and placed in a directory named "profile_pictures." This change is specifically for youtube videos, but will not cause errors on other sites (rather it will simply not result in a profile photo). Additionally, if the profile photo cannot be found for some reason, the program will ignore the request and not download it.

Usage: --profile-picture True: will download the profile photo of the user who uploaded the youtube video 

