### PR TITLE
[YoutubeDL] improvements to writing thumbnails

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2446,11 +2446,18 @@ class YoutubeDL(object):
             # No thumbnails present, so return immediately
             return
 
+        def make_thumb_filename(filename, suffix, thumb_ext, file_ext):
+            thumb_filename = replace_extension(filename, thumb_ext, file_ext)
+            if suffix:
+                name, ext = os.path.splitext(thumb_filename)
+                thumb_filename = name + suffix + ext
+            return thumb_filename
+
         for t in thumbnails:
             thumb_ext = determine_ext(t['url'], 'jpg')
             suffix = '_%s' % t['id'] if len(thumbnails) > 1 else ''
             thumb_display_id = '%s ' % t['id'] if len(thumbnails) > 1 else ''
-            t['filename'] = thumb_filename = replace_extension(filename + suffix, thumb_ext, info_dict.get('ext'))
+            t['filename'] = thumb_filename = make_thumb_filename(filename, suffix, thumb_ext, info_dict.get('ext'))
 
             if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(thumb_filename)):
                 self.to_screen('[%s] %s: Thumbnail %sis already present' %
@@ -2460,6 +2467,15 @@ class YoutubeDL(object):
                                (info_dict['extractor'], info_dict['id'], thumb_display_id))
                 try:
                     uf = self.urlopen(t['url'])
+                    if uf.headers.get('Content-Type', '').startswith('image/webp') and thumb_ext.lower() != 'webp':
+                        self.to_screen('[%s] %s: Set thumbnail %sextension to "webp" according to "Content-Type" header' %
+                                       (info_dict['extractor'], info_dict['id'], thumb_display_id))
+                        t['filename'] = thumb_filename = make_thumb_filename(
+                            filename, suffix, 'webp', info_dict.get('ext'))
+                        if self.params.get('nooverwrites', False) and os.path.exists(encodeFilename(thumb_filename)):
+                            self.to_screen('[%s] %s: Thumbnail %sis already present' %
+                                           (info_dict['extractor'], info_dict['id'], thumb_display_id))
+                            continue
                     with open(encodeFilename(thumb_filename), 'wb') as thumbf:
                         shutil.copyfileobj(uf, thumbf)
                     self.to_screen('[%s] %s: Writing thumbnail %sto: %s' %


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

As shown in the output below, there are problems on writing thumbnails.
1. improper file names like _filename.**mp4**\_0.jpg_ (should be like _filename_0.jpg_) for `--write-all-thumbnails`
2. (mostly for YouTube) webp formats may have _jpg_ extensions (should have _webp_ extensions)
```
$ youtube-dl --version
2021.06.06
$ youtube-dl _BggT--yxf0 --ignore-config --id -f18 --skip-download --write-all-thumbnails
[youtube] _BggT--yxf0: Downloading webpage
[youtube] _BggT--yxf0: Downloading thumbnail 0 ...
[youtube] _BggT--yxf0: Writing thumbnail 0 to: _BggT--yxf0.mp4_0.jpg
[youtube] _BggT--yxf0: Downloading thumbnail 1 ...
[youtube] _BggT--yxf0: Writing thumbnail 1 to: _BggT--yxf0.mp4_1.jpg
[youtube] _BggT--yxf0: Downloading thumbnail 2 ...
[youtube] _BggT--yxf0: Writing thumbnail 2 to: _BggT--yxf0.mp4_2.jpg
[youtube] _BggT--yxf0: Downloading thumbnail 3 ...
[youtube] _BggT--yxf0: Writing thumbnail 3 to: _BggT--yxf0.mp4_3.jpg
$ file _BggT--yxf0.mp4_0.jpg 
_BggT--yxf0.mp4_0.jpg: RIFF (little-endian) data, Web/P image, VP8 encoding, 168x94, Scaling: [none]x[none], YUV color, decoders should clamp
```
This PR improves these problems. (resolves #29754 by 2.)
