### PR TITLE
changes to use libavformat runtime version when adding aac_adtstoasc filter

### DIFF
--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -321,7 +321,7 @@ class FFmpegFD(ExternalFD):
                 args += ['-f', 'mpegts']
             else:
                 args += ['-f', 'mp4']
-                if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._versions['ffmpeg'], '3.2', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
+                if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._lavf_version, '57.56.100', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
                     args += ['-bsf:a', 'aac_adtstoasc']
         elif protocol == 'rtmp':
             args += ['-f', 'flv']

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -321,7 +321,7 @@ class FFmpegFD(ExternalFD):
                 args += ['-f', 'mpegts']
             else:
                 args += ['-f', 'mp4']
-                if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._lavf_version, '57.56.100', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
+                if (ffpp.basename == 'ffmpeg' and is_outdated_version(ffpp._lavf_version.get('runtime'), '57.56.100', False)) and (not info_dict.get('acodec') or info_dict['acodec'].split('.')[0] in ('aac', 'mp4a')):
                     args += ['-bsf:a', 'aac_adtstoasc']
         elif protocol == 'rtmp':
             args += ['-f', 'flv']

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -81,11 +81,14 @@ class FFmpegPostProcessor(PostProcessor):
                 # get ffmpeg and libavformat runtime versions
                 vers = get_exe_version(
                     path, args=['-version'],
-                    version_re=r'(?s)version\s+([-0-9._a-zA-Z]+)(?:.*?libavformat.*?/\s+([0-9. ]+))?')
+                    version_re=r'(?s)version\s+([-0-9._a-zA-Z]+)(?:.*?libavformat\s+([0-9. ]+)\s+/\s+([0-9. ]+))?')
                 if isinstance(vers, (list, tuple)):
                     ver = vers[0]
-                    if len(vers) > 1 and vers[1]:
-                        self._lavf_version = vers[1].replace(' ', '')
+                    if len(vers) > 2 and vers[1] and vers[2]:
+                        self._lavf_version = {
+                            'build': vers[1].replace(' ', ''),
+                            'runtime': vers[2].replace(' ', '')
+                        }
                 else:
                     ver = vers
             else:
@@ -107,7 +110,7 @@ class FFmpegPostProcessor(PostProcessor):
 
         self._paths = None
         self._versions = None
-        self._lavf_version = None
+        self._lavf_version = {}
         if self._downloader:
             prefer_ffmpeg = self._downloader.params.get('prefer_ffmpeg', True)
             location = self._downloader.params.get('ffmpeg_location')

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -77,7 +77,19 @@ class FFmpegPostProcessor(PostProcessor):
         prefer_ffmpeg = True
 
         def get_ffmpeg_version(path):
-            ver = get_exe_version(path, args=['-version'])
+            if os.path.basename(path) == 'ffmpeg':
+                # get ffmpeg and libavformat runtime versions
+                vers = get_exe_version(
+                    path, args=['-version'],
+                    version_re=r'(?s)version\s+([-0-9._a-zA-Z]+)(?:.*?libavformat.*?/\s+([0-9. ]+))?')
+                if isinstance(vers, (list, tuple)):
+                    ver = vers[0]
+                    if len(vers) > 1 and vers[1]:
+                        self._lavf_version = vers[1].replace(' ', '')
+                else:
+                    ver = vers
+            else:
+                ver = get_exe_version(path, args=['-version'])
             if ver:
                 regexs = [
                     r'(?:\d+:)?([0-9.]+)-[0-9]+ubuntu[0-9.]+$',  # Ubuntu, see [1]
@@ -95,6 +107,7 @@ class FFmpegPostProcessor(PostProcessor):
 
         self._paths = None
         self._versions = None
+        self._lavf_version = None
         if self._downloader:
             prefer_ffmpeg = self._downloader.params.get('prefer_ffmpeg', True)
             location = self._downloader.params.get('ffmpeg_location')

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -3800,7 +3800,10 @@ def detect_exe_version(output, version_re=None, unrecognized='present'):
         version_re = r'version\s+([-0-9._a-zA-Z]+)'
     m = re.search(version_re, output)
     if m:
-        return m.group(1)
+        if len(m.groups()) == 1:
+            return m.group(1)
+        else:
+            return m.groups()
     else:
         return unrecognized
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Should resolve #28501, and maybe #28078 

Changes to use libavformat runtime version to determine supported features when adding aac_adtstoasc filter.
The filter is automatically added in libavformat.
libavformat 57.56.100 corresponds to ffmpeg 3.2
