### PR TITLE
[bigo] Add extractor (closes #18357)

### DIFF
--- a/youtube_dl/extractor/bigo.py
+++ b/youtube_dl/extractor/bigo.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    urlencode_postdata,
+    ExtractorError,
+)
+
+
+class BigoIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?bigo\.tv/(?:[a-z]{2,}/)?(?P<id>[^/]+)'
+    # Note: I would like to provide some real test, but Bigo is a live streaming
+    # site, and a test would require that the broadcaster is live at the moment.
+    # So, I don't have a good way to provide a real test here.
+    _TESTS = [{
+        'url': 'https://www.bigo.tv/th/Tarlerm1304',
+        'only_matching': True,
+    }, {
+        'url': 'https://bigo.tv/115976881',
+        'only_matching': True,
+    }]
+
+    def _real_extract(self, url):
+        user_id = self._match_id(url)
+
+        INFO_URL = 'https://bigo.tv/studio/getInternalStudioInfo'
+        info_raw = self._download_json(
+            INFO_URL, user_id, data=urlencode_postdata({'siteId': user_id}))
+
+        if info_raw['code'] != 0:
+            if self._downloader.params.get('verbose', False):
+                self.to_screen(
+                    '[debug] getInternalStudioInfo returns code %i, msg "%s"'
+                    % (info_raw['code'], info_raw['msg']))
+
+            raise ExtractorError(
+                "Failed to get user's data. Most likely the user doesn't exist",
+                expected=True)
+        info = info_raw['data']
+
+        alive = info.get('alive')
+        if alive is not None and alive == 0:
+            raise ExtractorError(
+                'User "%s" is not live at the moment' % user_id,
+                expected=True)
+
+        return {
+            'id': info.get('roomId') or user_id,
+            'title': info.get('roomTopic'),
+            'url': info.get('hls_src'),
+            'ext': 'mp4',
+            'thumbnail': info.get('snapshot'),
+            'uploader': info.get('nick_name'),
+            'is_live': True,
+        }

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -114,6 +114,7 @@ from .bfmtv import (
 )
 from .bibeltv import BibelTVIE
 from .bigflix import BigflixIE
+from .bigo import BigoIE
 from .bild import BildIE
 from .bilibili import (
     BiliBiliIE,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
  - I would like to provide some real tests, but Bigo is a live streaming site, and a test would require that the broadcaster is live at the moment. Currently, the code is covered only by `only_matching` tests.
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR adds a new extractor for https://bigo.tv. Bigo is a live streaming platform, focused on engagement between broadcasters and viewers. Viewers can chat & send gifts (using real money) to the broadcaster. Users primarily use the applications to watch the stream, but the website is also available.

The extractor uses an internal API which returns JSON. It checks if the user is currently live and provides an appropriate error message if they aren't.