### PR TITLE
[safari] fix 404 on Manning videos

### DIFF
--- a/youtube_dl/extractor/safari.py
+++ b/youtube_dl/extractor/safari.py
@@ -193,6 +193,9 @@ class SafariApiIE(SafariBaseIE):
         part = self._download_json(
             url, '%s/%s' % (mobj.group('course_id'), mobj.group('part')),
             'Downloading part JSON')
+        part['web_url'] = part['asset_base_url'].replace('library/view',
+                                                         'videos') +\
+            part['videoclips'][0]['reference_id'] + '/'
         return self.url_result(part['web_url'], SafariIE.ie_key())
 
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [X] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

URL schema of videos /library/view/ would default 302 redirect to /videos/, but fails to redirect on some Manning videos, and got 404

for example
downloading playlist below
`https://learning.oreilly.com/videos/unit-testing-principles/9781617296277VE/`
the first video url is
`https://learning.oreilly.com/library/view/unit-testing-principles/9781617296277VE/UTPPP_part1.html`
but then it report 404 error:
```
ERROR: Unable to download webpage: HTTP Error 404: Not Found (caused by <HTTPError 404: 'Not Found'>); please repor
t this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  
on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```
this commit change the video url into
`https://learning.oreilly.com/videos/unit-testing-principles/9781617296277VE/9781617296277VE-UTPPP_part1/`

and it went through without problem