### PR TITLE
[common] Test for valid URL with HEAD

### DIFF
--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -53,6 +53,7 @@ from ..utils import (
     float_or_none,
     GeoRestrictedError,
     GeoUtils,
+    HEADRequest,
     int_or_none,
     js_to_json,
     JSON_LD_RE,
@@ -1469,7 +1470,8 @@ class InfoExtractor(object):
         if not (url.startswith('http://') or url.startswith('https://')):
             return True
         try:
-            self._request_webpage(url, video_id, 'Checking %s URL' % item, headers=headers)
+            req = HEADRequest(url, headers=headers)
+            self._request_webpage(req, video_id, 'Checking %s URL' % item)
             return True
         except ExtractorError as e:
             self.to_screen(


### PR DESCRIPTION
## Please follow the guide below
---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

In the IE `_is_valid_url()` method, the URL is tested for validity. The resource linked may be a large media file which could be downloaded and then discarded. An early version of the method used a `HEAD` request, as would be expected. This was then changed to `GET` in 4069766c527d10b8e25b9262a3882101367deb3e, but there is no supporting rationale and no issues mentioning that `HEAD` requests were being rejected.

If that should be a problem with a specific site, we can set a class var, say `_test_valid_with GET = False` and then make the changed lines as follows, with the var set to `True` for the problem site:
```
            req = url if self._test_valid_with GET else HEADRequest(url)
            self._request_webpage(req, video_id, 'Checking %s URL' % item, headers=headers)
```
Comments welcome.