### PR TITLE
Fix umg:de as API site no longer resolves

### DIFF
--- a/youtube_dl/extractor/umg.py
+++ b/youtube_dl/extractor/umg.py
@@ -28,7 +28,7 @@ class UMGDeIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
         video_data = self._download_json(
-            'https://api.universal-music.de/graphql',
+            'https://graphql.universal-music.de/',
             video_id, query={
                 'query': '''{
   universalMusic(channel:16) {
@@ -50,17 +50,10 @@ class UMGDeIE(InfoExtractor):
 }''' % video_id})['data']['universalMusic']['video']
 
         title = video_data['headline']
-        hls_url_template = 'http://mediadelivery.universal-music-services.de/vod/mp4:autofill/storage/' + '/'.join(list(video_id)) + '/content/%s/file/playlist.m3u8'
+        hls_url_template = 'https://hls.universal-music.de/' + '/'.join(list(video_id)) + '/playlist.m3u8'
 
         thumbnails = []
         formats = []
-
-        def add_m3u8_format(format_id):
-            m3u8_formats = self._extract_m3u8_formats(
-                hls_url_template % format_id, video_id, 'mp4',
-                'm3u8_native', m3u8_id='hls', fatal='False')
-            if m3u8_formats and m3u8_formats[0].get('height'):
-                formats.extend(m3u8_formats)
 
         for f in video_data.get('formats', []):
             f_url = f.get('url')
@@ -77,11 +70,6 @@ class UMGDeIE(InfoExtractor):
             if f_type == 'Image':
                 thumbnails.append(fmt)
             elif f_type == 'Video':
-                format_id = f.get('formatId')
-                if format_id:
-                    fmt['format_id'] = format_id
-                    if mime_type == 'video/mp4':
-                        add_m3u8_format(format_id)
                 urlh = self._request_webpage(f_url, video_id, fatal=False)
                 if urlh:
                     first_byte = urlh.read(1)
@@ -89,8 +77,10 @@ class UMGDeIE(InfoExtractor):
                         continue
                     formats.append(fmt)
         if not formats:
-            for format_id in (867, 836, 940):
-                add_m3u8_format(format_id)
+            m3u8_formats = self._extract_m3u8_formats(
+                hls_url_template, 'mp4',
+                'm3u8_native', m3u8_id='hls', fatal='False')
+            formats.extend(m3u8_formats)
         self._sort_formats(formats, ('width', 'height', 'filesize', 'tbr'))
 
         return {

--- a/youtube_dl/extractor/umg.py
+++ b/youtube_dl/extractor/umg.py
@@ -58,7 +58,7 @@ class UMGDeIE(InfoExtractor):
         def add_m3u8_format(format_id):
             formats.extend(self._extract_m3u8_formats(
                 hls_url_template % format_id, video_id, 'mp4',
-                'm3u8_native', m3u8_id='hls', fatal='False'))
+                'm3u8_native', m3u8_id='hls', fatal=False))
 
         for f in video_data.get('formats', []):
             f_url = f.get('url')

--- a/youtube_dl/extractor/umg.py
+++ b/youtube_dl/extractor/umg.py
@@ -56,11 +56,9 @@ class UMGDeIE(InfoExtractor):
         formats = []
 
         def add_m3u8_format(format_id):
-            m3u8_formats = self._extract_m3u8_formats(
+            formats.extend(self._extract_m3u8_formats(
                 hls_url_template % format_id, video_id, 'mp4',
-                'm3u8_native', m3u8_id='hls', fatal='False')
-            if m3u8_formats:
-                formats.extend(m3u8_formats)
+                'm3u8_native', m3u8_id='hls', fatal='False'))
 
         for f in video_data.get('formats', []):
             f_url = f.get('url')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

"api.universal-music.de" no longer resolves, updated to the current URL. Site now also issues a "master" m3u8 which has the audioonly and video quality options instead of different formats. Updated the script to not rely on the "height" as this m3u8 doesn't have it.
