### PR TITLE
[core] add autonumber_reset (closes #29158)

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -192,6 +192,7 @@ class YoutubeDL(object):
     keepvideo:         Keep the video file after post-processing
     daterange:         A DateRange object, download only if the upload_date is in the range.
     skip_download:     Skip the actual download of the video file
+    autonumber_reset:  Reset autonumber counter to autonumber-start before each playlist
     cachedir:          Location of the cache files in the filesystem.
                        False to disable filesystem cache.
     noplaylist:        Download single video instead of a playlist if in doubt.
@@ -339,6 +340,7 @@ class YoutubeDL(object):
     _pps = []
     _download_retcode = None
     _num_downloads = None
+    _autonumber_index = None
     _playlist_level = 0
     _playlist_urls = set()
     _screen_file = None
@@ -353,6 +355,7 @@ class YoutubeDL(object):
         self._progress_hooks = []
         self._download_retcode = 0
         self._num_downloads = 0
+        self._autonumber_index = 0
         self._screen_file = [sys.stdout, sys.stderr][params.get('logtostderr', False)]
         self._err_file = sys.stderr
         self.params = {
@@ -643,7 +646,7 @@ class YoutubeDL(object):
             autonumber_size = self.params.get('autonumber_size')
             if autonumber_size is None:
                 autonumber_size = 5
-            template_dict['autonumber'] = self.params.get('autonumber_start', 1) - 1 + self._num_downloads
+            template_dict['autonumber'] = self.params.get('autonumber_start', 1) - 1 + self._autonumber_index
             if template_dict.get('resolution') is None:
                 if template_dict.get('width') and template_dict.get('height'):
                     template_dict['resolution'] = '%dx%d' % (template_dict['width'], template_dict['height'])
@@ -964,6 +967,9 @@ class YoutubeDL(object):
         playlist = ie_result.get('title') or ie_result.get('id')
 
         self.to_screen('[download] Downloading playlist: %s' % playlist)
+
+        if self.params.get('autonumber_reset'):
+            self._autonumber_index = 0
 
         playlist_results = []
 
@@ -1795,6 +1801,7 @@ class YoutubeDL(object):
             return
 
         self._num_downloads += 1
+        self._autonumber_index += 1
 
         info_dict['_filename'] = filename = self.prepare_filename(info_dict)
 

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -343,6 +343,7 @@ def _real_main(argv=None):
         'outtmpl_na_placeholder': opts.outtmpl_na_placeholder,
         'autonumber_size': opts.autonumber_size,
         'autonumber_start': opts.autonumber_start,
+        'autonumber_reset': opts.autonumber_reset,
         'restrictfilenames': opts.restrictfilenames,
         'ignoreerrors': opts.ignoreerrors,
         'force_generic_extractor': opts.force_generic_extractor,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -710,6 +710,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='autonumber', default=False,
         help=optparse.SUPPRESS_HELP)
     filesystem.add_option(
+        '--autonumber-reset',
+        action='store_true', dest='autonumber_reset', default=False,
+        help='Reset %(autonumber)s counter to %(autonumber_start)s before each playlist')
+    filesystem.add_option(
         '-t', '--title',
         action='store_true', dest='usetitle', default=False,
         help=optparse.SUPPRESS_HELP)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Autonumber Reset

I encountered an issue while attempting to use autonumber recently. I was attempting to download some playlists from the YouTube channel Crash Course. For each series, they have a preview video that functions as an "Episode 00". With one playlist, this is simple enough to fix. You simply add `--autonumber-start 0` and use `%(autonumber)02d` for episode indexing.

However, issues arise when passing in multiple playlists. Youtube-DL supports a variable number of URL's to be processed. When multiple playlists are passed in, the autonumber does not reset between operands. This makes sense if you're passing in individual video URL's and want them to be indexed, but for me it is important that each series have it's own indexing starting from 00.

For additional context, I am downloading these videos to be used with a media server that references TVDB. Having the "first" episode (i.e. the second video in the playlist) indexed as 01 is important to ensure that the metadata is mapped properly. So, `%(playlist_index)02d` doesn't satisfy my use case, and `%(autonumber)02d` in its current state requires me to pass in each playlist as a separate `youtube-dl` command.

I could have solved this problem by creating a PowerShell wrapper that batched a series of playlists and sent separate `youtube-dl` commands for each, but it seemed like others might benefit from having the ability to reset this counter in the future. I tested the reset functionality via local execution, but did not see an applicable space for autonumber tests in the current suite.

This is my first open-source PR submission, so feedback and advice would be appreciated. Thank you!