### PR TITLE
[postprocessor/ffmpeg] skip postprocessing for missing subtitles

### DIFF
--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -395,8 +395,13 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
         for lang, sub_info in subtitles.items():
             sub_ext = sub_info['ext']
             if ext != 'webm' or ext == 'webm' and sub_ext == 'vtt':
+                sub_filename = subtitles_filename(filename, lang, sub_ext, ext)
+                if not os.path.exists(encodeFilename(sub_filename)):
+                    self._downloader.report_warning(
+                        '[ffmpeg] Skip embedding subtitles because the file "%s" is missing.' % sub_filename)
+                    continue
                 sub_langs.append(lang)
-                sub_filenames.append(subtitles_filename(filename, lang, sub_ext, ext))
+                sub_filenames.append(sub_filename)
             else:
                 if not webm_vtt_warn and ext == 'webm' and sub_ext != 'vtt':
                     webm_vtt_warn = True
@@ -621,6 +626,10 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
                     '[ffmpeg] Subtitle file for %s is already in the requested format' % new_ext)
                 continue
             old_file = subtitles_filename(filename, lang, ext, info.get('ext'))
+            if not os.path.exists(encodeFilename(old_file)):
+                self._downloader.report_warning(
+                    '[ffmpeg] Skip converting subtitles because the file "%s" is missing.' % old_file)
+                continue
             sub_filenames.append(old_file)
             new_file = subtitles_filename(filename, lang, new_ext, info.get('ext'))
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
Could not find suitable test module.
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #28632

Skip postprocessing (converting/embedding) for missing subtitles, like skip embedding for missing thumbnails now.
This situation can occur if subtitles could not be downloaded, or if the user (un)intentionally deleted subtitles file while downloading the video.

_If PR #29702 was merged first, this PR needs modifications._