### PR TITLE
[downloader/hls] fix to do unpad after decrypt

### DIFF
--- a/youtube_dl/downloader/hls.py
+++ b/youtube_dl/downloader/hls.py
@@ -4,6 +4,7 @@ import re
 import binascii
 try:
     from Crypto.Cipher import AES
+    from Crypto.Util.Padding import unpad
     can_decrypt_frag = True
 except ImportError:
     can_decrypt_frag = False
@@ -178,6 +179,7 @@ class HlsFD(FragmentFD):
                         if not test:
                             frag_content = AES.new(
                                 decrypt_info['KEY'], AES.MODE_CBC, iv).decrypt(frag_content)
+                            frag_content = unpad(frag_content, AES.block_size, style='pkcs7')
                     self._append_fragment(ctx, frag_content)
                     # We only download the first fragment during the test
                     if test:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
_Not done specifically. Consider to be satisfied by the Description below._
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #30208.

`unpad` after decrypt seems to be needed from the start of supporting AES-128 in hlsnative downloader.

In ref 1. `draft-pantos-http-live-streaming-17#section-4.3.2.4` (now `RFC 8216`) in `hls.py`, it is described as: 
An encryption method of AES-128 signals that Media Segments are completely encrypted using the Advanced Encryption Standard [AES_128] with a 128-bit key, Cipher Block Chaining, and **PKCS7 padding** [RFC5652]. (bold is by me)

It's hard to believe that not doing `unpad` didn't cause problems other than #30208 for a long time, but it seems to have been actually processed well by ffmpeg (when merge or fixup).

To confirm this, I made files from encrypted hls streams by `youtube-dl ... --hls-prefer-native --fixup never` without and with `unpad` (version 2021.12.17 and 2021.12.17 plus this PR), then did `ffmpeg -loglevel trace -i INPUT -c copy -bitexact OUTPUT` for both.
The OUTPUT files were identical, and in the log of without `unpad` INPUT, there were extra messages like `[mpegts @ 0x7f886d803c00] Probe: 8192, score: 44, dvhs_score: -3, fec_score: -1` almost as many as the number of fragments, indicating skipping the paddings I guess.
