### PR TITLE
[utils] add --raw to setfattr

### DIFF
--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -5703,7 +5703,7 @@ def write_xattr(path, key, value):
             except EnvironmentError as e:
                 raise XAttrMetadataError(e.errno, e.strerror)
         else:
-            user_has_setfattr = check_executable('setfattr', ['--version'])
+            user_has_setfattr = get_exe_version('setfattr', ['--version'], r'setfattr\s*([0-9.]+)')
             user_has_xattr = check_executable('xattr', ['-h'])
 
             if user_has_setfattr or user_has_xattr:
@@ -5712,6 +5712,8 @@ def write_xattr(path, key, value):
                 if user_has_setfattr:
                     executable = 'setfattr'
                     opts = ['-n', key, '-v', value]
+                    if not is_outdated_version(user_has_setfattr, '2.4.48', False):
+                        opts += ['--raw']
                 elif user_has_xattr:
                     executable = 'xattr'
                     opts = ['-w', key, value]


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Resolves #28665 if setfattr is version 2.4.48 or later (released on 2017-09-15).

I think it's enough to just add `--raw` practically. However, some LTS (ex. debian stretch, ubuntu bionic) still seem to have version 2.4.47, so made it conditional.
