### PR TITLE
[sohu] Fix extraction (closes #18542, closes #28944)

### DIFF
--- a/youtube_dl/extractor/sohu.py
+++ b/youtube_dl/extractor/sohu.py
@@ -16,7 +16,8 @@ from ..utils import (
 
 
 class SohuIE(InfoExtractor):
-    _VALID_URL = r'https?://(?P<mytv>my\.)?tv\.sohu\.com/.+?/(?(mytv)|n)(?P<id>\d+)\.shtml.*?'
+    _VALID_URL = r'https?://(?:my\.)?tv\.sohu\.com/.+?/.+(?:\.html|\.shtml).*?'
+    _VALID_URL_OG_URL = r'https?://(?P<mytv>my\.)?tv\.sohu\.com/.+?/(?(mytv)|n)(?P<id>\d+)\.shtml.*?'
 
     # Sohu videos give different MD5 sums on Travis CI and my machine
     _TESTS = [{
@@ -82,6 +83,29 @@ class SohuIE(InfoExtractor):
         'params': {
             'skip_download': True
         }
+    }, {
+        'url': 'https://tv.sohu.com/v/dXMvMjMyNzk5ODg5Lzc4NjkzNDY0LnNodG1s.html',
+        'info_dict': {
+            'id': '78693464',
+            'ext': 'mp4',
+            'title': '【爱范品】第31期：MWC见不到的奇葩手机',
+        }
+    }, {
+        'note': 'Video in issue #18542: https://github.com/ytdl-org/youtube-dl/issues/18542',
+        'url': 'https://tv.sohu.com/v/MjAxNzA3MTMvbjYwMDA1MzM4MS5zaHRtbA==.html',
+        'info_dict': {
+            'id': '600053381',
+            'ext': 'mp4',
+            'title': '试听：侯旭《孤鸟》',
+        },
+    }, {
+        'note': 'Video in issue #28944: https://github.com/ytdl-org/youtube-dl/issues/28944',
+        'url': 'https://tv.sohu.com/v/dXMvNTAyMjA5MTMvNjg1NjIyNTYuc2h0bWw=.html?src=pl',
+        'info_dict': {
+            'id': '68562256',
+            'ext': 'mp4',
+            'title': "Cryin'  [HD 1080p]  Chris.Botti(feat. Steven Tyler",
+        },
     }]
 
     def _real_extract(self, url):
@@ -97,7 +121,12 @@ class SohuIE(InfoExtractor):
                 'Downloading JSON data for %s' % vid_id,
                 headers=self.geo_verification_headers())
 
-        mobj = re.match(self._VALID_URL, url)
+        mobj = re.match(self._VALID_URL_OG_URL, url)
+        if mobj is None:
+            webpage = self._download_webpage(url, '')
+            url = self._og_search_url(webpage)
+            mobj = re.match(self._VALID_URL_OG_URL, url)
+
         video_id = mobj.group('id')
         mytv = mobj.group('mytv') is not None
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This PR fixes #18542 and #28944. The video platform, Sohu, changes its URL structure which makes the extractor unable to recognize the URL directly.
For example:
* previously, the expected URL structure is like: `http://my.tv.sohu.com/us/232799889/78693464.shtml`
* the new URL structure is like: `https://tv.sohu.com/v/dXMvMjMyNzk5ODg5Lzc4NjkzNDY0LnNodG1s.html`

