### PR TITLE
[GBNews]Add new extractor for GB News TV channel

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -426,10 +426,7 @@ from .gamespot import GameSpotIE
 from .gamestar import GameStarIE
 from .gaskrank import GaskrankIE
 from .gazeta import GazetaIE
-from .gbnews import (
-    GBNewsIE,
-    GBNewsLiveIE,
-)
+from .gbnews import GBNewsIE
 from .gdcvault import GDCVaultIE
 from .gedidigital import GediDigitalIE
 from .generic import GenericIE

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -426,6 +426,10 @@ from .gamespot import GameSpotIE
 from .gamestar import GameStarIE
 from .gaskrank import GaskrankIE
 from .gazeta import GazetaIE
+from .gbnews import (
+    GBNewsIE,
+    GBNewsLiveIE,
+)
 from .gdcvault import GDCVaultIE
 from .gedidigital import GediDigitalIE
 from .generic import GenericIE

--- a/youtube_dl/extractor/gbnews.py
+++ b/youtube_dl/extractor/gbnews.py
@@ -15,7 +15,8 @@ from ..utils import (
 class GBNewsIE(InfoExtractor):
     '''GB News clips and features'''
 
-    _VALID_URL = r'https?://(?:www\.)?gbnews\.uk/(?:shows(?:/(?P<display_id>[^/]+))?|a)/(?P<id>\d+)'
+    # \w+ is normally shows or news, but apparently any word redirects to the correct URL
+    _VALID_URL = r'https?://(?:www\.)?gbnews\.uk/(?:\w+(?:/(?P<display_id>[^/]+))?|a)/(?P<id>\d+)'
     _PLATFORM = 'safari'
     _SSMP_URL = 'https://mm-dev.simplestream.com/ssmp/api.php'
     _TESTS = [{

--- a/youtube_dl/extractor/gbnews.py
+++ b/youtube_dl/extractor/gbnews.py
@@ -1,0 +1,151 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..compat import (
+    compat_str,
+)
+from ..utils import (
+    extract_attributes,
+    ExtractorError,
+    try_get,
+)
+
+
+class GBNewsIE(InfoExtractor):
+    '''GB News clips and features'''
+
+    _VALID_URL = r'https?://(?:www\.)?gbnews\.uk/(?:shows(?:/(?P<display_id>[^/]+))?|a)/(?P<id>\d+)'
+    _PLATFORM = 'safari'
+    _SSMP_URL = 'https://mm-dev.simplestream.com/ssmp/api.php'
+    _TESTS = [{
+        'url': 'https://www.gbnews.uk/shows/andrew-neils-message-to-companies-choosing-to-boycott-gb-news/106889',
+        'info_dict': {
+            'id': '106889',
+            'ext': 'mp4',
+            'title': "Andrew Neil's message to companies choosing to boycott GB News",
+            'description': 'md5:b281f5d22fd6d5eda64a4e3ba771b351',
+        },
+    },
+    ]
+
+    def _real_extract(self, url):
+        display_id = self._match_id(url)
+
+        webpage = self._download_webpage(url, display_id)
+        # extraction based on https://github.com/ytdl-org/youtube-dl/issues/29341
+        '''
+        <div id="video-106908"
+            class="simplestream"
+            data-id="GB001"
+            data-type="vod"
+            data-key="3Li3Nt2Qs8Ct3Xq9Fi5Uy0Mb2Bj0Qs"
+            data-token="f9c317c727dc07f515b20036c8ef14a6"
+            data-expiry="1624300052"
+            data-uvid="37900558"
+            data-poster="https://thumbnails.simplestreamcdn.com/gbnews/ondemand/37900558.jpg?width=700&"
+            data-npaw="false"
+            data-env="production">
+        '''
+        # exception if no match
+        video_data = self._search_regex(
+            r'<\s*div\s[^>]*class\s*=\s*([\'"])simplestream\1[^>]*>',
+            webpage, "video data", group=0)
+
+        # print(video_data)
+        video_data = extract_attributes(video_data)
+        ss_id = try_get(video_data, lambda x: x['data-id'])
+        if not ss_id:
+            raise ExtractorError('Simplestream ID not found')
+
+        # exception if no JSON
+        json_data = self._download_json(
+            self._SSMP_URL, display_id,
+            note='Downloading Simplestream JSON metadata',
+            errnote='Unable to download Simplestream JSON metadata',
+            query={
+                'id': ss_id,
+                'env': video_data.get('data-env'),
+            })
+
+        meta_url = try_get(json_data, lambda x: x['response']['api_hostname'], compat_str)
+        if not meta_url:
+            raise ExtractorError('No API host found')
+
+        uvid = video_data.get('data-uvid')
+        dtype = video_data.get('data-type')
+        # exception if no JSON
+        stream_data = self._download_json(
+            '%s/api/%s/stream/%s' % (meta_url, 'show' if dtype == 'vod' else dtype, uvid),
+            display_id,
+            query={
+                'key': video_data.get('data-key'),
+                'platform': self._PLATFORM,
+            },
+            headers={
+                'Token': video_data.get('data-token'),
+                'Token-Expiry': video_data.get('data-expiry'),
+                'Uvid': uvid,
+            })
+
+        stream_url = try_get(stream_data, lambda x: x['response']['stream'], compat_str)
+        if not stream_url:
+            raise ExtractorError('No stream data')
+
+        # now known to be a dict
+        stream_data = stream_data['response']
+        drm = stream_data.get('drm')
+        if drm:
+            raise ExtractorError(
+                'Stream is requesting DRM (%s) playback: unsupported' % drm,
+                expected=True)
+
+        formats = []
+        formats.extend(
+            self._extract_m3u8_formats(stream_url, display_id, ext='mp4', fatal=False))
+
+        # exception if no formats
+        self._sort_formats(formats)
+
+        # no 'title' attribute seen, but if it comes ...
+        title = stream_data.get('title') or self._og_search_title(webpage)
+
+        return {
+            'id': display_id,
+            'title': title,
+            'description': self._og_search_description(webpage, default=None),
+            'thumbnail': video_data.get('data-poster') or None,
+            'formats': formats,
+            'is_live': 'Live' in self.IE_NAME,
+        }
+
+
+class GBNewsLiveIE(GBNewsIE):
+    '''GB News live programme stream'''
+
+    _VALID_URL = r'https?://(?:www.)?gbnews.uk/(?P<id>watchlive)(?:$|[/?#])'
+    _TESTS = [{
+        'url': 'https://www.gbnews.uk/watchlive',
+        'info_dict': {
+            'id': 'watchlive',
+            'ext': 'mp4',
+            'title': "Watchlive",
+            'is_live': True,
+        },
+    },
+    ]
+
+    '''
+    <div id="video-104872"
+        class="simplestream"
+        data-id="gb002"
+        data-type="live"
+        data-key="3Li3Nt2Qs8Ct3Xq9Fi5Uy0Mb2Bj0Qs"
+        data-token="d10b3ea37f6ce539ffd1ce2f6ce5fe35"
+        data-expiry="1624984755"
+        data-uvid="1069"
+        data-poster=""
+        data-npaw="false"
+        data-env="production">
+    </div>
+    '''

--- a/youtube_dl/extractor/gbnews.py
+++ b/youtube_dl/extractor/gbnews.py
@@ -2,23 +2,24 @@
 from __future__ import unicode_literals
 
 from .common import InfoExtractor
-from ..compat import (
-    compat_str,
-)
 from ..utils import (
     extract_attributes,
     ExtractorError,
-    try_get,
+    T,
+    traverse_obj,
+    txt_or_none,
+    url_or_none,
 )
 
 
 class GBNewsIE(InfoExtractor):
-    '''GB News clips and features'''
+    IE_DESC = 'GB News clips, features and live stream'
 
     # \w+ is normally shows or news, but apparently any word redirects to the correct URL
-    _VALID_URL = r'https?://(?:www\.)?gbnews\.uk/(?:\w+(?:/(?P<display_id>[^/]+))?|a)/(?P<id>\d+)'
+    _VALID_URL = r'https?://(?:www\.)?gbnews\.(?:uk|com)/(?:\w+/)?(?P<id>[^#?]+)'
+
     _PLATFORM = 'safari'
-    _SSMP_URL = 'https://mm-dev.simplestream.com/ssmp/api.php'
+    _SSMP_URL = 'https://mm-v2.simplestream.com/ssmp/api.php'
     _TESTS = [{
         'url': 'https://www.gbnews.uk/shows/andrew-neils-message-to-companies-choosing-to-boycott-gb-news/106889',
         'info_dict': {
@@ -27,11 +28,32 @@ class GBNewsIE(InfoExtractor):
             'title': "Andrew Neil's message to companies choosing to boycott GB News",
             'description': 'md5:b281f5d22fd6d5eda64a4e3ba771b351',
         },
-    },
-    ]
+        'skip': '404 not found',
+    }, {
+        'url': 'https://www.gbnews.com/news/bbc-claudine-gay-harvard-university-antisemitism-row',
+        'info_dict': {
+            'id': '52264136',
+            'display_id': 'bbc-claudine-gay-harvard-university-antisemitism-row',
+            'ext': 'mp4',
+            'title': 'BBC deletes post after furious backlash over headline downplaying antisemitism',
+            'description': 'The post was criticised by former employers of the broadcaster',
+        },
+    }, {
+        'url': 'https://www.gbnews.uk/watchlive',
+        'info_dict': {
+            'id': '1069',
+            'display_id': 'watchlive',
+            'ext': 'mp4',
+            'title': 'GB News Live',
+            'is_live': True,
+        },
+        'params': {
+            'skip_download': 'm3u8',
+        },
+    }]
 
     def _real_extract(self, url):
-        display_id = self._match_id(url)
+        display_id = self._match_id(url).split('/')[-1]
 
         webpage = self._download_webpage(url, display_id)
         # extraction based on https://github.com/ytdl-org/youtube-dl/issues/29341
@@ -50,35 +72,32 @@ class GBNewsIE(InfoExtractor):
         '''
         # exception if no match
         video_data = self._search_regex(
-            r'<\s*div\s[^>]*class\s*=\s*([\'"])simplestream\1[^>]*>',
-            webpage, "video data", group=0)
+            r'(<div\s[^>]*\bclass\s*=\s*(\'|")(?!.*sidebar\b)simplestream(?:\s[\s\w$-]*)?\2[^>]*>)',
+            webpage, 'video data')
 
-        # print(video_data)
         video_data = extract_attributes(video_data)
-        ss_id = try_get(video_data, lambda x: x['data-id'])
+        ss_id = video_data.get('data-id')
         if not ss_id:
             raise ExtractorError('Simplestream ID not found')
 
-        # exception if no JSON
         json_data = self._download_json(
             self._SSMP_URL, display_id,
             note='Downloading Simplestream JSON metadata',
             errnote='Unable to download Simplestream JSON metadata',
             query={
                 'id': ss_id,
-                'env': video_data.get('data-env'),
-            })
+                'env': video_data.get('data-env', 'production'),
+            }, fatal=False)
 
-        meta_url = try_get(json_data, lambda x: x['response']['api_hostname'], compat_str)
+        meta_url = traverse_obj(json_data, ('response', 'api_hostname'))
         if not meta_url:
             raise ExtractorError('No API host found')
 
-        uvid = video_data.get('data-uvid')
+        uvid = video_data['data-uvid']
         dtype = video_data.get('data-type')
-        # exception if no JSON
         stream_data = self._download_json(
             '%s/api/%s/stream/%s' % (meta_url, 'show' if dtype == 'vod' else dtype, uvid),
-            display_id,
+            uvid,
             query={
                 'key': video_data.get('data-key'),
                 'platform': self._PLATFORM,
@@ -87,66 +106,34 @@ class GBNewsIE(InfoExtractor):
                 'Token': video_data.get('data-token'),
                 'Token-Expiry': video_data.get('data-expiry'),
                 'Uvid': uvid,
-            })
+            }, fatal=False)
 
-        stream_url = try_get(stream_data, lambda x: x['response']['stream'], compat_str)
+        stream_url = traverse_obj(stream_data, (
+            'response', 'stream', T(url_or_none)))
         if not stream_url:
-            raise ExtractorError('No stream data')
+            raise ExtractorError('No stream data/URL')
 
         # now known to be a dict
         stream_data = stream_data['response']
         drm = stream_data.get('drm')
         if drm:
-            raise ExtractorError(
-                'Stream is requesting DRM (%s) playback: unsupported' % drm,
-                expected=True)
+            self.report_drm(uvid)
 
-        formats = []
-        formats.extend(
-            self._extract_m3u8_formats(stream_url, display_id, ext='mp4', fatal=False))
-
+        formats = self._extract_m3u8_formats(
+            stream_url, uvid, ext='mp4', entry_protocol='m3u8_native',
+            fatal=False)
         # exception if no formats
         self._sort_formats(formats)
 
-        # no 'title' attribute seen, but if it comes ...
-        title = stream_data.get('title') or self._og_search_title(webpage)
-
         return {
-            'id': display_id,
-            'title': title,
+            'id': uvid,
+            'display_id': display_id,
+            'title': (traverse_obj(stream_data, ('title', T(txt_or_none)))
+                      or self._og_search_title(webpage, default=None)
+                      or display_id.replace('-', ' ').capitalize()),
             'description': self._og_search_description(webpage, default=None),
-            'thumbnail': video_data.get('data-poster') or None,
+            'thumbnail': (traverse_obj(video_data, ('data-poster', T(url_or_none)))
+                          or self._og_search_thumbnail(webpage)),
             'formats': formats,
-            'is_live': 'Live' in self.IE_NAME,
+            'is_live': (dtype == 'live') or None,
         }
-
-
-class GBNewsLiveIE(GBNewsIE):
-    '''GB News live programme stream'''
-
-    _VALID_URL = r'https?://(?:www.)?gbnews.uk/(?P<id>watchlive)(?:$|[/?#])'
-    _TESTS = [{
-        'url': 'https://www.gbnews.uk/watchlive',
-        'info_dict': {
-            'id': 'watchlive',
-            'ext': 'mp4',
-            'title': "Watchlive",
-            'is_live': True,
-        },
-    },
-    ]
-
-    '''
-    <div id="video-104872"
-        class="simplestream"
-        data-id="gb002"
-        data-type="live"
-        data-key="3Li3Nt2Qs8Ct3Xq9Fi5Uy0Mb2Bj0Qs"
-        data-token="d10b3ea37f6ce539ffd1ce2f6ce5fe35"
-        data-expiry="1624984755"
-        data-uvid="1069"
-        data-poster=""
-        data-npaw="false"
-        data-env="production">
-    </div>
-    '''


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
Issue #29341 identified the need for an extractor for the new GB News channel from the UK, and demonstrated extraction using a shell script.

This PR adds an extractor for the two types of GB News URLs (clips, live) shown in the issue, using the procedure from the issue.

The live stream appears to operate OK with a shell command line piping yt-dl output to `mpv`, but hasn't been extensively exercised.

Closes #29341.
