### PR TITLE
Setting a cookie helps to avoid http 429 errors on the Youtube "watch?v=" page.

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -8,6 +8,7 @@ import os.path
 import random
 import re
 import traceback
+import string
 
 from .common import InfoExtractor, SearchInfoExtractor
 from ..compat import (
@@ -1478,8 +1479,14 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         video_id = self._match_id(url)
         base_url = self.http_scheme() + '//www.youtube.com/'
         webpage_url = base_url + 'watch?v=' + video_id
+        # setting a random cookie helps to avoid http 429 errors
+        cookie = 'CONSENT=YES+cb.20210523-18-p0.de+FX+696; GPS=1; YSC='
+        cookie = cookie.join(random.choice(string.ascii_letters+string.digits) for i in range(11))
+        cookie = cookie + '; VISITOR_INFO1_LIVE='
+        cookie = cookie.join(random.choice(string.ascii_letters+string.digits) for i in range(11))
+        cookie = cookie +'; PREF=tz=Europe.Berlin'
         webpage = self._download_webpage(
-            webpage_url + '&bpctr=9999999999&has_verified=1', video_id, fatal=False)
+            webpage_url + '&bpctr=9999999999&has_verified=1', video_id, fatal=False, headers={'Cookie':cookie})
 
         player_response = None
         if webpage:


### PR DESCRIPTION
Seems youtube now blocks IP's very fast when requesting there "watch?v="-page. This seems NOT the case if you add a cookie to this request.
This is not a production-ready patch. I know setting a static text for the consent-date and for the global zone is far from ideal. But it works for now.