### PR TITLE
[options] modify --get-thumbnail option name to --get-thumbnail-url

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -603,7 +603,7 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='getid', default=False,
         help='Simulate, quiet but print id')
     verbosity.add_option(
-        '--get-thumbnail',
+        '--get-thumbnail-url',
         action='store_true', dest='getthumbnail', default=False,
         help='Simulate, quiet but print thumbnail URL')
     verbosity.add_option(


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

From its name, users may expect that `--get-thumbnail` gets thumbnail, but it actually displays the thumbnail URL. It is peculiar among other `--get-...` option names.
Better to be renamed to `--get-thumbnail-url`.

`--get-thumbnail` will continue to be recognized by python optparse and work.
