### PR TITLE
[YoutubeDL] improve --console-title on macos terminal or output

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -557,7 +557,18 @@ class YoutubeDL(object):
                 window_title = None
                 try:
                     ttyname = os.ttyname(self._screen_file.fileno())
-                    opts = ['-e', 'tell app "Terminal" to get custom title of item 1 of (every window whose tty is "%s")' % ttyname]
+                    scpt = [
+                        'tell app "Terminal"',
+                        'repeat with win in (every window)',
+                        'if tty of win is "%s" then' % ttyname,
+                        'return custom title of win',
+                        'end if',
+                        'end repeat',
+                        'end tell'
+                    ]
+                    opts = []
+                    for s in scpt:
+                        opts += ['-e', s]
                     cmd = ([encodeFilename('osascript', True)]
                            + [encodeArgument(o) for o in opts])
                     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

2 improvements: 1. resolves #1782, 2. resolves #28651

1. Escape sequences to save/restore window title don't work with macOS Terminal app. Added the code to get window title on save and set on restore.

2. Make sure that output go to tty.
