### PR TITLE
[YoutubeDL] improvements to warn_if_short_id()

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -437,11 +437,11 @@ class YoutubeDL(object):
 
         register_socks_protocols()
 
-    def warn_if_short_id(self, argv):
+    def warn_if_short_id(self, argv, parser):
         # short YouTube ID starting with dash?
         idxs = [
             i for i, a in enumerate(argv)
-            if re.match(r'^-[0-9A-Za-z_-]{10}$', a)]
+            if re.match(r'^-[0-9A-Za-z_-]{10}$', a) and not parser.has_option(a)]
         if idxs:
             correct_argv = (
                 ['youtube-dl']

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -13,6 +13,7 @@ import sys
 
 
 from .options import (
+    _hide_login_info,
     parseOpts,
 )
 from .compat import (
@@ -453,7 +454,7 @@ def _real_main(argv=None):
             if opts.update_self or opts.rm_cachedir:
                 sys.exit()
 
-            ydl.warn_if_short_id(sys.argv[1:] if argv is None else argv)
+            ydl.warn_if_short_id(_hide_login_info(sys.argv[1:] if argv is None else argv), parser)
             parser.error(
                 'You must provide at least one URL.\n'
                 'Type youtube-dl --help to see a list of all options.')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

_This explanation is very intentional but based on the user's issue report I've recently seen._

There are cases that youtube-dl incorrectly reports 11 characters-long option as YouTube's video id and prints account information to the log, thus lead the user to expose account information inadvertently in the verbose log.
```
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'-u', u'PRIVATE', u'-p', u'PRIVATE', u'--get-title', u'-fCtvurGDD8']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.06.06
[debug] Python version 2.7.10 (CPython) - Darwin-16.7.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 4.4, ffprobe 4.4, phantomjs 2.1.1
[debug] Proxy map: {}
WARNING: Long argument string detected. Use -- to separate parameters and URLs, like this:
youtube-dl -v -u My_Name -p My_Pass -- --get-title -fCtvurGDD8

Usage: youtube-dl [OPTIONS] URL [URL...]

youtube-dl: error: You must provide at least one URL.
Type youtube-dl --help to see a list of all options.
```

With this PR, the line
`youtube-dl -v -u My_Name -p My_Pass -- --get-title -fCtvurGDD8`
will be shown as
`youtube-dl -v -u PRIVATE -p PRIVATE --get-title -- -fCtvurGDD8`
