### PR TITLE
[YoutubeDL] direct debug messages to stderr

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -510,6 +510,9 @@ class YoutubeDL(object):
 
     def to_stdout(self, message, skip_eol=False, check_quiet=False):
         """Print message to stdout if not in quiet mode."""
+        if message.startswith('[debug]'):
+            # dirty fix, direct debug messages to stderr
+            return self.to_stderr(message, debug=True, check_quiet=check_quiet)
         if self.params.get('logger'):
             self.params['logger'].debug(message)
         elif not check_quiet or not self.params.get('quiet', False):
@@ -519,12 +522,17 @@ class YoutubeDL(object):
 
             self._write_string(output, self._screen_file)
 
-    def to_stderr(self, message):
+    def to_stderr(self, message, debug=False, check_quiet=False):
         """Print message to stderr."""
         assert isinstance(message, compat_str)
         if self.params.get('logger'):
-            self.params['logger'].error(message)
+            if debug:
+                self.params['logger'].debug(message)
+            else:
+                self.params['logger'].error(message)
         else:
+            if debug and check_quiet and self.params.get('quiet', False):
+                return
             message = self._bidi_workaround(message)
             output = message + '\n'
             self._write_string(output, self._err_file)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Relates to 9585b376db8cb0a3f0e7a866e5d64b351fb6ecf7, #22593, #27238

There currently are below [debug] messages written to stdout. A dirty fix to direct them to stderr. _I ignored `skip_eol` since it is not used in these messages._

[debug] Invoking downloader on ... (YoutubeDL.py)
[debug] Using fake IP ... (extractor/common.py)
[debug] %s command line: ... (downloader/common.py)
[debug] ffmpeg command line: ... (postprocessor/ffmpeg.py)
[debug] AtomicParsley command line: ... (postprocessor/embedthumbnail.py)
