### PR TITLE
Add checks for external downloader

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -56,6 +56,7 @@ from .utils import (
     encodeFilename,
     error_to_compat_str,
     expand_path,
+    ExternalDownloaderError,
     ExtractorError,
     format_bytes,
     formatSeconds,
@@ -1907,7 +1908,7 @@ class YoutubeDL(object):
         if not self.params.get('skip_download', False):
             try:
                 def dl(name, info):
-                    fd = get_suitable_downloader(info, self.params)(self, self.params)
+                    fd = get_suitable_downloader(info, self, self.params)(self, self.params)
                     for ph in self._progress_hooks:
                         fd.add_progress_hook(ph)
                     if self.params.get('verbose'):
@@ -1981,6 +1982,9 @@ class YoutubeDL(object):
                 raise UnavailableVideoError(err)
             except (ContentTooShortError, ) as err:
                 self.report_error('content too short (expected %s bytes and served %s)' % (err.expected, err.downloaded))
+                return
+            except (ExternalDownloaderError, ) as err:
+                self.report_error(error_to_compat_str(err))
                 return
 
             if success and filename != '-':

--- a/youtube_dl/downloader/external.py
+++ b/youtube_dl/downloader/external.py
@@ -218,7 +218,8 @@ class FFmpegFD(ExternalFD):
 
     @classmethod
     def available(cls):
-        return FFmpegPostProcessor().available
+        ffpp = FFmpegPostProcessor()
+        return ffpp.available and ffpp.basename == cls.get_basename()
 
     def _call_downloader(self, tmpfilename, info_dict):
         url = info_dict['url']
@@ -368,4 +369,4 @@ def get_external_downloader(external_downloader):
         downloader . """
     # Drop .exe extension on Windows
     bn = os.path.splitext(os.path.basename(external_downloader))[0]
-    return _BY_NAME[bn]
+    return _BY_NAME.get(bn)

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2451,6 +2451,10 @@ class ContentTooShortError(YoutubeDLError):
         self.expected = expected
 
 
+class ExternalDownloaderError(YoutubeDLError):
+    pass
+
+
 class XAttrMetadataError(YoutubeDLError):
     def __init__(self, code=None, msg='Unknown error'):
         super(XAttrMetadataError, self).__init__(msg)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Add checks for external downloader:
1. if unknown/unsupported downloader is specified, raise explicit exception instead of now causing KeyError, like:
```
  File "/usr/local/bin/youtube-dl/youtube_dl/YoutubeDL.py", line 1910, in dl
  File "/usr/local/bin/youtube-dl/youtube_dl/downloader/__init__.py", line 42, in get_suitable_downloader
  File "/usr/local/bin/youtube-dl/youtube_dl/downloader/external.py", line 371, in get_external_downloader
KeyError: 'DOWNLOADER'
```
2. if downloader is not found in PATH, raise exception instead of ignoring/skipping silently,
also distinguish avconv from ffmpeg to not use ffmpeg if avconv is specified (or vice versa)
3. if downloader will not be used for protocol, show warning when continuing (related to #29813)

2nd condition above may be strict, but I think it should have been done.
3rd condition continues to work, as the user should not be made strongly aware of the protocol.
