### PR TITLE
Allow embedding thumbnail in MKV as attachment (fix #10359, fix #6046)

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -42,6 +42,10 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 'Skipping embedding the thumbnail because the file is missing.')
             return [], info
 
+        # Early exit if the container is not supported
+        if info['ext'] not in ['mp3', 'm4a', 'mp4', 'mkv']:
+            raise EmbedThumbnailPPError('Only mp3, m4a/mp4 and mkv are supported for thumbnail embedding for now.')
+
         def is_webp(path):
             with open(encodeFilename(path), 'rb') as f:
                 b = f.read(12)
@@ -74,20 +78,45 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             os.rename(encodeFilename(escaped_thumbnail_jpg_filename), encodeFilename(thumbnail_jpg_filename))
             thumbnail_filename = thumbnail_jpg_filename
 
-        if info['ext'] == 'mp3':
-            options = [
-                '-c', 'copy', '-map', '0', '-map', '1',
-                '-metadata:s:v', 'title="Album cover"', '-metadata:s:v', 'comment="Cover (Front)"']
+        # Uses ffmpeg
+        if info['ext'] in ['mp3', 'mkv']:
+            if info['ext'] == 'mp3':
+                options = [
+                    '-c', 'copy', '-map', '0', '-map', '1',
+                    '-metadata:s:v', 'title="Album cover"', '-metadata:s:v', 'comment="Cover (Front)"']
+                input_paths = [filename, thumbnail_filename]
+            elif info['ext'] == 'mkv':
+                if thumbnail_filename.endswith('.png'):
+                    mimetype = 'image/png'
+                    extension = 'png'
+                else:
+                    mimetype = 'image/jpeg'
+                    extension = 'jpg'
+
+                options = [
+                    '-c', 'copy',
+                    '-map', '0',
+                    '-attach', thumbnail_filename,
+                    # https://matroska.org/technical/cover_art/index.html as pointed in #6046
+                    # No orientation detection nor dimensions checking/convertion
+                    '-metadata:s:t', 'filename=cover_land.%s' % extension,
+                    # If not given : "[matroska @ 000001458de38840] Attachment stream 2 has no mimetype tag and it cannot be deduced from the codec id."
+                    '-metadata:s:t', 'mimetype=%s' % mimetype,
+                    # Use metadata "title" so it is set as MATROSKA_ID_FILEDESC - optional
+                    # https://github.com/FFmpeg/FFmpeg/blob/9cfdf0e3322b9a451277cf36406ac4a8e4e3da74/libavformat/matroskaenc.c#L1762
+                    '-metadata:s:t', 'title=Thumbnail']
+                input_paths = [filename]
 
             self._downloader.to_screen('[ffmpeg] Adding thumbnail to "%s"' % filename)
 
-            self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options)
+            self.run_ffmpeg_multiple_files(input_paths, temp_filename, options)
 
             if not self._already_have_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))
             os.remove(encodeFilename(filename))
             os.rename(encodeFilename(temp_filename), encodeFilename(filename))
 
+        # Uses AtomicParsley
         elif info['ext'] in ['m4a', 'mp4']:
             atomicparsley = next((x
                                   for x in ['AtomicParsley', 'atomicparsley']
@@ -124,7 +153,5 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             else:
                 os.remove(encodeFilename(filename))
                 os.rename(encodeFilename(temp_filename), encodeFilename(filename))
-        else:
-            raise EmbedThumbnailPPError('Only mp3 and m4a/mp4 are supported for thumbnail embedding for now.')
 
         return [], info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
   - -> no existing tests regarding PostProcessors, are the binaries available when running thoses? Do you have examples regarding tests on PostProcessors / external commands?
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Allow embedding thumbnail in MKV as attachment ; with the following highlights:
* early exit if container format is not supported (before converting the thumbnail for nothing)
* factorize mp3 & mkv paths
* detect thumbnail orientation, with default/fallback to `cover.ext` filename
  * no attempt to use ffprobe, since ffmpeg is required to embed the thumbnail
  * the regex ensures the matched resolution is in the form `<pos.int>x<post.int>` before converting to tuple of int, uses `str_to_int`
* protect thumbnail filename using `_ffmpeg_filename_argument()`

Edit: could you please close the old https://github.com/ytdl-org/youtube-dl/pull/15445 this reimplements (with enhancements)?

Best, 