### PR TITLE
cda: fix bug, when cda link was in form cda.pl/video/[id]/vfilm

### DIFF
--- a/youtube_dl/extractor/cda.py
+++ b/youtube_dl/extractor/cda.py
@@ -196,9 +196,14 @@ class CDAIE(InfoExtractor):
             else:
                 handler = self._download_webpage
 
-            webpage = handler(
-                self._BASE_URL + href, video_id,
-                'Downloading %s version information' % resolution, fatal=False)
+            if "vfilm" in href:
+                webpage = handler(
+                    href, video_id,
+                    'Downloading %s version information' % resolution, fatal=False)
+            else:
+                webpage = handler(
+                    self._BASE_URL + href, video_id,
+                    'Downloading %s version information' % resolution, fatal=False)
             if not webpage:
                 # Manually report warning because empty page is returned when
                 # invalid version is requested.


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests (no Pr's with `cda` in title/body)
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request fixes #28936 .
because my issue was closed, without any reason, and I wasn't able to find `duplication` I decided to fix this bug myself.
these chenges should fix bug, when URLs like https://cda.pl/video/[id]/vfilm was not downloaded
btw, I'm not a native python developer, so let me know, if there is another (better) solution of this problem.