### PR TITLE
[Nuvid] Use site JSON for video details

### DIFF
--- a/youtube_dl/extractor/nuvid.py
+++ b/youtube_dl/extractor/nuvid.py
@@ -1,23 +1,29 @@
 from __future__ import unicode_literals
 
-import re
-
 from .common import InfoExtractor
+from ..compat import (
+    compat_str,
+)
 from ..utils import (
     parse_duration,
+    try_get,
+    url_or_none,
 )
 
 
 class NuvidIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www|m)\.nuvid\.com/video/(?P<id>[0-9]+)'
+    _PLAYER_CONFIG_URL_TEMPLATE = (
+        'https://www.nuvid.com/player_config_json/?vid=%s'
+        '&aid=0&domain_id=0&embed=0&ref=null&check_speed=0')
     _TEST = {
-        'url': 'http://m.nuvid.com/video/1310741/',
-        'md5': 'eab207b7ac4fccfb4e23c86201f11277',
+        'url': 'http://m.nuvid.com/video/6415801/',
         'info_dict': {
-            'id': '1310741',
+            'id': '6415801',
+            'format_id': 'hq',
             'ext': 'mp4',
-            'title': 'Horny babes show their awesome bodeis and',
-            'duration': 129,
+            'title': 'My best friend wanted to fuck my wife for a long time',
+            'duration': 1882,
             'age_limit': 18,
         }
     }
@@ -25,47 +31,39 @@ class NuvidIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
+        # nice to have, not required
         page_url = 'http://m.nuvid.com/video/%s' % video_id
         webpage = self._download_webpage(
-            page_url, video_id, 'Downloading video page')
-        # When dwnld_speed exists and has a value larger than the MP4 file's
-        # bitrate, Nuvid returns the MP4 URL
-        # It's unit is 100bytes/millisecond, see mobile-nuvid-min.js for the algorithm
-        self._set_cookie('nuvid.com', 'dwnld_speed', '10.0')
-        mp4_webpage = self._download_webpage(
-            page_url, video_id, 'Downloading video page for MP4 format')
-
-        html5_video_re = r'(?s)<(?:video|audio)[^<]*(?:>.*?<source[^>]*)?\s+src=["\'](.*?)["\']',
-        video_url = self._html_search_regex(html5_video_re, webpage, video_id)
-        mp4_video_url = self._html_search_regex(html5_video_re, mp4_webpage, video_id)
-        formats = [{
-            'url': video_url,
-        }]
-        if mp4_video_url != video_url:
-            formats.append({
-                'url': mp4_video_url,
-            })
-
-        title = self._html_search_regex(
+            page_url, video_id, 'Downloading video page', fatal=False)
+        json_url = self._PLAYER_CONFIG_URL_TEMPLATE % video_id
+        # necessary
+        player_json = self._download_json(
+            json_url, video_id, 'Downloading player JSON')
+        title = (try_get(player_json, lambda x: x['title'], compat_str)
+                 or self._html_search_regex(
             [r'<span title="([^"]+)">',
              r'<div class="thumb-holder video">\s*<h5[^>]*>([^<]+)</h5>',
-             r'<span[^>]+class="title_thumb">([^<]+)</span>'], webpage, 'title').strip()
-        thumbnails = [
-            {
-                'url': thumb_url,
-            } for thumb_url in re.findall(r'<img src="([^"]+)" alt="" />', webpage)
-        ]
-        thumbnail = thumbnails[0]['url'] if thumbnails else None
-        duration = parse_duration(self._html_search_regex(
-            [r'<i class="fa fa-clock-o"></i>\s*(\d{2}:\d{2})',
-             r'<span[^>]+class="view_time">([^<]+)</span>'], webpage, 'duration', fatal=False))
-
+             r'<span[^>]+class="title_thumb">([^<]+)</span>'],
+            webpage, 'title'))
+        if not title:
+            return
+        formats = []
+        for (k, v) in (try_get(
+                player_json, lambda x: x['files'], dict) or {}).items():
+            v = url_or_none(v)
+            if v:
+                formats.append({
+                    'format_id': k,
+                    'resolution': k,
+                    'quality': -2 if k == 'lq' else -1,
+                    'url': v,
+                })
+        self._sort_formats(formats)
         return {
             'id': video_id,
-            'title': title,
-            'thumbnails': thumbnails,
-            'thumbnail': thumbnail,
-            'duration': duration,
+            'title': title.strip(),
+            'thumbnail': player_json.get('poster'),
+            'duration': parse_duration(player_json.get('duration')),
             'age_limit': 18,
             'formats': formats,
         }

--- a/youtube_dl/extractor/nuvid.py
+++ b/youtube_dl/extractor/nuvid.py
@@ -1,69 +1,113 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from ..compat import (
-    compat_str,
-)
+from ..compat import compat_str
 from ..utils import (
     parse_duration,
+    int_or_none,
     try_get,
     url_or_none,
 )
 
+import re
+
 
 class NuvidIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www|m)\.nuvid\.com/video/(?P<id>[0-9]+)'
-    _PLAYER_CONFIG_URL_TEMPLATE = (
-        'https://www.nuvid.com/player_config_json/?vid=%s'
-        '&aid=0&domain_id=0&embed=0&ref=null&check_speed=0')
-    _TEST = {
+    _TESTS = [{
+        'url': 'https://www.nuvid.com/video/6513023/italian-babe',
+        'md5': '772d2f8288f3d3c5c45f7a41761c7844',
+        'info_dict': {
+            'id': '6513023',
+            'ext': 'mp4',
+            'title': 'italian babe',
+            'format_id': '360p',
+            'duration': 321.0,
+            'age_limit': 18,
+            'thumbnail': r're:https?://.+\.jpg',
+            'thumbnails': list,
+        }
+    }, {
+        'url': 'https://m.nuvid.com/video/6523263',
+        'md5': 'ebd22ce8e47e1d9a4d0756a15c67da52',
+        'info_dict': {
+            'id': '6523263',
+            'ext': 'mp4',
+            'title': 'Slut brunette college student anal dorm',
+            'format_id': '720p',
+            'duration': 421.0,
+            'age_limit': 18,
+            'thumbnail': r're:https?://.+\.jpg',
+            'thumbnails': list,
+        }
+    }, {
         'url': 'http://m.nuvid.com/video/6415801/',
+        'md5': '638d5ececb138d5753593f751ae3f697',
         'info_dict': {
             'id': '6415801',
-            'format_id': 'hq',
             'ext': 'mp4',
             'title': 'My best friend wanted to fuck my wife for a long time',
+            'format_id': '720p',
             'duration': 1882,
             'age_limit': 18,
+            'thumbnail': r're:https?://.+\.jpg',
+            'thumbnails': list,
         }
-    }
+    }]
 
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
+        qualities = {
+            'lq': '360p',
+            'hq': '720p',
+        }
+
+        json_url = 'https://www.nuvid.com/player_config_json/?vid={video_id}&aid=0&domain_id=0&embed=0&check_speed=0'.format(**locals())
+        video_data = self._download_json(
+            json_url, video_id, headers={
+                'Accept': 'application/json, text/javascript, */*; q = 0.01',
+                'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            }) or {}
+
         # nice to have, not required
-        page_url = 'http://m.nuvid.com/video/%s' % video_id
         webpage = self._download_webpage(
-            page_url, video_id, 'Downloading video page', fatal=False)
-        json_url = self._PLAYER_CONFIG_URL_TEMPLATE % video_id
-        # necessary
-        player_json = self._download_json(
-            json_url, video_id, 'Downloading player JSON')
-        title = (try_get(player_json, lambda x: x['title'], compat_str)
-                 or self._html_search_regex(
-            [r'<span title="([^"]+)">',
-             r'<div class="thumb-holder video">\s*<h5[^>]*>([^<]+)</h5>',
-             r'<span[^>]+class="title_thumb">([^<]+)</span>'],
-            webpage, 'title'))
-        if not title:
-            return
-        formats = []
-        for (k, v) in (try_get(
-                player_json, lambda x: x['files'], dict) or {}).items():
-            v = url_or_none(v)
-            if v:
-                formats.append({
-                    'format_id': k,
-                    'resolution': k,
-                    'quality': -2 if k == 'lq' else -1,
-                    'url': v,
-                })
+            'http://m.nuvid.com/video/%s' % (video_id, ),
+            video_id, 'Downloading video page', fatal=False) or ''
+
+        title = (
+            try_get(video_data, lambda x: x['title'], compat_str)
+            or self._html_search_regex(
+                (r'''<span\s[^>]*?\btitle\s*=\s*(?P<q>"|'|\b)(?P<title>[^"]+)(?P=q)\s*>''',
+                 r'''<div\s[^>]*?\bclass\s*=\s*(?P<q>"|'|\b)thumb-holder video(?P=q)>\s*<h5\b[^>]*>(?P<title>[^<]+)</h5''',
+                 r'''<span\s[^>]*?\bclass\s*=\s*(?P<q>"|'|\b)title_thumb(?P=q)>(?P<title>[^<]+)</span'''),
+                webpage, 'title', group='title')).strip()
+
+        formats = [{
+            'url': source,
+            'format_id': qualities.get(quality),
+            'height': int_or_none(qualities.get(quality)[:-1]),
+        } for quality, source in video_data.get('files').items() if source]
+
+        self._check_formats(formats, video_id)
         self._sort_formats(formats)
+
+        duration = parse_duration(video_data.get('duration') or video_data.get('duration_format'))
+        thumbnails = [
+            {'url': thumb_url, }
+            for thumb_url in (
+                url_or_none(src) for src in re.findall(
+                    r'<div\s+class\s*=\s*"video-tmb-wrap"\s*>\s*<img\s+src\s*=\s*"([^"]+)"\s*/>',
+                    webpage))
+        ]
+
         return {
             'id': video_id,
-            'title': title.strip(),
-            'thumbnail': player_json.get('poster'),
-            'duration': parse_duration(player_json.get('duration')),
-            'age_limit': 18,
             'formats': formats,
+            'title': title,
+            'thumbnail': url_or_none(video_data.get('poster')),
+            'thumbnails': thumbnails,
+            'duration': duration,
+            'age_limit': 18,
         }


### PR DESCRIPTION
## Please follow the guide below

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except Unlicense code from yt-dlp PR 1022, PR #17890.
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Video details aren't in the original HTML any longer. Instead they are populated by async JS.  

The final version is back-ported from yt-dlp (thanks @u-spec-png) onto the version from PR #17890 (thanks @vidaritos) with some elements of the initial version added back.

Fixes #29321
Fixes #29886.

Also closes #17890 (PR) and so also:
* closes  #27578
* closes #15355
