### PR TITLE
[postprocessor/embedthumbnail] keep original thumbnail after embedding

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -59,6 +59,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 thumbnail_filename = thumbnail_webp_filename
                 thumbnail_ext = 'webp'
 
+        converted_thumbnail = False
         # Convert unsupported thumbnail formats to JPEG (see #25687, #25717)
         if thumbnail_ext not in ['jpg', 'png']:
             # NB: % is supposed to be escaped with %% but this does not work
@@ -68,11 +69,16 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             escaped_thumbnail_jpg_filename = replace_extension(escaped_thumbnail_filename, 'jpg')
             self._downloader.to_screen('[ffmpeg] Converting thumbnail "%s" to JPEG' % escaped_thumbnail_filename)
             self.run_ffmpeg(escaped_thumbnail_filename, escaped_thumbnail_jpg_filename, ['-bsf:v', 'mjpeg2jpeg'])
-            os.remove(encodeFilename(escaped_thumbnail_filename))
+            if self._already_have_thumbnail:
+                # Rename back to original filename and keep
+                os.rename(encodeFilename(escaped_thumbnail_filename), encodeFilename(thumbnail_filename))
+            else:
+                os.remove(encodeFilename(escaped_thumbnail_filename))
             thumbnail_jpg_filename = replace_extension(thumbnail_filename, 'jpg')
             # Rename back to unescaped for further processing
             os.rename(encodeFilename(escaped_thumbnail_jpg_filename), encodeFilename(thumbnail_jpg_filename))
             thumbnail_filename = thumbnail_jpg_filename
+            converted_thumbnail = True
 
         if info['ext'] == 'mp3':
             options = [
@@ -83,7 +89,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
 
             self.run_ffmpeg_multiple_files([filename, thumbnail_filename], temp_filename, options)
 
-            if not self._already_have_thumbnail:
+            if not self._already_have_thumbnail or converted_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))
             os.remove(encodeFilename(filename))
             os.rename(encodeFilename(temp_filename), encodeFilename(filename))
@@ -115,7 +121,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
                 msg = stderr.decode('utf-8', 'replace').strip()
                 raise EmbedThumbnailPPError(msg)
 
-            if not self._already_have_thumbnail:
+            if not self._already_have_thumbnail or converted_thumbnail:
                 os.remove(encodeFilename(thumbnail_filename))
             # for formats that don't support thumbnails (like 3gp) AtomicParsley
             # won't create to the temporary file


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

When the original thumbnail is not jpg/png and do `--write-thumbnail --embed-thumbnail`, original thumbnail is removed and converted jpg remains.
This is not correct as `--write-thumbnail`. Original thumbnail must be kept and converted jpg must be removed.
