### PR TITLE
Add hidden --load-webpage option for debug purposes

### DIFF
--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -385,6 +385,7 @@ def _real_main(argv=None):
         'verbose': opts.verbose,
         'dump_intermediate_pages': opts.dump_intermediate_pages,
         'write_pages': opts.write_pages,
+        'load_webpage_filename': opts.load_webpage_filename,
         'test': opts.test,
         'keepvideo': opts.keepvideo,
         'min_filesize': opts.min_filesize,

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import base64
 import datetime
 import hashlib
+import io
 import json
 import netrc
 import os
@@ -753,6 +754,14 @@ class InfoExtractor(object):
 
         return content
 
+    def _load_webpage_file(self, video_id, webpage_filename):
+        self.to_screen('%s: Loading webpage from file' % video_id)
+        try:
+            with io.open(webpage_filename, mode='r', encoding='utf-8') as f:
+                return f.read()
+        except (IOError, OSError) as err:
+            self._downloader.report_warning('Unable to load webpage from file: [Errno %s] %s. Continue to download from URL' % (err.errno, error_to_compat_str(err.strerror)))
+
     def _download_webpage(
             self, url_or_request, video_id, note=None, errnote=None,
             fatal=True, tries=1, timeout=5, encoding=None, data=None,
@@ -790,6 +799,12 @@ class InfoExtractor(object):
             Note that this argument does not affect success status codes (2xx)
             which are always accepted.
         """
+
+        webpage_filename = self._downloader.params.get('load_webpage_filename')
+        if webpage_filename:
+            content = self._load_webpage_file(video_id, webpage_filename)
+            if content:
+                return content
 
         success = False
         try_count = 0

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -660,6 +660,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='write_pages', default=False,
         help='Write downloaded intermediary pages to files in the current directory to debug problems')
     verbosity.add_option(
+        '--load-webpage',
+        dest='load_webpage_filename', metavar='FILE',
+        help=optparse.SUPPRESS_HELP)
+    verbosity.add_option(
         '--youtube-print-sig-code',
         action='store_true', dest='youtube_print_sig_code', default=False,
         help=optparse.SUPPRESS_HELP)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

Add hidden `--load-webpage` option for debug purposes.

Sometimes it is convenient to be able to load webpage from a file which was saved with `--write-pages` or a command line tool like curl.
Mainly intended for sites like Facebook, where accesses in succession will be blocked, and only can be used when a single `self._download_webpage()` is sufficient.

Usage: `youtube-dl [OPTIONS] URL --load-webpage FILE`

If specified FILE cannot be read, continued from URL.
