### PR TITLE
[extractor/common] add transform_source kwargs to _search_json_ld()

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -1195,10 +1195,12 @@ class InfoExtractor(object):
         # At the same time `default` may be passed that assumes `fatal=False`
         # for _search_regex. Let's simulate the same behavior here as well.
         fatal = kwargs.get('fatal', True) if default == NO_DEFAULT else False
+        # Give the caller extractor the opportunity to fix malformed JSON-LD.
+        transform_source = kwargs.get('transform_source', None)
         json_ld = []
         for mobj in json_ld_list:
             json_ld_item = self._parse_json(
-                mobj.group('json_ld'), video_id, fatal=fatal)
+                mobj.group('json_ld'), video_id, transform_source=transform_source, fatal=fatal)
             if not json_ld_item:
                 continue
             if isinstance(json_ld_item, dict):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

add `transform_source` kwargs to `_search_json_ld()` and pass it the first `_parse_json()` call.

I'm making a change to vbox7 extractor, and vbox7.com returns malformed JSON-LD, containing raw CRLFs in string. I need to replace these with escaped LFs and want `transform_source`.

Since this enhancement is not related to vbox7 extractor directly, I submit this separate PR.
 