### PR TITLE
[postprocessor] modify severities of embedding subtitles and thumbnail

### DIFF
--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -32,7 +32,10 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         temp_filename = prepend_extension(filename, 'temp')
 
         if not info.get('thumbnails'):
-            self._downloader.to_screen('[embedthumbnail] There aren\'t any thumbnails to embed')
+            self._downloader.report_warning('There\'s no thumbnail to embed.')
+            return [], info
+        if info['ext'] not in ('mp3', 'm4a', 'mp4'):
+            self._downloader.report_warning('Thumbnails can only be embedded in mp3, m4a or mp4 files.')
             return [], info
 
         thumbnail_filename = info['thumbnails'][-1]['filename']
@@ -124,7 +127,5 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             else:
                 os.remove(encodeFilename(filename))
                 os.rename(encodeFilename(temp_filename), encodeFilename(filename))
-        else:
-            raise EmbedThumbnailPPError('Only mp3 and m4a/mp4 are supported for thumbnail embedding for now.')
 
         return [], info

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -377,12 +377,12 @@ class FFmpegVideoConvertorPP(FFmpegPostProcessor):
 
 class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
     def run(self, information):
-        if information['ext'] not in ('mp4', 'webm', 'mkv'):
-            self._downloader.to_screen('[ffmpeg] Subtitles can only be embedded in mp4, webm or mkv files')
-            return [], information
         subtitles = information.get('requested_subtitles')
         if not subtitles:
-            self._downloader.to_screen('[ffmpeg] There aren\'t any subtitles to embed')
+            self._downloader.report_warning('There are no subtitles to embed.')
+            return [], information
+        if information['ext'] not in ('mp4', 'webm', 'mkv'):
+            self._downloader.report_warning('Subtitles can only be embedded in mp4, webm or mkv files.')
             return [], information
 
         filename = information['filepath']
@@ -400,7 +400,7 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
             else:
                 if not webm_vtt_warn and ext == 'webm' and sub_ext != 'vtt':
                     webm_vtt_warn = True
-                    self._downloader.to_screen('[ffmpeg] Only WebVTT subtitles can be embedded in webm files')
+                    self._downloader.report_warning('Only WebVTT subtitles can be embedded in webm files.')
 
         if not sub_langs:
             return [], information


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

- It is too strict to raise error when `--embed-thumbnail` is used to non-target files. And it is not balanced with subtitles handling (no errors for subtitles now).
Resolves #9289, resolves #10500
- If users don't get the results they directed or expected, users should be strongly notified by warning, not info level message. In this sense, modify to warn `--embed-sub` and `--embed-thumbnail` when there's nothing to embed.

Also modified message text to be more consistent, added "." since many warning messages end with it.

_Part of the code for FFmpegEmbedSubtitlePP conflicts with PR #29807._