### PR TITLE
[YouTube] Added named subtitle support

### DIFF
--- a/test/test_subtitles.py
+++ b/test/test_subtitles.py
@@ -64,8 +64,8 @@ class TestYoutubeSubtitles(BaseTestSubtitles):
         self.DL.params['allsubtitles'] = True
         subtitles = self.getSubtitles()
         self.assertEqual(len(subtitles.keys()), 13)
-        self.assertEqual(md5(subtitles['en']), '3cb210999d3e021bd6c7f0ea751eab06')
-        self.assertEqual(md5(subtitles['it']), '6d752b98c31f1cf8d597050c7a2cb4b5')
+        self.assertEqual(md5(subtitles['en']), 'ae1bd34126571a77aabd4d276b28044d')
+        self.assertEqual(md5(subtitles['it']), '0e0b667ba68411d88fd1c5f4f4eab2f9')
         for lang in ['fr', 'de']:
             self.assertTrue(subtitles.get(lang) is not None, 'Subtitles for \'%s\' not extracted' % lang)
 
@@ -73,13 +73,13 @@ class TestYoutubeSubtitles(BaseTestSubtitles):
         self.DL.params['writesubtitles'] = True
         self.DL.params['subtitlesformat'] = 'ttml'
         subtitles = self.getSubtitles()
-        self.assertEqual(md5(subtitles['en']), 'e306f8c42842f723447d9f63ad65df54')
+        self.assertEqual(md5(subtitles['en']), 'c97ddf1217390906fa9fbd34901f3da2')
 
     def test_youtube_subtitles_vtt_format(self):
         self.DL.params['writesubtitles'] = True
         self.DL.params['subtitlesformat'] = 'vtt'
         subtitles = self.getSubtitles()
-        self.assertEqual(md5(subtitles['en']), '3cb210999d3e021bd6c7f0ea751eab06')
+        self.assertEqual(md5(subtitles['en']), 'ae1bd34126571a77aabd4d276b28044d')
 
     def test_youtube_automatic_captions(self):
         self.url = '8YoUxe5ncPo'
@@ -98,11 +98,19 @@ class TestYoutubeSubtitles(BaseTestSubtitles):
 
     def test_youtube_nosubtitles(self):
         self.DL.expect_warning('video doesn\'t have subtitles')
-        self.url = 'n5BB19UTcdA'
+        self.url = 'Ltzcqax0BrU'
         self.DL.params['writesubtitles'] = True
         self.DL.params['allsubtitles'] = True
         subtitles = self.getSubtitles()
         self.assertFalse(subtitles)
+
+    def test_youtube_namedsubtitles(self):
+        self.url = 'oIa3BFBHJFI'
+        self.DL.params['writesubtitles'] = True
+        self.DL.params['allsubtitles'] = True
+        subtitles = self.getSubtitles()
+        self.assertTrue(subtitles['en'] is not None)
+        self.assertTrue(subtitles['en-PHP'] is not None)
 
 
 class TestDailymotionSubtitles(BaseTestSubtitles):

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1836,8 +1836,27 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     lang_code = caption_track.get('languageCode')
                     if not lang_code:
                         continue
+
+                    name = caption_track.get('name')
+                    if not name:
+                        process_language(
+                            subtitles, base_url, lang_code, {})
+                        continue
+                    name_text = name.get('simpleText')
+                    if not name_text:
+                        process_language(
+                            subtitles, base_url, lang_code, {})
+                        continue
+
+                    if len(name_text.split(' - ', 1)) != 2:
+                        process_language(
+                            subtitles, base_url, lang_code, {})
+                        continue
+
+                    suffix = name_text.split(' - ', 1)[1]
+
                     process_language(
-                        subtitles, base_url, lang_code, {})
+                        subtitles, base_url, lang_code + '-' + suffix, {})
                     continue
                 automatic_captions = {}
                 for translation_language in (pctr.get('translationLanguages') or []):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [X] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [X] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [X] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [X] Covered the code with tests (note that PRs without tests will be REJECTED)
- [X] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [X] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [X] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information
- Fixed the issue described in https://github.com/ytdl-org/youtube-dl/issues/29464
- Added support for non-standard named subtitles i.e. "English - Hexadecimal" or "English - Cuneiform" 
- New subtitles will download with the format `(videotitle)-(videoid).(language)(-name if exists).(subtitle format)`
- Fixed most of the old unit tests for YT subtitles and added a new test