### PR TITLE
[extractor/vbox7] improve extraction

### DIFF
--- a/youtube_dl/extractor/vbox7.py
+++ b/youtube_dl/extractor/vbox7.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 import re
 
 from .common import InfoExtractor
-from ..utils import ExtractorError
+from ..compat import compat_str
+from ..utils import (
+    ExtractorError,
+    int_or_none,
+)
 
 
 class Vbox7IE(InfoExtractor):
@@ -23,7 +27,7 @@ class Vbox7IE(InfoExtractor):
     _GEO_COUNTRIES = ['BG']
     _TESTS = [{
         'url': 'http://vbox7.com/play:0946fff23c',
-        'md5': 'a60f9ab3a3a2f013ef9a967d5f7be5bf',
+        'md5': '50ca1f78345a9c15391af47d8062d074',
         'info_dict': {
             'id': '0946fff23c',
             'ext': 'mp4',
@@ -34,9 +38,11 @@ class Vbox7IE(InfoExtractor):
             'upload_date': '20160812',
             'uploader': 'zdraveibulgaria',
         },
-        'params': {
-            'proxy': '127.0.0.1:8118',
-        },
+        'expected_warnings': ['Failed to parse MPD manifest.*'],
+        # direct connection should work
+        # 'params': {
+        #     'proxy': '127.0.0.1:8118',
+        # },
     }, {
         'url': 'http://vbox7.com/play:249bb972c2',
         'md5': '99f65c0c9ef9b682b97313e052734c3f',
@@ -65,6 +71,11 @@ class Vbox7IE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
+        # Download webpage first. It should be more natural than download json first,
+        # though crucial video information is not extracted from it
+        webpage = self._download_webpage(
+            'https://www.vbox7.com/play:%s' % video_id, video_id, fatal=None)
+
         response = self._download_json(
             'https://www.vbox7.com/ajax/video/nextvideo.php?vid=%s' % video_id,
             video_id)
@@ -72,6 +83,9 @@ class Vbox7IE(InfoExtractor):
         if 'error' in response:
             raise ExtractorError(
                 '%s said: %s' % (self.IE_NAME, response['error']), expected=True)
+        elif response.get('success') is False:
+            raise ExtractorError(
+                'Unable to get video information. Please make sure that the URL is alive and playable in a browser.', expected=True)
 
         video = response['options']
 
@@ -83,23 +97,61 @@ class Vbox7IE(InfoExtractor):
 
         uploader = video.get('uploader')
 
-        webpage = self._download_webpage(
-            'http://vbox7.com/play:%s' % video_id, video_id, fatal=None)
+        formats = []
+        if re.search(r'\.mpd\b', video_url):
+            # youtube-dl cannot parse GPAC generated MPD used here, but try anyway,
+            # and use mp4 formats (usually provided to Safari, iOS and old Win's) on failure
+            try:
+                formats.extend(self._extract_mpd_formats(
+                    video_url, video_id, 'dash', fatal=False))
+            except KeyError:
+                self.report_warning('Failed to parse MPD manifest. Use alternate mp4 formats')
+                highest_res = video.get('highestRes') or 1080
+                resolutions = video.get('resolutions') or (1080, 720, 480, 240, 144)
+                for res in resolutions:
+                    if not res or res > highest_res:
+                        continue
+                    formats.append({
+                        'url': video_url.replace('.mpd', '_%s.mp4' % res),
+                        'format_id': compat_str(res),
+                        'height': res,
+                    })
+        else:
+            formats.append({
+                'url': video_url,
+            })
+
+        self._sort_formats(formats)
 
         info = {}
+        thumbnail = None
 
         if webpage:
+            def transform_source(src):
+                # fix malformed JSON-LD. replace raw CRLFs with escaped LFs
+                return re.sub(
+                    r'"[^"]+"', lambda m: re.sub(r'\r?\n', r'\\n', m.group(0)), src)
+
             info = self._search_json_ld(
                 webpage.replace('"/*@context"', '"@context"'), video_id,
-                fatal=False)
+                transform_source=transform_source,
+                default={})
+            if not info:
+                description = self._html_search_meta(
+                    ['description', 'og:description'], webpage, default=None)
+                if description:
+                    description = description.replace('\r ', '\n')
+                info.update({
+                    'description': description,
+                    'duration': int_or_none(video.get('duration')),
+                })
+            thumbnail = info.get('thumbnail') or self._og_search_thumbnail(webpage)
 
         info.update({
             'id': video_id,
             'title': title,
-            'url': video_url,
+            'formats': formats,
             'uploader': uploader,
-            'thumbnail': self._proto_relative_url(
-                info.get('thumbnail') or self._og_search_thumbnail(webpage),
-                'http:'),
+            'thumbnail': self._proto_relative_url(thumbnail, 'https:'),
         })
         return info

--- a/youtube_dl/extractor/vbox7.py
+++ b/youtube_dl/extractor/vbox7.py
@@ -99,8 +99,8 @@ class Vbox7IE(InfoExtractor):
 
         formats = []
         if re.search(r'\.mpd\b', video_url):
-            # youtube-dl cannot parse GPAC generated MPD used here, but try anyway,
-            # and use mp4 formats (usually provided to Safari, iOS and old Win's) on failure
+            # In case MPD cannot be parsed, use mp4 format as a fallback
+            # usually provided to Safari, iOS, and old Win's
             try:
                 formats.extend(self._extract_mpd_formats(
                     video_url, video_id, 'dash', fatal=False))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Can supersede #18698
Resolves #14685, resolves #26063 (though the log is wrong), resolves #26218, resolves #27575

_PR #29669 is not required (works without it), but desirable to parse malformed JSON-LD for some videos (#26063 or #26218)._

vbox7.com returns GPAC generated MPD. youtube-dl currently cannot parse this MPD (causes KeyError). On the other hand, vbox7.com provides mp4 formats to Safari, iOS and old Win's (conditions in canPlayDash() in [jquery.vboxmediaplayer.v5.js](https://i49.vbox7.com/assets/js/vbox/vboxplayer/jquery.vboxmediaplayer.v5.js)).

I changed the extractor to try parsing MPD first (may succeed if vbox7.com or youtube-dl future changes) and use mp4 formats as fallbacks.
~~_Edit: Confirmed that PR #14648 can parse MPD used here._~~
_Edit: Made PR #30279 and GPAC generated MPD can be parsed._

thumbnail url extraction would cause exception if `webpage` was not set, so I moved its position into `if` block.