### PR TITLE
[YoutubeDL] check the validity of api options

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -26,8 +26,10 @@ import tokenize
 import traceback
 import random
 
+from optparse import SUPPRESS_HELP
 from string import ascii_letters
 
+from .options import parseOpts
 from .compat import (
     compat_basestring,
     compat_cookiejar,
@@ -361,6 +363,38 @@ class YoutubeDL(object):
         }
         self.params.update(params)
         self.cache = Cache(self)
+
+        # check the validity of api options if not invoked from cli or test
+        if 'test' not in params:
+            parser = parseOpts([])[0]
+            valid_opts = set(
+                [o.dest for o in parser._get_all_options() if o.dest and o.help != SUPPRESS_HELP])
+            valid_opts.update([
+                # aliases
+                'continuedl',
+                'daterange',
+                'forcedescription',
+                'forceduration',
+                'forcefilename',
+                'forceformat',
+                'forceid',
+                'forcejson',
+                'forcethumbnail',
+                'forcetitle',
+                'forceurl',
+                'logtostderr',
+                'nocheckcertificate',
+                'playlistrandom',
+                'playlistreverse',
+                'postprocessors',
+                # logger, hook
+                'logger',
+                'progress_hooks',
+            ])
+            passed_opts = set(params.keys())
+            invalid_opts = passed_opts - valid_opts
+            if invalid_opts:
+                self.report_error('Invalid option(s): %s' % ', '.join(invalid_opts))
 
         def check_deprecated(param, option, suggestion):
             if self.params.get(param) is not None:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #26793, resolves #29442

Check the validity of api options if not invoked from cli or test.
To distinguish invocations, I've used the key 'test' that \_\_init\_\_.py uses.