### PR TITLE
feat(arte_extractor): add alt_title for regular shows                …

### DIFF
--- a/youtube_dl/extractor/arte.py
+++ b/youtube_dl/extractor/arte.py
@@ -33,6 +33,15 @@ class ArteTVIE(ArteTVBaseIE):
                         /(?P<id>\d{6}-\d{3}-[AF])
                     ''' % {'langs': ArteTVBaseIE._ARTE_LANGUAGES}
     _TESTS = [{
+        'url': 'https://www.arte.tv/de/videos/092724-001-A/lasst-mich-schlafen/',
+        'info_dict': {
+            'id': '092724-001-A',
+            'ext': 'mp4',
+            'title': 'Lasst mich schlafen!',
+            'alt_title': 'Wie schlafen wir?',
+            'upload_date': '20200224'
+        },
+    }, {
         'url': 'https://www.arte.tv/en/videos/088501-000-A/mexico-stealing-petrol-to-survive/',
         'info_dict': {
             'id': '088501-000-A',
@@ -170,7 +179,7 @@ class ArteTVIE(ArteTVBaseIE):
 
         self._sort_formats(formats)
 
-        return {
+        extracted_metadata = {
             'id': player_info.get('VID') or video_id,
             'title': title,
             'description': player_info.get('VDE'),
@@ -178,6 +187,9 @@ class ArteTVIE(ArteTVBaseIE):
             'thumbnail': player_info.get('programImage') or player_info.get('VTU', {}).get('IUR'),
             'formats': formats,
         }
+        if player_info.get('subtitle', '').strip():
+            extracted_metadata['alt_title'] = player_info.get('subtitle', '').strip()
+        return extracted_metadata
 
 
 class ArteTVEmbedIE(InfoExtractor):


### PR DESCRIPTION
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

I changed somone elses extractor. However, I presume its ok. The checkboxes confused me.

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

Currently a regular show like ARTE Reportage gets the same title
for all ARTE Reportage shows.
This change adds the more meaningful title additionally if available:

https://www.arte.tv/de/videos/030273-820-A/arte-reportage/

Now: title is `ARTE Reportage` and no alt_title is available
With this: title is `ARTE Reportage - Sudan: Die Tigray fliehen aus Äthiopien` and
           alt_title is `Sudan: Die Tigray fliehen aus Äthiopien`