### PR TITLE
[Funimation] allow for URLs with language codes

### DIFF
--- a/youtube_dl/extractor/funimation.py
+++ b/youtube_dl/extractor/funimation.py
@@ -51,6 +51,9 @@ class FunimationIE(InfoExtractor):
     }, {
         'url': 'https://www.funimationnow.uk/shows/puzzle-dragons-x/drop-impact/simulcast/',
         'only_matching': True,
+    }, {
+        'url': 'https://www.funimation.com/en/shows/hacksign/role-play/',
+        'only_matching': True,
     }]
 
     def _login(self):

--- a/youtube_dl/extractor/funimation.py
+++ b/youtube_dl/extractor/funimation.py
@@ -16,7 +16,7 @@ from ..utils import (
 
 
 class FunimationIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?funimation(?:\.com|now\.uk)/shows/[^/]+/(?P<id>[^/?#&]+)'
+    _VALID_URL = r'https?://(?:www\.)?funimation(?:\.com|now\.uk)/(?:[a-z]{2}/)?shows/[^/]+/(?P<id>[^/?#&]+)'
 
     _NETRC_MACHINE = 'funimation'
     _TOKEN = None


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is a follow up to #28950. This fixes #28879. Funimation recently made an update to include the two-letter language code in URLs. This change allows the new URL format in addition to the old one. The old format does not work for me (see output below) so the unit tests fail for me. Apparently they work for others so I left them as is.

```
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'--verbose', u'--skip-download', u'https://www.funimation.com/shows/hacksign/role-play/']
[debug] Encodings: locale cp1252, fs mbcs, out UTF-8, pref cp1252
[debug] youtube-dl version 2021.04.26
[debug] Python version 2.7.17 (CPython) - Windows-10-10.0.18362
[debug] exe versions: ffmpeg git-2020-04-17-889ad93, ffprobe git-2020-04-17-889ad93
[debug] Proxy map: {}
[Funimation] role-play: Downloading webpage
WARNING: [Funimation] role-play: Failed to parse JSON No JSON object could be decoded
ERROR: Unable to extract al:web:url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\YoutubeDL.py", line 806, in wrapper
    return func(self, *args, **kwargs)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\YoutubeDL.py", line 827, in __extract_info
    ie_result = ie.extract(url)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\extractor\common.py", line 534, in extract
    ie_result = self._real_extract(url)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\extractor\funimation.py", line 101, in _real_extract
    ], webpage, fatal=True)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\extractor\common.py", line 1142, in _html_search_meta
    html, display_name, fatal=fatal, group='content', **kwargs)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\extractor\common.py", line 1021, in _html_search_regex
    res = self._search_regex(pattern, string, name, default, fatal, flags, group)
  File "C:\Users\Nasir\source\repos\youtube-dl-1\youtube_dl\extractor\common.py", line 1012, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
RegexNotFoundError: Unable to extract al:web:url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.


Process finished with exit code 1
```