### PR TITLE
[youtube] Fix bug where autogenerated subtitles could not be downloaded for videos without ASR

### DIFF
--- a/test/test_subtitles.py
+++ b/test/test_subtitles.py
@@ -88,6 +88,13 @@ class TestYoutubeSubtitles(BaseTestSubtitles):
         subtitles = self.getSubtitles()
         self.assertTrue(subtitles['it'] is not None)
 
+    def test_youtube_automatic_captions_no_asr(self):
+        self.url = '6XiFntEQXmA'
+        self.DL.params['writeautomaticsub'] = True
+        self.DL.params['subtitleslangs'] = ['ro']
+        subtitles = self.getSubtitles()
+        self.assertTrue(subtitles['ro'] is not None)
+
     def test_youtube_translated_subtitles(self):
         # This video has a subtitles track, which can be translated
         self.url = 'Ky9eprVWzlI'

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -1838,7 +1838,6 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                         continue
                     process_language(
                         subtitles, base_url, lang_code, {})
-                    continue
                 automatic_captions = {}
                 for translation_language in (pctr.get('translationLanguages') or []):
                     translation_language_code = translation_language.get('languageCode')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Currently, youtube-dl only downloads automatically-generated subtitles from videos that also have ASR subtitles (“automatic speech recognition”, so subtitles automatically generated from speech). This is, however, a bug. There are videos (here's [an example](https://www.youtube.com/watch?v=6XiFntEQXmA)) that have autogenerated subtitles, but no ASR subtitles.

I've attempted to make the minimal possible change to fix this issue, and validate it using the tests. I can confirm that this change fixes the bug for me, and that it does not cause any subtitle tests to fail.

However, I am not familiar with the youtube-dl codebase, and I cannot say for sure that my change will not affect some other aspect of the code, so I'm very open to suggestions.

I think some version of this change should happen, because currently, attempting to download autogenerated subtitles on non-ASR videos simply silently fails without printing anything, which is very frustrating and confusing to the user.
