### PR TITLE
[YoutubeDL] modify messages for subtitles and thumbnails

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1889,6 +1889,8 @@ class YoutubeDL(object):
                             self.report_warning('Unable to download subtitle for "%s": %s' %
                                                 (sub_lang, error_to_compat_str(err)))
                             continue
+        elif subtitles_are_requested and not info_dict.get('requested_subtitles'):
+            self.report_warning('There are no subtitles to write.')
 
         if self.params.get('writeinfojson', False):
             infofn = replace_extension(filename, 'info.json', info_dict.get('ext'))
@@ -2261,11 +2263,11 @@ class YoutubeDL(object):
     def list_thumbnails(self, info_dict):
         thumbnails = info_dict.get('thumbnails')
         if not thumbnails:
-            self.to_screen('[info] No thumbnails present for %s' % info_dict['id'])
+            self.to_screen('%s has no thumbnail' % info_dict['id'])
             return
 
         self.to_screen(
-            '[info] Thumbnails for %s:' % info_dict['id'])
+            '[info] Available thumbnails for %s:' % info_dict['id'])
         self.to_screen(render_table(
             ['ID', 'width', 'height', 'URL'],
             [[t['id'], t.get('width', 'unknown'), t.get('height', 'unknown'), t['url']] for t in thumbnails]))
@@ -2275,7 +2277,7 @@ class YoutubeDL(object):
             self.to_screen('%s has no %s' % (video_id, name))
             return
         self.to_screen(
-            'Available %s for %s:' % (name, video_id))
+            '[info] Available %s for %s:' % (name, video_id))
         self.to_screen(render_table(
             ['Language', 'formats'],
             [[lang, ', '.join(f['ext'] for f in reversed(formats))]
@@ -2443,7 +2445,7 @@ class YoutubeDL(object):
             return
 
         if not thumbnails:
-            # No thumbnails present, so return immediately
+            self.report_warning('There\'s no thumbnail to write.')
             return
 
         for t in thumbnails:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Modify messages for subtitles and thumbnails.
- balance `--list-subs` and `--list-thumbnails`
- report warning for `--write-sub` and `--write-thumbnail` when no subtitles or thumbnail to write, like `--write-description / -annotations`
currently no feedback, which confuses users