### PR TITLE
[tv2] fix extraction

### DIFF
--- a/youtube_dl/extractor/tv2.py
+++ b/youtube_dl/extractor/tv2.py
@@ -24,7 +24,7 @@ class TV2IE(InfoExtractor):
         'url': 'http://www.tv2.no/v/916509/',
         'info_dict': {
             'id': '916509',
-            'ext': 'flv',
+            'ext': 'mp4',
             'title': 'Se Frode Gryttens hyllest av Steven Gerrard',
             'description': 'TV 2 Sportens huspoet tar avskjed med Liverpools kaptein Steven Gerrard.',
             'timestamp': 1431715610,
@@ -35,7 +35,7 @@ class TV2IE(InfoExtractor):
         },
     }]
     _API_DOMAIN = 'sumo.tv2.no'
-    _PROTOCOLS = ('HDS', 'HLS', 'DASH')
+    _PROTOCOLS = ('HLS', 'DASH')
     _GEO_COUNTRIES = ['NO']
 
     def _real_extract(self, url):
@@ -53,7 +53,7 @@ class TV2IE(InfoExtractor):
         for protocol in self._PROTOCOLS:
             try:
                 data = self._download_json(
-                    api_base + '/play.json?protocol=%s&videoFormat=SMIL+ISMUSP' % protocol,
+                    api_base + '/play.json?protocol=%s' % protocol,
                     video_id, 'Downloading play JSON')['playback']
             except ExtractorError as e:
                 if isinstance(e.cause, compat_HTTPError) and e.cause.code == 401:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is an easy fix to resolve #29829.
Have confirmed that Katsomo (subclass of TV2) works the same as before.

It would be better to use new api, though. Minimal call using curl would be:
```
curl https://api.sumo.tv2.no/play/1676282?stream=HLS \
-H 'Content-Type: application/json' \
--data-raw '{"device":{"id":"1-1-1","name":"Nettleser (HTML)"}}'
```
and `stream=DASH`.
