### PR TITLE
[postprocessor] several improvements on adding metadata

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -512,8 +512,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             if info['ext'] in ('mov', 'avi', 'wav'):
                 add_comment('', 'description')
                 add_comment('composer')  # may be by --metadata-from-title
-            if info['ext'] in ('mp4', 'm4a', 'avi', 'wav'):
-                add_comment('author')  # may be by --metadata-from-title
+            add_comment('author')  # may be by --metadata-from-title
             add_comment('conductor')  # may be by --metadata-from-title
             add_comment('publisher', ('uploader', 'uploader_id'))
             add_comment('URL', 'webpage_url')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -13,6 +13,7 @@ from ..utils import (
     encodeArgument,
     encodeFilename,
     get_exe_version,
+    hyphenate_date,
     is_outdated_version,
     PostProcessingError,
     prepend_extension,
@@ -450,19 +451,43 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
                         metadata[meta_f] = info[info_f]
                     break
 
+        comment = []
+
+        def add_comment(meta_key, info_list=None):
+            if not info_list:
+                info_list = meta_key
+            if not isinstance(info_list, (list, tuple)):
+                info_list = (info_list,)
+            if meta_key:
+                if not meta_key[0].isupper():
+                    meta_key = meta_key.capitalize()
+                meta_key += ': '
+            for info_f in info_list:
+                if info.get(info_f):
+                    comment.append(meta_key + info[info_f])
+                    break
+
         # See [1-4] for some info on media metadata/metadata supported
         # by ffmpeg.
         # 1. https://kdenlive.org/en/project/adding-meta-data-to-mp4-video/
         # 2. https://wiki.multimedia.cx/index.php/FFmpeg_Metadata
         # 3. https://kodi.wiki/view/Video_file_tagging
         # 4. http://atomicparsley.sourceforge.net/mpeg-4files.html
+        #
+        # And other refs. about metadata tags.
+        #    https://www.matroska.org/technical/tagging.html
+        #    https://mediaarea.net/en/MediaInfo/Support/Tags
 
         add('title', ('track', 'title'))
-        add('date', 'upload_date')
-        add(('description', 'comment'), 'description')
-        add('purl', 'webpage_url')
+        if info.get('upload_date'):
+            metadata['date'] = hyphenate_date(info['upload_date'])
+        add('description')
+        add('url', 'webpage_url')
         add('track', 'track_number')
-        add('artist', ('artist', 'creator', 'uploader', 'uploader_id'))
+        add('artist', ('artist', 'creator'))
+        if not metadata.get('artist'):  # keep older versions' behavior
+            add('artist', ('uploader', 'uploader_id'))
+        add('publisher', ('uploader', 'uploader_id'))
         add('genre')
         add('album')
         add('album_artist')
@@ -471,6 +496,31 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         add('season_number')
         add('episode_id', ('episode', 'episode_id'))
         add('episode_sort', 'episode_number')
+        add('license')
+
+        # add any metadata extracted by --metadata-from-title
+        # possibly 'copyright', 'author', 'composer', 'conductor' or 'comment'
+        for user_meta in info.get('user_meta', []):
+            if user_meta != 'comment':
+                add(user_meta)
+            else:
+                add_comment('', 'comment')
+
+        # add metadata together into comment which may not be added dedicatedly
+        # for some file formats
+        if info['ext'] in ('mp4', 'm4a', 'mov', 'avi', 'wav'):
+            if info['ext'] in ('mov', 'avi', 'wav'):
+                add_comment('', 'description')
+                add_comment('composer')  # may be by --metadata-from-title
+            if info['ext'] in ('mp4', 'm4a', 'avi', 'wav'):
+                add_comment('author')  # may be by --metadata-from-title
+            add_comment('conductor')  # may be by --metadata-from-title
+            add_comment('publisher', ('uploader', 'uploader_id'))
+            add_comment('URL', 'webpage_url')
+            add_comment('license')
+
+        if comment:
+            metadata['comment'] = '\n'.join(comment)
 
         if not metadata:
             self._downloader.to_screen('[ffmpeg] There isn\'t any metadata to add')

--- a/youtube_dl/postprocessor/metadatafromtitle.py
+++ b/youtube_dl/postprocessor/metadatafromtitle.py
@@ -44,5 +44,9 @@ class MetadataFromTitlePP(PostProcessor):
             self._downloader.to_screen(
                 '[fromtitle] parsed %s: %s'
                 % (attribute, value if value is not None else 'NA'))
+            if info.get('user_meta'):
+                info['user_meta'].append(attribute)
+            else:
+                info['user_meta'] = [attribute]
 
         return [], info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #22848, resolves #29493, resolves #26533, resolves #16878

This PR improves several problems on adding metadata with `--add-metadata`.
- Stop adding duplicate description to `comment`, and use it to set other information like url, uploader.
This change is mainly intended for mp4, since ffmpeg doesn't add every passed metadata to every file formats. (#22848, #29493)
- Change to add webpage url from `purl` to `url`. "purl" is for podcasts.
- Separate uploader from artist, and add uploader to `publisher`. To keep older version's behavior, if artist is not set, add uploader to `artist`.
- Change date format from _"YYYYMMDD"_ to more widely used _"YYYY-MM-DD"_. (#26533)
- Enable to add any metadata (if not used by youtube-dl) like composer, conductor with `--metadata-from-title`. (#16878)
