### PR TITLE
[downloader/external] fix wget proxy

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -171,11 +171,29 @@ class WgetFD(ExternalFD):
                 retry[1] = '0'
             cmd += retry
         cmd += self._option('--bind-address', 'source_address')
-        cmd += self._option('--proxy', 'proxy')
         cmd += self._valueless_option('--no-check-certificate', 'nocheckcertificate')
         cmd += self._configuration_args()
         cmd += ['--', info_dict['url']]
         return cmd
+
+    def _call_downloader(self, tmpfilename, info_dict):
+        env = None
+        proxy = self.params.get('proxy')
+        if proxy:
+            env = os.environ.copy()
+            compat_setenv('http_proxy', proxy, env=env)
+            compat_setenv('https_proxy', proxy, env=env)
+
+        cmd = [encodeArgument(a) for a in self._make_cmd(tmpfilename, info_dict)]
+
+        self._debug_cmd(cmd)
+
+        p = subprocess.Popen(
+            cmd, stderr=subprocess.PIPE, env=env)
+        _, stderr = p.communicate()
+        if p.returncode != 0:
+            self.to_stderr(stderr.decode('utf-8', 'replace'))
+        return p.returncode
 
 
 class Aria2cFD(ExternalFD):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
I couldn't find test cases for external downloaders so I didn't run python test/test_.... Did execution test to this change of course.
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I noticed that youtube-dl passes proxy to wget incorrectly by command line `--proxy`. The standard way (as in 'man wget') is to use environment variables `http_proxy` and `https_proxy` which this PR fixes.

Actually, if I run youtube-dl with --external-downloader wget and --proxy ..., I get error. The full log is too long so I quote only the part of it.

> $ youtube-dl h<span></span>ttps://www.youtube.com/watch?v=U7qKJi4elro -o '%(id)s.%(ext)s' -v -f18 --external-downloader wget --external-downloader-args --no-config --proxy h<span></span>ttp://127.0.0.1:8080 --no-check-certificate 
> ...
> [youtube] U7qKJi4elro: Downloading webpage
> [debug] Invoking downloader on ...
> [download] Destination: U7qKJi4elro.mp4
> [debug] wget command line: wget -O U7qKJi4elro.mp4.part ...
> h<span></span>ttp://127.0.0.1:8080/:
> 2021-06-20 13:45:25 ERROR 400: Bad Request.
> 2021-06-20 13:45:29 URL:... [5004778/5004778] -> "U7qKJi4elro.mp4.part" [1]
> FINISHED --2021-06-20 13:45:29--
> Total wall clock time: 4.2s
> Downloaded: 1 files, 4.8M in 1.3s (3.78 MB/s)
> 
> ERROR: wget exited with code 8
> 

And to be sure, I checked old wget around commit bf812ef71438036c23640f29bd7ae955289720ed which youtube-dl started to pass proxy to wget. Environment variables seem to have been needed for wget since before.
