### PR TITLE
[TikTok] Support Sigi-type pages, etc

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1249,6 +1249,7 @@ from .threeqsdn import ThreeQSDNIE
 from .tiktok import (
     TikTokIE,
     TikTokUserIE,
+    TikTokVMIE,
 )
 from .tinypic import TinyPicIE
 from .tmz import (

--- a/youtube_dl/extractor/tiktok.py
+++ b/youtube_dl/extractor/tiktok.py
@@ -1,15 +1,18 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+import re
+
 from .common import InfoExtractor
+from .generic import GenericIE
 from ..compat import (
-    compat_str,
-    compat_urllib_request,
+    compat_kwargs,
 )
 from ..utils import (
+    dict_get,
     ExtractorError,
     float_or_none,
-    HEADRequest,
+    get_element_by_id,
     int_or_none,
     str_or_none,
     try_get,
@@ -17,24 +20,37 @@ from ..utils import (
 )
 
 
+# decorator enforces UA that TT doesn't block
+def vanilla_UA_request(func):
+
+    vanilla_UA = 'Mozilla/5.0'
+
+    def wrapped(*args, **kwargs):
+        headers = kwargs.get('headers', {})
+        if 'User-Agent' not in headers:
+            headers['User-Agent'] = vanilla_UA
+            kwargs.update({'headers': headers, })
+            kwargs = compat_kwargs(kwargs)
+        return func(*args, **kwargs)
+
+    return wrapped
+
+
 class TikTokBaseIE(InfoExtractor):
-    def _download_webpage(
-            self, url_or_request, video_id, note=None, errnote=None,
-            fatal=True, tries=1, timeout=5, encoding=None, data=None,
-            headers={}, query={}, expected_status=None, setup=True):
+    IE_DESC = 'Abstract base for TikTok extractors'
+    IE_NAME = 'tiktok:base'
 
-        if setup:
-            url = url_or_request.geturl() if isinstance(url_or_request, compat_urllib_request.Request) else url_or_request
-            # dummy request to set cookies
-            self._request_webpage(
-                HEADRequest(url), video_id,
-                note=False, errnote='Could not send HEAD request to %s' % url,
-                fatal=False, headers=headers)
+    @vanilla_UA_request
+    def _request_webpage(self, *args, **kwargs):
+        return super(TikTokBaseIE, self)._request_webpage(*args, **kwargs)
 
-        return super(TikTokBaseIE, self)._download_webpage(
-            url_or_request, video_id, note=note, errnote=errnote,
-            fatal=fatal, tries=tries, timeout=timeout, encoding=encoding, data=data,
-            headers=headers, query=query, expected_status=expected_status)
+    def _get_SIGI_STATE(self, video_id, html):
+        state = self._parse_json(
+            get_element_by_id('SIGI_STATE', html)
+            or self._search_regex(
+                r'''(?s)<script\s[^>]*?\bid\s*=\s*(?P<q>"|'|\b)sigi-persisted-data(?P=q)[^>]*>[^=]*=\s*(?P<json>{.+?})\s*(?:;[^<]+)?</script''',
+                html, 'sigi data', default='{}', group='json'), video_id)
+        return state if isinstance(state, dict) else {}
 
     def _extract_video(self, data, video_id=None):
         video = try_get(data, lambda x: x['video'], dict)
@@ -102,18 +118,20 @@ class TikTokBaseIE(InfoExtractor):
 
 
 class TikTokIE(TikTokBaseIE):
-    _VALID_URL = r'https?://(?:www\.)?tiktok\.com/@[^/]+/video/(?P<id>\d+)'
+    IE_DESC = 'TikTok video extractor'
+    IE_NAME = 'tiktok'
+    _VALID_URL = r'(?:https?://(?:(?:www|m)\.)?tiktok\.com/@[^/]+/video/|tiktok:(?P<user_id>[^/?#&]+):)(?P<id>\d+)'
     _TESTS = [{
         'url': 'https://www.tiktok.com/@zureeal/video/6606727368545406213',
         'md5': '163ceff303bb52de60e6887fe399e6cd',
         'info_dict': {
             'id': '6606727368545406213',
             'ext': 'mp4',
-            'title': 'md5:24acc456b62b938a7e2dd88e978b20d9',
+            'title': 'md5:363e08ccb6c691314710429f379bffe5',
             'description': '#bowsette#mario#cosplay#uk#lgbt#gaming#asian#bowsettecosplay',
             'thumbnail': r're:^https?://.*',
             'duration': 15,
-            'uploader': 'md5:24acc456b62b938a7e2dd88e978b20d9',
+            'uploader': 'md5:363e08ccb6c691314710429f379bffe5',
             'uploader_id': '188294915489964032',
             'timestamp': 1538248586,
             'upload_date': '20180929',
@@ -124,78 +142,85 @@ class TikTokIE(TikTokBaseIE):
         }
     }]
 
+    def _real_initialize(self):
+        # Setup session (will set necessary cookies)
+        self._request_webpage(
+            'https://www.tiktok.com/', None, note='Setting up session')
+
     def _real_extract(self, url):
-        video_id = self._match_id(url)
+        m = re.match(self._VALID_URL, url).groupdict()
+        video_id = m['id']
+        if 'user_id' in m:
+            url = 'https://www.tiktok.com/@%(user_id)s/video/%(id)s/' % m
 
-        webpage = self._download_webpage(url, video_id)
+        webpage = self._download_webpage(url.replace('://m.', '://www.'), video_id)
 
-        page_props = self._parse_json(self._search_regex(
-            r'''(?s)<script\s[^>]*?\bid\s*=\s*(?P<q>"|'|\b)sigi-persisted-data(?P=q)[^>]*>[^=]*=\s*(?P<json>{.+?})\s*(?:;[^<]+)?</script''',
-            webpage, 'sigi data', default='{}', group='json'), video_id)
-        data = try_get(page_props, lambda x: x['ItemModule'][video_id]['video'], dict)
-        if data:
+        page_props = self._get_SIGI_STATE(video_id, webpage)
+        if try_get(page_props, lambda x: x['ItemModule'][video_id]['video'], dict):
             data = page_props['ItemModule'][video_id]
             if data.get('privateItem'):
                 raise ExtractorError('This video is private', expected=True)
             return self._extract_video(data, video_id)
 
-        page_props = self._parse_json(self._search_regex(
-            r'<script[^>]+\bid=["\']__NEXT_DATA__[^>]+>\s*({.+?})\s*</script',
-            webpage, 'data'), video_id)['props']['pageProps']
+        # old page format - may still be served?
+        page_props = self._parse_json(
+            get_element_by_id('__NEXT_DATA__', webpage),
+            video_id)['props']['pageProps']
         data = try_get(page_props, lambda x: x['itemInfo']['itemStruct'], dict)
         if not data and page_props.get('statusCode') == 10216:
             raise ExtractorError('This video is private', expected=True)
         return self._extract_video(data, video_id)
 
 
-class TikTokUserIE(TikTokBaseIE):
-    _VALID_URL = r'https://(?:www\.)?tiktok\.com/@(?P<id>[^/?#&]+)'
+class TikTokUserIE(TikTokIE):
+    IE_DESC = 'TikTok user profile extractor'
+    IE_NAME = 'tiktok:user'
+    _VALID_URL = r'https?://(?:(?:www|m)\.)?tiktok\.com/@(?P<id>[^/?#&]+)'
     _TESTS = [{
         'url': 'https://www.tiktok.com/@zureeal',
         'info_dict': {
             'id': '188294915489964032',
         },
-        'playlist_mincount': 24,
+        'playlist_mincount': 30,
+        'expected_warnings': [
+            'More videos are available',
+        ],
     }]
 
     @classmethod
     def suitable(cls, url):
-        return False if TikTokIE.suitable(url) else super(TikTokUserIE, cls).suitable(url)
+        return False if TikTokIE.suitable(url) else super(TikTokBaseIE, cls).suitable(url)
 
     def _real_extract(self, url):
         user_id = self._match_id(url)
 
-        webpage = self._download_webpage(url, user_id)
-        page_props = self._parse_json(self._search_regex(
-            r'''(?s)<script\s[^>]*?\bid\s*=\s*(?P<q>"|'|\b)sigi-persisted-data(?P=q)[^>]*>[^=]*=\s*(?P<json>{.+?})\s*(?:;[^<]+)?</script''',
-            webpage, 'sigi data', default='{}', group='json'), user_id)
+        webpage = self._download_webpage(url.replace('://m.', '://www.'), user_id)
+
+        page_props = self._get_SIGI_STATE(user_id, webpage)
         user_data = try_get(page_props, lambda x: x['UserModule']['users'], dict)
-        entries = []
         if user_data:
             num_id = try_get(
                 user_data.values(),
-                lambda x: [user['id'] for user in x if user['uniqueId'] == user_id][0],
-                compat_str)
-            item_data = try_get(page_props, lambda x: x['ItemModule'], dict)
-            if item_data:
-                item_data = item_data.values()
-            for data in item_data or []:
-                if data.get('privateItem'):
-                    continue
-                item = self._extract_video(data, user_id)
-                if item:
-                    entries.append(item)
-            result = entries and self.playlist_result(entries, num_id)
-            if not result:
-                item_data = try_get(page_props, lambda x: x['ItemList']['user-post']['list'], list)
-                result = self.playlist_from_matches(item_data, playlist_id=num_id, getter=lambda m: 'tiktok:%s' % (m, ))
+                lambda x: [user['id'] for user in x if user['uniqueId'] == user_id and user['id'].isdigit()][0])
+            item_data = try_get(page_props, lambda x: x['ItemList']['user-post'], dict) or {}
+            item_list = dict_get(item_data, ('list', 'browserList'))
+            if not item_list:
+                item_list = try_get(item_data, lambda x: [y['id'] for y in x['preloadList']], list)
+            entries = ['tiktok:%s:%s' % (user_id, x, ) for x in item_list or []]
+            if item_data.get('hasMore', False):
+                self._downloader.report_warning('More videos are available but the current extractor doesn\'t know how to find them')
+
+            result = entries and self.playlist_from_matches(entries, num_id, ie='TikTok')
             if result:
                 result['display_id'] = user_id
                 return result
 
+        """
+        # this no longer works 2022-01
         data = self._download_json(
             'https://m.tiktok.com/h5/share/usr/list/%s/' % user_id, user_id,
             query={'_signature': '_'})
+        entries = []
         for aweme in data['aweme_list']:
             try:
                 entry = self._extract_video(aweme)
@@ -205,3 +230,27 @@ class TikTokUserIE(TikTokBaseIE):
             entries.append(entry)
 
         return self.playlist_result(entries, user_id)
+        """
+
+
+class TikTokVMIE(GenericIE):
+    IE_DESC = 'Resolver for TikTok shortcuts'
+    IE_NAME = 'tiktok:shortcut'
+    _VALID_URL = r'https?://(?:vm\.tiktok\.com|m\.tiktok\.com/v)/(?P<id>[^/?#&.]+)'
+    _TESTS = [{
+        'url': 'https://vm.tiktok.com/ZMLesneqK/',
+        'info_dict': {
+            'id': '7054218882072055046',
+            'ext': 'mp4',
+            'title': 'EddY',
+            'upload_date': '20220117',
+            'description': 'Hilft bestimmt gegen nervige Anrufer! 😂 #telefon #call #prank #fail #sprecher #stimme #voice #band #ansage #sound #comedy #unterhaltung #scammer #fy',
+            'timestamp': 1642438324,
+            'uploader': 'EddY',
+            'uploader_id': '6850021004246467590',
+        },
+    }]
+
+    @vanilla_UA_request
+    def _request_webpage(self, *args, **kwargs):
+        return super(GenericIE, self)._request_webpage(*args, **kwargs)


### PR DESCRIPTION
## Please follow the guide below

---

### Before submitting a *pull request* make sure you have:
- [ ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
Except: this PR subsumes PR #30224 whose author also affirmed this.
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

TT switched (possibly partially) its framework from NextJS to Sigi, and the persisted state JSON sent in the page changed as a result. Instead of a `<script>` element with `id` `__NEXT_DATA__`, we get one with `id` `sigi_persisted_state` and JSON with a slightly different structure.

This PR deals with both types of page format, based on PR #30224 and [this patch](https://github.com/ytdl-org/youtube-dl/issues/30251#issuecomment-976947005) which gets more metadata.

Also, extraction could fail with a timeout (Error 60 in Windows, SSLError('The read operation timed out',) in Linux) or connection reset (Error 54 in Windows) due to some weird blocking by whatever fronts TikTok's pages (Akamai, apparenty). In order to download the page for parsing, some cookie has to be sent and a way to get it is to make a previous request to the site. The extractor fetched https://www.tiktok.com/ before doing anything else. In yt-dlp, the code fetches the webpage itself twice, commenting that you get 403 otherwise. This PR copies that tactic but instead of fetching the whole page (`GET` request) it just sends a `HEAD` request; if a page is actually returned, rather than an error with a `Set-Cookie` header, it doesn't actually have to be downloaded.

Probably resolves #28741
Resolves #30251
Resolves #30432
Resolves #30439
Resolves #30445
Resolves #30454
Resolves #30470.

Finally the non-working `TikTokUserIE` has been resurrected for accessing all the videos of a specific user.

Resolves #30174.
