### PR TITLE
[tubitv] improve video error message

### DIFF
--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -4,10 +4,12 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
+from ..compat import compat_str
 from ..utils import (
     ExtractorError,
     int_or_none,
     sanitized_Request,
+    try_get,
     urlencode_postdata,
 )
 
@@ -19,7 +21,7 @@ class TubiTvIE(InfoExtractor):
     _GEO_COUNTRIES = ['US']
     _TESTS = [{
         'url': 'http://tubitv.com/video/283829/the_comedian_at_the_friday',
-        'md5': '43ac06be9326f41912dc64ccf7a80320',
+        'md5': '90e715ae752b37d2074e9f310c5c483b',
         'info_dict': {
             'id': '283829',
             'ext': 'mp4',
@@ -75,8 +77,15 @@ class TubiTvIE(InfoExtractor):
             'http://tubitv.com/oz/videos/%s/content' % video_id, video_id)
         title = video_data['title']
 
+        video_url = try_get(
+            video_data,
+            (lambda x: x['url'],
+             lambda x: x['video_resources'][0]['manifest']['url']), compat_str)
+        if not video_url:
+            raise ExtractorError('This video is not available', expected=True)
+
         formats = self._extract_m3u8_formats(
-            self._proto_relative_url(video_data['url']),
+            self._proto_relative_url(video_url),
             video_id, 'mp4', 'm3u8_native')
         self._sort_formats(formats)
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Closes #29153

There are cases that TubiTV returns empty video url for whatever reason and youtube-dl fails with `ValueError: unknown url type: ''` which is not easy to understand.

With this PR, error message `This video is not available` will be shown.
