### PR TITLE
modify --write-all-thumbnails option

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -774,7 +774,7 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='writethumbnail', default=False,
         help='Write thumbnail image to disk')
     thumbnail.add_option(
-        '--write-all-thumbnails',
+        '--all-thumbnails', '--write-all-thumbnails',
         action='store_true', dest='write_all_thumbnails', default=False,
         help='Write all thumbnail image formats to disk')
     thumbnail.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
No test module using `write_all_thumbnails`
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

`--write-all-thumbnails` option is not well balanced as compared to formats and subs.

`--list-formats`/`--all-formats` for formats, `--list-subs`/`--all-subs` for subs, while
`--list-thumbnails`/`--write-all-thumbnails` for thumbnails.

Modify option name to `--all-thumbnails` and leave `--write-all-thumbnails` as its alias.
