### PR TITLE
improve --write-auto-sub when used with --write-sub

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -614,12 +614,13 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
             return [], info
         self._downloader.to_screen('[ffmpeg] Converting subtitles')
         sub_filenames = []
-        for lang, sub in subs.items():
+
+        def convert_sub(filename, lang, sub, info, new_ext):
             ext = sub['ext']
             if ext == new_ext:
                 self._downloader.to_screen(
-                    '[ffmpeg] Subtitle file for %s is already in the requested format' % new_ext)
-                continue
+                    '[ffmpeg] Subtitle file for %s.%s is already in the requested format' % (lang, new_ext))
+                return {}
             old_file = subtitles_filename(filename, lang, ext, info.get('ext'))
             sub_filenames.append(old_file)
             new_file = subtitles_filename(filename, lang, new_ext, info.get('ext'))
@@ -639,22 +640,37 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
                     f.write(srt_data)
                 old_file = srt_file
 
-                subs[lang] = {
+                new_sub = {
                     'ext': 'srt',
                     'data': srt_data
                 }
 
                 if new_ext == 'srt':
-                    continue
+                    return new_sub
                 else:
                     sub_filenames.append(srt_file)
 
             self.run_ffmpeg(old_file, new_file, ['-f', new_format])
 
             with io.open(new_file, 'rt', encoding='utf-8') as f:
-                subs[lang] = {
+                new_sub = {
                     'ext': new_ext,
                     'data': f.read(),
                 }
+                return new_sub
+
+        new_subs = {}
+        for lang, sub in subs.items():
+            new_sub = convert_sub(filename, lang, sub, info, new_ext)
+            if not new_sub:  # no conversion done, keep original sub
+                new_sub = sub
+            if sub.get('auto'):
+                new_auto_sub = convert_sub(filename, lang + '.auto', sub['auto'], info, new_ext)
+                if not new_auto_sub:  # no conversion done, keep original auto sub
+                    new_auto_sub = sub['auto']
+                new_sub.update({'auto': new_auto_sub})
+            new_subs[lang] = new_sub
+
+        info['requested_subtitles'] = new_subs
 
         return sub_filenames, info


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #29366

When normal and auto subs are available for some language and if both `--write-sub` and `--write-auto-sub` are specified, normal sub is written to _filename.lang.fmt_ but auto sub is not.

This PR makes it possible to write auto sub to _filename.lang.**auto**.fmt_
Works for the aforementioned condition only. Otherwise, auto sub will be written to _filename.lang.fmt_ same as previous versions.

`--embed-subs` is not changed and works as before. ~~If I found how to embed two subs for one language, I would update.~~
