### PR TITLE
minor improvements on progress output

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -419,6 +419,9 @@ class YoutubeDL(object):
                 'Parameter outtmpl is bytes, but should be a unicode string. '
                 'Put  from __future__ import unicode_literals  at the top of your code file or consider switching to Python 3.x.')
 
+        if not self._screen_file.isatty():
+            self.params['progress_with_newline'] = True
+
         self._setup_opener()
 
         if auto_init:

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -2,7 +2,6 @@ from __future__ import division, unicode_literals
 
 import os
 import re
-import sys
 import time
 import random
 
@@ -241,7 +240,7 @@ class FileDownloader(object):
                 self._report_progress_prev_line_length = len(fullmsg)
                 clear_line = '\r'
             else:
-                clear_line = ('\r\x1b[K' if sys.stderr.isatty() else '\r')
+                clear_line = '\r\x1b[K'
             self.to_screen(clear_line + fullmsg, skip_eol=not is_last_line)
         self.to_console_title('youtube-dl ' + msg)
 

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -638,7 +638,7 @@ def parseOpts(overrideArguments=None):
     verbosity.add_option(
         '--newline',
         action='store_true', dest='progress_with_newline', default=False,
-        help='Output progress bar as new lines')
+        help='Output progress bar as new lines (implied if output is not to the console)')
     verbosity.add_option(
         '--no-progress',
         action='store_true', dest='noprogress', default=False,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

2 minor improvements on progress output.

1. Imply --newline option and not output escape sequences if output is not to the console.
Although this might be against the comment on #21067, I think it should be better treated like no-color of `WARNING:` or `ERROR:`.
2. Make progress line cleared properly if stderr is redirected. In such a case I get like:
```
$ youtube-dl BaW_jenozKc --ignore-config --id -f18 2>err.txt 
[youtube] BaW_jenozKc: Downloading webpage
[download] Destination: BaW_jenozKc.mp4
[download] 100% of 354.29KiB in 00:0030MiB/s ETA 00:000
```
The last line should be: `[download] 100% of 354.29KiB in 00:00`


_Changes to YoutubeDL.py will conflict with my another PR #29420. I ended up inserting the changes in the same position._