### PR TITLE
setup.py: disable version normalisation in setuptools mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import warnings
 import sys
 
 try:
-    from setuptools import setup, Command
+    from setuptools import setup, sic, Command
     setuptools_available = True
 except ImportError:
     from distutils.core import setup, Command
@@ -35,6 +35,10 @@ py2exe_options = {
 # Get the version from youtube_dl/version.py without importing the package
 exec(compile(open('youtube_dl/version.py').read(),
              'youtube_dl/version.py', 'exec'))
+if setuptools_available:
+    # The yyyy-mm-dd scheme is PEP 440-compliant, tell setuptools
+    # not to normalise version numbers (and complain about having to)
+    __version__ = sic(__version__)
 
 DESCRIPTION = 'YouTube video downloader'
 LONG_DESCRIPTION = 'Command-line program to download videos from YouTube.com and other video sites'


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The yyyy.mm.dd versioning scheme is not PEP 440-compliant due to leading zeros in many month and day numbers. distutils doesn't care about that, on the other hand setuptools by default normalises version numbers. Results:
 - the same version of youtube-dl ends up being installed with a different version depending on whether setuptools was used or not, e.g. 2021.06.06 vs 2021.6.6;
 - setuptools produces a UserWarning (which is a bit of a misnomer given it should be addressed at developers rather than end users) if normalisation is required.

Bypass setuptools version-number normalisation if setuptools is present, quelling the warning and restoring consistency between distutils and setuptools modes.
