### PR TITLE
fix: SkylineWebcams extractor

### DIFF
--- a/youtube_dl/extractor/skylinewebcams.py
+++ b/youtube_dl/extractor/skylinewebcams.py
@@ -7,7 +7,7 @@ from .common import InfoExtractor
 class SkylineWebcamsIE(InfoExtractor):
     _VALID_URL = r'https?://(?:www\.)?skylinewebcams\.com/[^/]+/webcam/(?:[^/]+/)+(?P<id>[^/]+)\.html'
     _TEST = {
-        'url': 'https://www.skylinewebcams.com/it/webcam/italia/lazio/roma/scalinata-piazza-di-spagna-barcaccia.html',
+        'url': 'https://www.skylinewebcams.com/it/webcam/italia/lazio/roma/piazza-di-spagna.html',
         'info_dict': {
             'id': 'scalinata-piazza-di-spagna-barcaccia',
             'ext': 'mp4',
@@ -24,10 +24,9 @@ class SkylineWebcamsIE(InfoExtractor):
         video_id = self._match_id(url)
 
         webpage = self._download_webpage(url, video_id)
-
-        stream_url = self._search_regex(
-            r'(?:url|source)\s*:\s*(["\'])(?P<url>(?:https?:)?//.+?\.m3u8.*?)\1', webpage,
-            'stream url', group='url')
+        stream_url = 'https://hd-auth.skylinewebcams.com/live.m3u8' + self._search_regex(
+            r'(?:url|source)\s*:\s*(["\'])(livee\.m3u8(?P<a_param>\?a=\w+))\1', webpage,
+            'stream url', group='a_param')
 
         title = self._og_search_title(webpage)
         description = self._og_search_description(webpage)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

SkylineWebcams extractor was not working.

Here are the list of changes to make it work:

1. Updated the regex to extract the stream URL from the webpage. In the webpage source code there is just a variable in the form `livee.m3u8?a=<id>` (multiple `e` is correct). The usage of that link by appending it to `https://hd-auth.skylinewebcams.com/` do not work. The solution was to extract just the `?a=<id>` area and appending it to `https://hd-auth.skylinewebcams.com/live.m3u8`. The extractor works properly.

2. Updated `_TEST` with a new `url`. The old one was disabled.

It solves #28873.