### PR TITLE
improve post-processing for HLS

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2028,12 +2028,11 @@ class YoutubeDL(object):
                     else:
                         assert fixup_policy in ('ignore', 'never')
 
-                if (info_dict.get('protocol') == 'm3u8_native'
-                        or info_dict.get('protocol') == 'm3u8'
-                        and self.params.get('hls_prefer_native')):
+                if (info_dict.get('requested_formats') is None
+                        and info_dict.get('protocol') in ('m3u8', 'm3u8_native')):
                     if fixup_policy == 'warn':
-                        self.report_warning('%s: malformed AAC bitstream detected.' % (
-                            info_dict['id']))
+                        self.report_warning('Possible malformed AAC bitstream in "%s".' % (
+                            filename))
                     elif fixup_policy == 'detect_or_warn':
                         fixup_pp = FFmpegFixupM3u8PP(self)
                         if fixup_pp.available:
@@ -2041,8 +2040,8 @@ class YoutubeDL(object):
                             info_dict['__postprocessors'].append(fixup_pp)
                         else:
                             self.report_warning(
-                                '%s: malformed AAC bitstream detected. %s'
-                                % (info_dict['id'], INSTALL_FFMPEG_MESSAGE))
+                                'Possible malformed AAC bitstream in "%s". %s'
+                                % (filename, INSTALL_FFMPEG_MESSAGE))
                     else:
                         assert fixup_policy in ('ignore', 'never')
 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2031,7 +2031,7 @@ class YoutubeDL(object):
                 if (info_dict.get('requested_formats') is None
                         and info_dict.get('protocol') in ('m3u8', 'm3u8_native')):
                     if fixup_policy == 'warn':
-                        self.report_warning('Possible malformed AAC bitstream in "%s".' % (
+                        self.report_warning('Container might be left MPEG-TS in "%s".' % (
                             filename))
                     elif fixup_policy == 'detect_or_warn':
                         fixup_pp = FFmpegFixupM3u8PP(self)
@@ -2040,7 +2040,7 @@ class YoutubeDL(object):
                             info_dict['__postprocessors'].append(fixup_pp)
                         else:
                             self.report_warning(
-                                'Possible malformed AAC bitstream in "%s". %s'
+                                'Container might be left MPEG-TS in "%s". %s'
                                 % (filename, INSTALL_FFMPEG_MESSAGE))
                     else:
                         assert fixup_policy in ('ignore', 'never')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

There are problems in post-processing for HLS:
- If native HLS downloader is used for a video-only stream, `FFmpegFixupM3u8PP` does nothing and file is left MPEG-TS. (#26410)
- If native HLS downloader is selected but the download is delegated to ffmpeg, file will be MP4 by default. However, if audio is AAC, `FFmpegFixupM3u8PP` copies MP4 to MP4 unnecessarily.
- Merge fails when audio is MPEG-TS and AAC and ffmpeg is old. (#9913)

So I made the following modifications:
- For single HLS stream, test file format and convert MPEG-TS to MP4 in `FFmpegFixupM3u8PP`. (resolves #26410 and the second above)
- For streams to be merged, test audio stream and fix AAC in `FFmpegMergerPP`. (resolves #9913 essentially, resolves #10644, can supersede #10645)
- Added to get file format in `get_audio_codec()`, thus renamed.

And I slightly modified messages to fit the change of purpose:
- From <code><i>VIDEO-ID</i>: malformed AAC bitstream detected</code> to <code>Container might be left MPEG-TS in "<i>FILENAME</i>"</code> in `YoutubeDL.py`.
Also modified to show filename instead of video-id; I think it would be helpful for users to know filename rather than video-id.
- From <code>Fixing malformed AAC bitstream in "<i>FILENAME</i>"</code> to <code>Correcting container in "<i>FILENAME</i>"</code> in `FFmpegFixupM3u8PP`.