### PR TITLE
warn --convert-sub with --skip-download

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -458,6 +458,10 @@ def _real_main(argv=None):
                 'You must provide at least one URL.\n'
                 'Type youtube-dl --help to see a list of all options.')
 
+        # Remove this `if` block when PR #9738 is finished
+        if opts.convertsubtitles and opts.skip_download:
+            ydl.report_warning('--convert-subs is a post-processing option and doesn\'t work with --skip-download')
+
         try:
             if opts.load_info_filename is not None:
                 retcode = ydl.download_with_info_file(expand_path(opts.load_info_filename))


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Show warning for `--convert-sub` if combined with `--skip-download` until PR #9738 is finished.

Unlike other post-processing options, it is not easy to tell from its name or feature that `--convert-sub` is a post-processing option and doesn't work with `--skip-download`.
There are users who try/expect to get converted subtitles with `--convert-sub --skip-download`, and without any indication they may confuse.

_command line only, it is obvious in python api that convert-sub is for post-processing._
