### PR TITLE
Thumbnail embedding for OGG, OPUS and FLAC

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -18,6 +18,8 @@ from ..utils import (
 )
 
 from base64 import b64encode
+from shutil import copyfile
+
 
 class EmbedThumbnailPPError(PostProcessingError):
     pass
@@ -129,15 +131,15 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         elif info['ext'] in ['opus', 'ogg', 'flac']:
             try:
                 from mutagen.oggvorbis import OggVorbis
-                from mutagen.oggopus   import OggOpus
-                from mutagen.flac      import Picture, FLAC
+                from mutagen.oggopus import OggOpus
+                from mutagen.flac import Picture, FLAC
             except ImportError:
                 raise EmbedThumbnailPPError('mutagen was not found. Please install.')
 
             # to prevent the behaviour of in-place modification of Mutagen
-            shutil.copyfile(filename, temp_filename)
+            copyfile(filename, temp_filename)
 
-            aufile = {'opus': OggOpus, 'flac': FLAC, 'ogg', OggVorbis}[info['ext']](temp_filename)
+            aufile = {'opus': OggOpus, 'flac': FLAC, 'ogg': OggVorbis}[info['ext']](temp_filename)
 
             covart = Picture()
             covart.data = open(thumbnail_filename, 'rb').read()
@@ -151,7 +153,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
             self._downloader.to_screen('[mutagen] Adding thumbnail to "%s"' % temp_filename)
             aufile.save()
-            
+
             if not self._already_have_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))
             os.remove(encodeFilename(filename))


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Thumbnail embedding is as of now limited to **mp3**, **mp4**/**m4a** which is inconvenient for some people (eg. #22338, me). This is issue is insolvable by FFmpeg as [it is inable to write `METADATA_BLOCK_PICTURE` VorbisComment field](https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/vorbiscomment.c#L33-L39).

This PR adds support for embedding thumbnails into OGGVorbis, OGGOpus, FLAC files using [mutagen](https://github.com/quodlibet/mutagen) as optional dependency  which is easily installable from `pip`.

This pull request was again filed, due to my fork being taken down due to DMCA.
