### PR TITLE
[downloader/ffmpeg] Add override option for FFmpeg output args

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -310,6 +310,9 @@ def _real_main(argv=None):
     postprocessor_args = None
     if opts.postprocessor_args:
         postprocessor_args = compat_shlex_split(opts.postprocessor_args)
+    ffmpeg_out_override = None
+    if opts.ffmpeg_out_override:
+        ffmpeg_out_override = compat_shlex_split(opts.ffmpeg_out_override)
     match_filter = (
         None if opts.match_filter is None
         else match_filter_func(opts.match_filter))
@@ -427,6 +430,7 @@ def _real_main(argv=None):
         'hls_prefer_native': opts.hls_prefer_native,
         'hls_use_mpegts': opts.hls_use_mpegts,
         'external_downloader_args': external_downloader_args,
+        'ffmpeg_out_override': ffmpeg_out_override,
         'postprocessor_args': postprocessor_args,
         'cn_verification_proxy': opts.cn_verification_proxy,
         'geo_verification_proxy': opts.geo_verification_proxy,

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -311,7 +311,10 @@ class FFmpegFD(ExternalFD):
             elif isinstance(conn, compat_str):
                 args += ['-rtmp_conn', conn]
 
-        args += ['-i', url, '-c', 'copy']
+        args += ['-i', url]
+
+        ffmpeg_out_override = self.params.get('ffmpeg_out_override')
+        args += ffmpeg_out_override if ffmpeg_out_override else ['-c', 'copy']
 
         if self.params.get('test', False):
             args += ['-fs', compat_str(self._TEST_FILE_SIZE)]

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -525,6 +525,10 @@ def parseOpts(overrideArguments=None):
         '--external-downloader-args',
         dest='external_downloader_args', metavar='ARGS',
         help='Give these arguments to the external downloader')
+    downloader.add_option(
+        '--ffmpeg-out-override',
+        dest='ffmpeg_out_override', metavar='ARGS',
+        help='Give these arguments to the ffmpeg instead of `-c copy`')
 
     workarounds = optparse.OptionGroup(parser, 'Workarounds')
     workarounds.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
  - No tests seem present for any similar options. I guess a test could be added to check whether the resulting ffmpeg command is as expected.
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Adds a new argument `--ffmpeg-out-override` and gives these arguments to FFmpeg in place of `-c copy` (which is currently always used) when present. The similar more general option `external-downloader-args` is not suited for this use case.
This would enable transcoding and compressing videos without first saving them as "copied" from the source.
An example use case would look like this: `youtube-dl --ffmpeg-out-override "-c:v libx265 -crf 31" some_source`. I've found it very useful with sources that normally yield very large video files.
The current name of the argument is questionable, maybe it should be changed before merging.