### PR TITLE
[JSInterpreter] Improve performance

### DIFF
--- a/youtube_dl/jsinterp.py
+++ b/youtube_dl/jsinterp.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import json
 import operator
 import re
+from collections import Counter
 
 from .utils import (
     ExtractorError,
@@ -19,6 +20,7 @@ class Nonlocal:
     pass
 
 
+# tightest first
 _OPERATORS = [
     ('|', operator.or_),
     ('^', operator.xor),
@@ -124,7 +126,7 @@ class JSInterpreter(object):
     def _separate(expr, delim=',', max_split=None):
         if not expr:
             return
-        counters = {k: 0 for k in _MATCHING_PARENS.values()}
+        counters = Counter()
         start, splits, pos, delim_len = 0, 0, 0, len(delim) - 1
         for idx, char in enumerate(expr):
             if char in _MATCHING_PARENS:


### PR DESCRIPTION
## Please follow the guide below

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The limited JS interpreter used to decode YT signature URLs was enhanced in PR #30188, back-porting yt-dlp PR 1437, and merged from PR #30184 in order to respond to the n parameter challenge introduced by YT.

In #30641, a specific embedded application of yt-dl identified significantly reduced extraction performance compared with previous versions and even the stopgap n-parameter response.

A test application was profiled. After pulling out some constant regex expressions and changing a loop over assignment operators into a regex alternative match, the execution time (Py 2.7) went from 22s to 18s. The number of function calls was down by almost 1M, nearly 25% (application extracting 42 YT pages).

The regex optimisations apply to expressions that used f-strings in the yt-dlp version, which are said to be faster than formatting operations available to yt-dl; however, the loop optimisation, and one already made in the back-port, could equally apply to the yt-dlp version.

Currently constants used in the `JSInterpreter` class include both global and class vars:
* globals: `_OPERATORS`, `_ASSIGN_OPERATORS`, `_NAME_RE`, `_MATCHING_PARENS`
* class vars: `_EXPR_SPLIT_RE`, `_VARNAME_RE`, `_ARRAY_REF_RE`, `_FN_CALL_RE`, `_MEMBER_REF_RE`, `_FN_NAME_RE`, `_FN_DEF_RE`, `_ASSIGN_EXPR_RE`.

As to whether the constant regex expressions used for parsing should be class or global vars, probably the following heuristics should apply:
* constants that are characteristics of the JS language should be _vars of the module or the class
* constants that are specific to the internal workings of the JS interpreter should be __vars of the class.
