### PR TITLE
Installation instructions: prevent multi-call binary from being overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ youtube-dl - download videos from youtube.com or other video platforms
 
 To install it right away for all UNIX users (Linux, macOS, etc.), type:
 
-    sudo curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
+    curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /tmp/youtube-dl && sudo mv /tmp/youtube-dl /usr/local/bin/
     sudo chmod a+rx /usr/local/bin/youtube-dl
 
 If you do not have curl, you can alternatively use a recent wget:
 
-    sudo wget https://yt-dl.org/downloads/latest/youtube-dl -O /usr/local/bin/youtube-dl
+    wget https://yt-dl.org/downloads/latest/youtube-dl -O /tmp/youtube-dl && sudo mv /tmp/youtube-dl /usr/local/bin/
     sudo chmod a+rx /usr/local/bin/youtube-dl
 
 Windows users can [download an .exe file](https://yt-dl.org/latest/youtube-dl.exe) and place it in any location on their [PATH](https://en.wikipedia.org/wiki/PATH_%28variable%29) except for `%SYSTEMROOT%\System32` (e.g. **do not** put in `C:\Windows\System32`).


### PR DESCRIPTION
This change prevents system damage when a multi-call binary is installed such as "/usr/local/bin/youtube-dl -> /usr/local/bin/firejail". This fixes issue #30427. (Yes, a user really reported this problem and had to ask for help in solving it.)

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [n/a] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [n/a] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [n/a] Covered the code with tests (note that PRs without tests will be REJECTED)
- [n/a] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request fixes the installation instructions (based on either curl or wget). If a system uses a multi-call binary with symlinks, such as "/usr/local/bin/youtube-dl -> /usr/local/bin/firejail", the multi-call binary will be overwritten when a user follows the installation instructions. Fortunately a simple change to the installation command solves that issue. I tested and found that both wget and curl overwrite a symlink referent, and outputting to a temp directory and installing with `sudo mv` solves the issue.
