### PR TITLE
[aes] Add signature conversion decorator to `aes`

### DIFF
--- a/devscripts/generate_aes_testdata.py
+++ b/devscripts/generate_aes_testdata.py
@@ -7,14 +7,13 @@ import os
 import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from youtube_dl.utils import intlist_to_bytes
-from youtube_dl.aes import aes_encrypt, key_expansion
+from youtube_dl.aes import aes_encrypt
 
 secret_msg = b'Secret message goes here'
 
 
 def hex_str(int_list):
-    return codecs.encode(intlist_to_bytes(int_list), 'hex')
+    return codecs.encode(int_list, 'hex')
 
 
 def openssl_encode(algo, key, iv):
@@ -24,20 +23,20 @@ def openssl_encode(algo, key, iv):
     return out
 
 
-iv = key = [0x20, 0x15] + 14 * [0]
+iv = key = b' \x15' + b'\x00' * 14
 
 r = openssl_encode('aes-128-cbc', key, iv)
 print('aes_cbc_decrypt')
 print(repr(r))
 
 password = key
-new_key = aes_encrypt(password, key_expansion(password))
+new_key = aes_encrypt(password, password)
 r = openssl_encode('aes-128-ctr', new_key, iv)
 print('aes_decrypt_text 16')
 print(repr(r))
 
-password = key + 16 * [0]
-new_key = aes_encrypt(password, key_expansion(password)) * (32 // 16)
+password = key + b'\x00' * 16
+new_key = aes_encrypt(password, password) * (32 // 16)
 r = openssl_encode('aes-256-ctr', new_key, iv)
 print('aes_decrypt_text 32')
 print(repr(r))

--- a/test/test_aes.py
+++ b/test/test_aes.py
@@ -6,9 +6,10 @@ from __future__ import unicode_literals
 import os
 import sys
 import unittest
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from youtube_dl.aes import aes_decrypt, aes_encrypt, aes_cbc_decrypt, aes_cbc_encrypt, aes_decrypt_text
+from youtube_dl.aes import _aes_decrypt, _aes_encrypt, aes_cbc_decrypt, aes_cbc_encrypt, aes_decrypt_text
 from youtube_dl.utils import bytes_to_intlist, intlist_to_bytes
 import base64
 
@@ -17,45 +18,40 @@ import base64
 
 class TestAES(unittest.TestCase):
     def setUp(self):
-        self.key = self.iv = [0x20, 0x15] + 14 * [0]
+        self.key = self.iv = b' \x15\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
         self.secret_msg = b'Secret message goes here'
 
     def test_encrypt(self):
         msg = b'message'
-        key = list(range(16))
-        encrypted = aes_encrypt(bytes_to_intlist(msg), key)
-        decrypted = intlist_to_bytes(aes_decrypt(encrypted, key))
+        key = list(range(16))  # this considered already expanded
+        encrypted = _aes_encrypt(bytes_to_intlist(msg), key)
+        decrypted = intlist_to_bytes(_aes_decrypt(encrypted, key))
         self.assertEqual(decrypted, msg)
 
     def test_cbc_decrypt(self):
-        data = bytes_to_intlist(
-            b"\x97\x92+\xe5\x0b\xc3\x18\x91ky9m&\xb3\xb5@\xe6'\xc2\x96.\xc8u\x88\xab9-[\x9e|\xf1\xcd"
-        )
-        decrypted = intlist_to_bytes(aes_cbc_decrypt(data, self.key, self.iv))
+        data = b"\x97\x92+\xe5\x0b\xc3\x18\x91ky9m&\xb3\xb5@\xe6'\xc2\x96.\xc8u\x88\xab9-[\x9e|\xf1\xcd"
+        decrypted = aes_cbc_decrypt(data, self.key, self.iv)
         self.assertEqual(decrypted.rstrip(b'\x08'), self.secret_msg)
 
     def test_cbc_encrypt(self):
-        data = bytes_to_intlist(self.secret_msg)
-        encrypted = intlist_to_bytes(aes_cbc_encrypt(data, self.key, self.iv))
+        encrypted = aes_cbc_encrypt(self.secret_msg, self.key, self.iv)
         self.assertEqual(
             encrypted,
             b"\x97\x92+\xe5\x0b\xc3\x18\x91ky9m&\xb3\xb5@\xe6'\xc2\x96.\xc8u\x88\xab9-[\x9e|\xf1\xcd")
 
     def test_decrypt_text(self):
-        password = intlist_to_bytes(self.key).decode('utf-8')
+        password = self.key.decode('utf-8')
         encrypted = base64.b64encode(
-            intlist_to_bytes(self.iv[:8])
-            + b'\x17\x15\x93\xab\x8d\x80V\xcdV\xe0\t\xcdo\xc2\xa5\xd8ksM\r\xe27N\xae'
+            self.iv[:8] + b'\x17\x15\x93\xab\x8d\x80V\xcdV\xe0\t\xcdo\xc2\xa5\xd8ksM\r\xe27N\xae'
         ).decode('utf-8')
-        decrypted = (aes_decrypt_text(encrypted, password, 16))
+        decrypted = aes_decrypt_text(encrypted, password, 16)
         self.assertEqual(decrypted, self.secret_msg)
 
-        password = intlist_to_bytes(self.key).decode('utf-8')
+        password = self.key.decode('utf-8')
         encrypted = base64.b64encode(
-            intlist_to_bytes(self.iv[:8])
-            + b'\x0b\xe6\xa4\xd9z\x0e\xb8\xb9\xd0\xd4i_\x85\x1d\x99\x98_\xe5\x80\xe7.\xbf\xa5\x83'
+            self.iv[:8] + b'\x0b\xe6\xa4\xd9z\x0e\xb8\xb9\xd0\xd4i_\x85\x1d\x99\x98_\xe5\x80\xe7.\xbf\xa5\x83'
         ).decode('utf-8')
-        decrypted = (aes_decrypt_text(encrypted, password, 32))
+        decrypted = aes_decrypt_text(encrypted, password, 32)
         self.assertEqual(decrypted, self.secret_msg)
 
 

--- a/youtube_dl/aes.py
+++ b/youtube_dl/aes.py
@@ -171,7 +171,7 @@ def _aes_decrypt(data, expanded_key):
     for i in range(rounds, 0, -1):
         data = xor(data, expanded_key[i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES])
         if i != rounds:
-            data = mix_columns_inv(data)
+            data = list(iter_mix_columns(data, MIX_COLUMN_MATRIX_INV))
         data = shift_rows_inv(data)
         data = sub_bytes_inv(data)
     data = xor(data, expanded_key[:BLOCK_SIZE_BYTES])
@@ -194,7 +194,7 @@ def _aes_encrypt(data, expanded_key):
         data = sub_bytes(data)
         data = shift_rows(data)
         if i != rounds:
-            data = mix_columns(data)
+            data = list(iter_mix_columns(data, MIX_COLUMN_MATRIX))
         data = xor(data, expanded_key[i * BLOCK_SIZE_BYTES: (i + 1) * BLOCK_SIZE_BYTES])
 
     return data
@@ -404,49 +404,29 @@ def xor(data1, data2):
     return [x ^ y for x, y in zip(data1, data2)]
 
 
-def rijndael_mul(a, b):
-    if a == 0 or b == 0:
-        return 0
-    return RIJNDAEL_EXP_TABLE[(RIJNDAEL_LOG_TABLE[a] + RIJNDAEL_LOG_TABLE[b]) % 0xFF]
-
-
-def mix_column(data, matrix):
-    data_mixed = []
-    for row in range(4):
-        mixed = 0
-        for column in range(4):
+def iter_mix_columns(data, matrix):
+    for i in (0, 4, 8, 12):
+        d0, d1, d2, d3 = data[i: i + 4]
+        for row in matrix:
+            c0, c1, c2, c3 = row
             # xor is (+) and (-)
-            mixed ^= rijndael_mul(data[column], matrix[row][column])
-        data_mixed.append(mixed)
-    return data_mixed
-
-
-def mix_columns(data, matrix=MIX_COLUMN_MATRIX):
-    data_mixed = []
-    for i in range(4):
-        column = data[i * 4: (i + 1) * 4]
-        data_mixed += mix_column(column, matrix)
-    return data_mixed
-
-
-def mix_columns_inv(data):
-    return mix_columns(data, MIX_COLUMN_MATRIX_INV)
+            v0 = (0 if d0 == 0 or c0 == 0 else
+                  RIJNDAEL_EXP_TABLE[(RIJNDAEL_LOG_TABLE[d0] + RIJNDAEL_LOG_TABLE[c0]) % 0xFF])
+            v1 = (0 if d1 == 0 or c1 == 0 else
+                  RIJNDAEL_EXP_TABLE[(RIJNDAEL_LOG_TABLE[d1] + RIJNDAEL_LOG_TABLE[c1]) % 0xFF])
+            v2 = (0 if d2 == 0 or c2 == 0 else
+                  RIJNDAEL_EXP_TABLE[(RIJNDAEL_LOG_TABLE[d2] + RIJNDAEL_LOG_TABLE[c2]) % 0xFF])
+            v3 = (0 if d3 == 0 or c3 == 0 else
+                  RIJNDAEL_EXP_TABLE[(RIJNDAEL_LOG_TABLE[d3] + RIJNDAEL_LOG_TABLE[c3]) % 0xFF])
+            yield v0 ^ v1 ^ v2 ^ v3
 
 
 def shift_rows(data):
-    data_shifted = []
-    for column in range(4):
-        for row in range(4):
-            data_shifted.append(data[((column + row) & 0b11) * 4 + row])
-    return data_shifted
+    return [data[((column + row) & 0b11) * 4 + row] for column in range(4) for row in range(4)]
 
 
 def shift_rows_inv(data):
-    data_shifted = []
-    for column in range(4):
-        for row in range(4):
-            data_shifted.append(data[((column - row) & 0b11) * 4 + row])
-    return data_shifted
+    return [data[((column - row) & 0b11) * 4 + row] for column in range(4) for row in range(4)]
 
 
 def shift_block(data):
@@ -505,7 +485,7 @@ def ghash(subkey, data):
 
     last_y = [0] * BLOCK_SIZE_BYTES
     for i in range(0, len(data), BLOCK_SIZE_BYTES):
-        block = data[i : i + BLOCK_SIZE_BYTES]  # noqa: E203
+        block = data[i: i + BLOCK_SIZE_BYTES]  # noqa: E203
         last_y = block_product(xor(last_y, block), subkey)
 
     return last_y

--- a/youtube_dl/aes.py
+++ b/youtube_dl/aes.py
@@ -224,7 +224,7 @@ def aes_decrypt_text(data, password, key_size_bytes):
     nonce = data[:NONCE_LENGTH_BYTES]
     cipher = data[NONCE_LENGTH_BYTES:]
 
-    decrypted_data = aes_ctr_decrypt(cipher, key, nonce + b'\00' * (BLOCK_SIZE_BYTES - NONCE_LENGTH_BYTES))
+    decrypted_data = aes_ctr_decrypt(cipher, key, nonce + b'\x00' * (BLOCK_SIZE_BYTES - NONCE_LENGTH_BYTES))
 
     return decrypted_data
 

--- a/youtube_dl/extractor/adn.py
+++ b/youtube_dl/extractor/adn.py
@@ -87,11 +87,11 @@ class ADNIE(InfoExtractor):
             return None
 
         # http://animedigitalnetwork.fr/components/com_vodvideo/videojs/adn-vjs.min.js
-        dec_subtitles = intlist_to_bytes(aes_cbc_decrypt(
-            bytes_to_intlist(compat_b64decode(enc_subtitles[24:])),
-            bytes_to_intlist(binascii.unhexlify(self._K + 'ab9f52f5baae7c72')),
-            bytes_to_intlist(compat_b64decode(enc_subtitles[:24]))
-        ))
+        dec_subtitles = aes_cbc_decrypt(
+            compat_b64decode(enc_subtitles[24:]),
+            binascii.unhexlify(self._K + 'ab9f52f5baae7c72'),
+            compat_b64decode(enc_subtitles[:24])
+        )
         subtitles_json = self._parse_json(
             dec_subtitles[:-compat_ord(dec_subtitles[-1])].decode(),
             None, fatal=False)

--- a/youtube_dl/extractor/anvato.py
+++ b/youtube_dl/extractor/anvato.py
@@ -12,9 +12,7 @@ from .common import InfoExtractor
 from ..aes import aes_encrypt
 from ..compat import compat_str
 from ..utils import (
-    bytes_to_intlist,
     determine_ext,
-    intlist_to_bytes,
     int_or_none,
     strip_jsonp,
     unescapeHTML,
@@ -253,8 +251,7 @@ class AnvatoIE(InfoExtractor):
         server_time = self._server_time(access_key, video_id)
         input_data = '%d~%s~%s' % (server_time, md5_text(video_data_url), md5_text(server_time))
 
-        auth_secret = intlist_to_bytes(aes_encrypt(
-            bytes_to_intlist(input_data[:64]), bytes_to_intlist(self._AUTH_KEY)))
+        auth_secret = aes_encrypt(input_data[:64], self._AUTH_KEY)
 
         video_data_url += '&X-Anvato-Adst-Auth=' + base64.b64encode(auth_secret).decode('ascii')
         anvrid = md5_text(time.time() * 1000 * random.random())[:30]

--- a/youtube_dl/extractor/drtv.py
+++ b/youtube_dl/extractor/drtv.py
@@ -10,10 +10,8 @@ from .common import InfoExtractor
 from ..aes import aes_cbc_decrypt
 from ..compat import compat_urllib_parse_unquote
 from ..utils import (
-    bytes_to_intlist,
     ExtractorError,
     int_or_none,
-    intlist_to_bytes,
     float_or_none,
     mimetype2ext,
     str_or_none,
@@ -191,13 +189,12 @@ class DRTVIE(InfoExtractor):
         def decrypt_uri(e):
             n = int(e[2:10], 16)
             a = e[10 + n:]
-            data = bytes_to_intlist(hex_to_bytes(e[10:10 + n]))
-            key = bytes_to_intlist(hashlib.sha256(
-                ('%s:sRBzYNXBzkKgnjj8pGtkACch' % a).encode('utf-8')).digest())
-            iv = bytes_to_intlist(hex_to_bytes(a))
+            data = hex_to_bytes(e[10:10 + n])
+            key = hashlib.sha256(
+                ('%s:sRBzYNXBzkKgnjj8pGtkACch' % a).encode('utf-8')).digest()
+            iv = hex_to_bytes(a)
             decrypted = aes_cbc_decrypt(data, key, iv)
-            return intlist_to_bytes(
-                decrypted[:-decrypted[-1]]).decode('utf-8').split('?')[0]
+            return decrypted[:-ord(decrypted[-1])].decode('utf-8').split('?')[0]
 
         for asset in assets:
             kind = asset.get('Kind')

--- a/youtube_dl/extractor/newstube.py
+++ b/youtube_dl/extractor/newstube.py
@@ -7,9 +7,7 @@ import hashlib
 from .common import InfoExtractor
 from ..aes import aes_cbc_decrypt
 from ..utils import (
-    bytes_to_intlist,
     int_or_none,
-    intlist_to_bytes,
     parse_codecs,
     parse_duration,
 )
@@ -47,10 +45,8 @@ class NewstubeIE(InfoExtractor):
             }))
         key = hashlib.pbkdf2_hmac(
             'sha1', video_guid.replace('-', '').encode(), enc_data[:16], 1)[:16]
-        dec_data = aes_cbc_decrypt(
-            bytes_to_intlist(enc_data[32:]), bytes_to_intlist(key),
-            bytes_to_intlist(enc_data[16:32]))
-        sources = self._parse_json(intlist_to_bytes(dec_data[:-dec_data[-1]]), video_guid)
+        dec_data = aes_cbc_decrypt(enc_data[32:], key, enc_data[16:32])
+        sources = self._parse_json(dec_data[:-ord(dec_data[-1])], video_guid)
 
         formats = []
         for source in sources:

--- a/youtube_dl/extractor/rtl2.py
+++ b/youtube_dl/extractor/rtl2.py
@@ -11,9 +11,7 @@ from ..compat import (
     compat_str,
 )
 from ..utils import (
-    bytes_to_intlist,
     ExtractorError,
-    intlist_to_bytes,
     int_or_none,
     strip_or_none,
 )
@@ -142,11 +140,7 @@ class RTL2YouIE(RTL2YouBaseIE):
             self._BACKWERK_BASE_URL + 'stream/video/' + video_id, video_id)
 
         data, iv = compat_b64decode(stream_data['streamUrl']).decode().split(':')
-        stream_url = intlist_to_bytes(aes_cbc_decrypt(
-            bytes_to_intlist(compat_b64decode(data)),
-            bytes_to_intlist(self._AES_KEY),
-            bytes_to_intlist(compat_b64decode(iv))
-        ))
+        stream_url = aes_cbc_decrypt(compat_b64decode(data), self._AES_KEY, compat_b64decode(iv))
         if b'rtl2_you_video_not_found' in stream_url:
             raise ExtractorError('video not found', expected=True)
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

It starts an overhaul of `aes`.
- [x] Simplifies signature of functions in the module, instead list of integers they accept bytes.
- [x] Adds function for AES-128-GCM  decrypt (uses already existing function for AES-CRT) and verification.
- [ ] Adds new functionality to existing code (i.e. AES-CRT nonce)
- [ ] Converts (internal) functions to also use mentioned types.
- [ ] Restructures the code according to OOP design
- [ ] Adds new tests cases to `test_aes` to safeguard code

I'd like to mention @pukkandan and the help he gave me during  the development of this code at https://github.com/yt-dlp/yt-dlp/pull/938.
