### PR TITLE
[kuleuven_live] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -548,6 +548,7 @@ from .kinopoisk import KinoPoiskIE
 from .konserthusetplay import KonserthusetPlayIE
 from .krasview import KrasViewIE
 from .ku6 import Ku6IE
+from .kuleuven_live import KULLiveIE
 from .kusi import KUSIIE
 from .kuwo import (
     KuwoIE,

--- a/youtube_dl/extractor/kuleuven_live.py
+++ b/youtube_dl/extractor/kuleuven_live.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+
+class KULLiveIE(InfoExtractor):
+    _VALID_URL = r'(?:(?:https?://(?:www\.)?livestream.kuleuven\.be/\?pin=)|kulive:)(?P<id>[0-9]+)'
+
+    def _real_extract(self, url):
+        pin = self._match_id(url)
+
+        json_res = self._download_json(
+            "https://icts-p-toledo-streaming-video-live-backend.cloud.icts.kuleuven.be/api/viewers/" + pin,
+            pin,
+            'Requesting stream URL',
+            errnote='The stream with pin %s does not exist or has not started yet' % pin,
+            fatal=True)
+        m3u8_url = json_res['streamUrl']
+
+        formats = self._extract_m3u8_formats(m3u8_url, pin, 'mp4')
+
+        return {
+            'id': pin,
+            'title': 'kul-stream',
+            'is_live': True,
+            'formats': formats,
+        }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
  - The nature of the platform doesn't really allow for tests that are similar to those on the other extractors, because the stream pins are supposed to be private and all streams are short-lived.
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add support for https://livestream.kuleuven.be, which is a lecture streaming platform used at KU Leuven university.
I am not sure whether this kind of service is within the scope of what youtube-dl is willing to support, but it would be a welcome addition for KU Leuven students.
The title is always set to 'kul-stream' because these streams do not have a title, I'm not sure whether this is appropriate.
Also see the note above on why I didn't add tests. I don't think tests that rely on an always and publicly available stream are possible here, because there is no such stream on this platform.
