### PR TITLE
[CBSLocal] Overhaul extractor and its back-end site extractors Anvato, SendtoNews

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1529,7 +1529,7 @@ class YoutubeDL(object):
                 # see http://bugs.python.org/issue1646728)
                 try:
                     upload_date = datetime.datetime.utcfromtimestamp(info_dict[ts_key])
-                    info_dict[date_key] = upload_date.strftime('%Y%m%d')
+                    info_dict[date_key] = compat_str(upload_date.strftime('%Y%m%d'))
                 except (ValueError, OverflowError, OSError):
                     pass
 

--- a/youtube_dl/extractor/anvato.py
+++ b/youtube_dl/extractor/anvato.py
@@ -17,6 +17,7 @@ from ..utils import (
     intlist_to_bytes,
     int_or_none,
     strip_jsonp,
+    try_get,
     unescapeHTML,
     unsmuggle_url,
 )
@@ -203,6 +204,7 @@ class AnvatoIE(InfoExtractor):
         'telemundo': 'anvato_mcp_telemundo_web_prod_c5278d51ad46fda4b6ca3d0ea44a7846a054f582'
     }
 
+    _API_PREFIX = 'https://tkx.mp.lura.live/rest/v2/'
     _API_KEY = '3hwbSuqqT690uxjNYBktSQpa5ZrpYYR0Iofx7NcJHyA'
 
     _ANVP_RE = r'<script[^>]+\bdata-anvp\s*=\s*(["\'])(?P<anvp>(?:(?!\1).)+)\1'
@@ -211,15 +213,18 @@ class AnvatoIE(InfoExtractor):
     _TESTS = [{
         # from https://www.boston25news.com/news/watch-humpback-whale-breaches-right-next-to-fishing-boat-near-nh/817484874
         'url': 'anvato:8v9BEynrwx8EFLYpgfOWcG1qJqyXKlRM:4465496',
+        'only_matching': True,
+    }, {
+        # from https://miami.cbslocal.com/2022/02/12/no-appetite-for-new-miami-restaurant-glorifying-castro-communism/
+        'url': 'anvato:5VD6Eyd6djewbCmNwBFnsJj17YAvGRwl:6197559',  # 8v9BEynrwx8EFLYpgfOWcG1qJqyXKlRM:4465496',
         'info_dict': {
-            'id': '4465496',
+            'id': '6197559',
             'ext': 'mp4',
-            'title': 'VIDEO: Humpback whale breaches right next to NH boat',
-            'description': 'VIDEO: Humpback whale breaches right next to NH boat. Footage courtesy: Zach Fahey.',
-            'duration': 22,
-            'timestamp': 1534855680,
-            'upload_date': '20180821',
-            'uploader': 'ANV',
+            'upload_date': '20220209',
+            'uploader': 'CBS',
+            'description': 'CBS4\'s Joel Waldman has more on the backlash Cafe Habana is receiving.',
+            'timestamp': 1644381300,
+            'title': 'Miamians Want No Part Of New Restaurant Set To Open In Brickell That Glorifies Fidel Castro & Communism',
         },
         'params': {
             'skip_download': True,
@@ -228,46 +233,85 @@ class AnvatoIE(InfoExtractor):
         # from https://sanfrancisco.cbslocal.com/2016/06/17/source-oakland-cop-on-leave-for-having-girlfriend-help-with-police-reports/
         'url': 'anvato:DVzl9QRzox3ZZsP9bNu5Li3X7obQOnqP:3417601',
         'only_matching': True,
+    }, {
+        # from https://sanfrancisco.cbslocal.com/2022/02/16/san-francisco-voters-recall-embattled-school-board-members/
+        'url': 'anvato:5VD6Eyd6djewbCmNwBFnsJj17YAvGRwl:6201051',
+        'info_dict': {
+            'id': '6201051',
+            'ext': 'mp4',
+            'upload_date': '20220216',
+            'uploader': 'CBS',
+            'description': 'Voters were successful in their high-profile effort to recall three San Francisco school board members. Anne Makovec reports.',
+            'timestamp': 1645043880,
+            'title': 'Voters Recall San Francisco School Board Members',
+        },
+        'params': {
+            'skip_download': True,
+        },
     }]
 
     def __init__(self, *args, **kwargs):
         super(AnvatoIE, self).__init__(*args, **kwargs)
         self.__server_time = None
 
-    def _server_time(self, access_key, video_id):
+    def _server_time(self, access_key, video_id, server_url=None):
         if self.__server_time is not None:
             return self.__server_time
 
+        if not server_url:
+            server_url = self._API_PREFIX + 'server_time?anvack={ANVACK}'
+
         self.__server_time = int(self._download_json(
-            self._api_prefix(access_key) + 'server_time?anvack=' + access_key, video_id,
+            server_url.format(ANVACK=access_key), video_id,
             note='Fetching server time')['server_time'])
 
         return self.__server_time
 
-    def _api_prefix(self, access_key):
-        return 'https://tkx2-%s.anvato.net/rest/v2/' % ('prod' if 'prod' in access_key else 'stage')
-
     def _get_video_json(self, access_key, video_id):
-        # See et() in anvplayer.min.js, which is an alias of getVideoJSON()
-        video_data_url = self._api_prefix(access_key) + 'mcp/video/%s?anvack=%s' % (video_id, access_key)
-        server_time = self._server_time(access_key, video_id)
+
+        def fix_template_vars(template):
+            return re.sub(r'\{(\{\w+})}', r'\1', template)
+
+        # https://access.mp.lura.live/anvacks/5VD6Eyd6djewbCmNwBFnsJj17YAvGRwl?apikey=3hwbSuqqT690uxjNYBktSQpa5ZrpYYR0Iofx7NcJHyA
+        access_info = self._download_json(
+            'https://access.mp.lura.live/anvacks/%s?apikey=%s'
+            % (access_key, self._API_KEY),
+            video_id, note='Downloading access details')
+        server_time_url = try_get(access_info, lambda x: x['api']['time'])
+
+        server_time_url = (
+            server_time_url
+            and fix_template_vars(server_time_url).format(ANVACK=access_key))
+        server_time = self._server_time(access_key, video_id, server_time_url)
+
+        video_data_url = access_info['api'].get('video')
+
+        if not video_data_url:
+            # use special knowledge
+            video_data_url = self._API_PREFIX + 'mcp/video/{{VIDEO_ID}}?anvack={{ANVACK}}'
+
+        video_data_url = fix_template_vars(video_data_url).format(ANVACK=access_key, VIDEO_ID=video_id)
+
         input_data = '%d~%s~%s' % (server_time, md5_text(video_data_url), md5_text(server_time))
 
         auth_secret = intlist_to_bytes(aes_encrypt(
             bytes_to_intlist(input_data[:64]), bytes_to_intlist(self._AUTH_KEY)))
 
-        video_data_url += '&X-Anvato-Adst-Auth=' + base64.b64encode(auth_secret).decode('ascii')
         anvrid = md5_text(time.time() * 1000 * random.random())[:30]
+
+        query = {
+            'X-Anvato-Adst-Auth': base64.b64encode(auth_secret).decode('ascii'),
+            'rtyp': 'fp',
+        }
         api = {
             'anvrid': anvrid,
             'anvts': server_time,
+            'anvstk2': 'default',
         }
-        api['anvstk'] = md5_text('%s|%s|%d|%s' % (
-            access_key, anvrid, server_time,
-            self._ANVACK_TABLE.get(access_key, self._API_KEY)))
-
         return self._download_json(
             video_data_url, video_id, transform_source=strip_jsonp,
+            note='Downloading video details',
+            query=query,
             data=json.dumps({'api': api}).encode('utf-8'))
 
     def _get_anvato_videos(self, access_key, video_id):

--- a/youtube_dl/extractor/sendtonews.py
+++ b/youtube_dl/extractor/sendtonews.py
@@ -5,43 +5,45 @@ import re
 
 from .common import InfoExtractor
 from ..utils import (
+    dict_get,
+    ExtractorError,
     float_or_none,
     parse_iso8601,
     update_url_query,
     int_or_none,
+    determine_ext,
     determine_protocol,
+    strip_or_none,
+    try_get,
     unescapeHTML,
+    urljoin,
 )
 
 
 class SendtoNewsIE(InfoExtractor):
-    _VALID_URL = r'https?://embed\.sendtonews\.com/player2/embedplayer\.php\?.*\bSC=(?P<id>[0-9A-Za-z-]+)'
-
-    _TEST = {
+    # TODO handle items with ?fk=XXXX6789&cid=1234 -> SC=XXXX6789-???????-1234
+    _VALID_URL = r'https?://embed\.sendtonews\.com/(?:player\d/embed(?:player|code)\.(?:php|js)|oembed/?)\?.*\bSC=(?P<id>[\w-]+)'
+    _TESTS = [{
         # From http://cleveland.cbslocal.com/2016/05/16/indians-score-season-high-15-runs-in-blowout-win-over-reds-rapid-reaction/
         'url': 'http://embed.sendtonews.com/player2/embedplayer.php?SC=GxfCe0Zo7D-175909-5588&type=single&autoplay=on&sound=YES',
         'info_dict': {
             'id': 'GxfCe0Zo7D-175909-5588'
         },
-        'playlist_count': 8,
-        # test the first video only to prevent lengthy tests
-        'playlist': [{
-            'info_dict': {
-                'id': '240385',
-                'ext': 'mp4',
-                'title': 'Indians introduce Encarnacion',
-                'description': 'Indians president of baseball operations Chris Antonetti and Edwin Encarnacion discuss the slugger\'s three-year contract with Cleveland',
-                'duration': 137.898,
-                'thumbnail': r're:https?://.*\.jpg$',
-                'upload_date': '20170105',
-                'timestamp': 1483649762,
-            },
-        }],
-        'params': {
-            # m3u8 download
-            'skip_download': True,
+        'playlist_count': 10,
+    }, {
+        'url': 'https://embed.sendtonews.com/player4/embedplayer.php?SC=mq3wIKSb68-1206898-8402&type=single',
+        'info_dict': {
+            'id': '1752278',
+            'ext': 'mp4',
+            'title': 'Las vegas homebuilders had banner sales year in 2021, and other top stories from January 24, 2022.',
+            'description': 'LAS VEGAS HOMEBUILDERS HAD BANNER SALES YEAR IN 2021., and other top stories from January 24, 2022.',
+            'timestamp': 1643063702,
+            'upload_date': '20220124',
+            'thumbnail': r're:https?://.*\.(?:png|jpg)$',
+            'categories': ['Business'],
+            'tags': list,
         },
-    }
+    }]
 
     _URL_TEMPLATE = '//embed.sendtonews.com/player2/embedplayer.php?SC=%s'
 
@@ -59,17 +61,62 @@ class SendtoNewsIE(InfoExtractor):
         playlist_id = self._match_id(url)
 
         data_url = update_url_query(
-            url.replace('embedplayer.php', 'data_read.php'),
-            {'cmd': 'loadInitial'})
+            re.sub(
+                r'(?P<player>player\d)?(?<!/)/(?P<embed>embed.+?|oembed/)\?',
+                lambda m: '/%s/data_read.php?' % ((m.group('player') or 'player4'), ),
+                url),
+            {'cmd': 'loadInitial', 'type': 'single', })
         playlist_data = self._download_json(data_url, playlist_id)
+        playlist = try_get(playlist_data, lambda x: x['playlistData'][0], (dict, list)) or {}
+        if isinstance(playlist, dict):
+            err = playlist.get('error', 'No or invalid data returned from API')
+            raise ExtractorError(err)
 
         entries = []
-        for video in playlist_data['playlistData'][0]:
-            info_dict = self._parse_jwplayer_data(
-                video['jwconfiguration'],
-                require_title=False, m3u8_id='hls', rtmp_params={'no_resume': True})
+        info_dict = {}
+        for video in playlist:
+            try:
+                err = video.get('error')
+                if err and video.get('S_ID') is not None:
+                    e = ExtractorError(err)
+                    e.msg = err
+                    raise e
+            except AttributeError:
+                continue
+            except ExtractorError as e:
+                self.report_warning(e.msg, playlist_id)
+                continue
+            if 'jwconfiguration' in video:
+                info_dict.update(self._parse_jwplayer_data(
+                    video['jwconfiguration'],
+                    require_title=False, m3u8_id='hls', rtmp_params={'no_resume': True}))
+            elif 'configuration' not in video:
+                continue
+            else:
+                fmt_url = urljoin(
+                    url,
+                    try_get(video, lambda x: x['configuration']['sources']['src']))
+                if not fmt_url:
+                    continue
+                video_id = strip_or_none(video.get('SM_ID') or video['configuration']['mediaid'])
+                title = strip_or_none(video.get('S_headLine') or video['configuration']['title'])
+                if not video_id or not title:
+                    continue
+                ext = determine_ext(fmt_url)
+                if ext == 'm3u8':
+                    formats = self._extract_m3u8_formats(
+                        fmt_url, playlist_id, 'mp4', entry_protocol='m3u8_native',
+                        m3u8_id='hls', fatal=False)
+                else:
+                    formats = [{
+                        'url': fmt_url,
+                        'ext': ext,
+                        'width': int_or_none(video.get('SM_M_VIDEO_WIDTH')),
+                        'height': int_or_none(video.get('SM_M_VIDEO_HEIGHT')),
+                    }]
+                info_dict['formats'] = formats
 
-            for f in info_dict['formats']:
+            for f in info_dict.get('formats') or []:
                 if f.get('tbr'):
                     continue
                 tbr = int_or_none(self._search_regex(
@@ -83,23 +130,31 @@ class SendtoNewsIE(InfoExtractor):
             self._sort_formats(info_dict['formats'], ('tbr', 'height', 'width', 'format_id'))
 
             thumbnails = []
-            if video.get('thumbnailUrl'):
+            for tn_id, tn in (('poster', video['configuration'].get('poster')),
+                              ('normal', video.get('thumbnailUrl')),
+                              ('small', video.get('smThumbnailUrl'))):
+                tn = urljoin(url, tn)
+                if not tn:
+                    continue
                 thumbnails.append({
-                    'id': 'normal',
-                    'url': video['thumbnailUrl'],
-                })
-            if video.get('smThumbnailUrl'):
-                thumbnails.append({
-                    'id': 'small',
-                    'url': video['smThumbnailUrl'],
+                    'id': tn_id,
+                    'url': tn,
                 })
             info_dict.update({
-                'title': video['S_headLine'].strip(),
-                'description': unescapeHTML(video.get('S_fullStory')),
+                'id': video_id,
+                'title': title,
+                'description': unescapeHTML(dict_get(video, ('S_fullStory', 'S_shortSummary'))),
                 'thumbnails': thumbnails,
-                'duration': float_or_none(video.get('SM_length')),
+                'duration': float_or_none(
+                    dict_get(video, ('SM_length', 'SM_M_LENGTH'))
+                    or video['configuration'].get('duration')),
                 'timestamp': parse_iso8601(video.get('S_sysDate'), delimiter=' '),
+                'tags': [t for t in video.get('S_tags', '').split(',') if t],
+                'categories': [c for c in video.get('S_category', '').split(',') if c],
             })
             entries.append(info_dict)
 
+        if len(entries) == 1:
+            entries[0]['display_id'] = playlist_id
+            return entries[0]
         return self.playlist_result(entries, playlist_id)


### PR DESCRIPTION
## Please follow the guide below

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

https://github.com/yt-dlp/yt-dlp/issues/2794 reported that extraction failed for the page https://miami.cbslocal.com/2022/02/12/no-appetite-for-new-miami-restaurant-glorifying-castro-communism/. The same issue affects yt-dl as the relevant code is substantially identical.

These problems were identified:
* the page uses Anvato embedding, which after Anvato was bought up by Google, now seems to be hosted at `mp.lura.live`, so the back-end Anvato extractor needed to be updated;
* the page itself has a structure not supported by the `CBSLocalArticleIE` extractor, so the Anvato access key and video ID have to be extracted in a different way, from a script inside the `section#featured-media` element containing the required fields as the `accessKey` and `video` members of JSON that is passed to `AnvatoPlayer('p0').init()`;
* default metadata could be extracted from the `ld+json` script element;
* the extractor first tries to extract a URL suitable for the `SendtoNewsIE` extractor; although no page was found with this, that extractor also needed a rework.

For the `AnvatoIE` extractor, a similar pattern of requests to the original is needed, but with slightly different parameters and different API URLs.
1. From `'https://access.mp.lura.live/anvacks/%s?apikey=%s' % (access_key, self._API_KEY)`, get JSON containing all the API URLs with replacement fields that have to be replaced with the video parameters.
2. Use the `api.time` member to get the server time (UNIX epoch).
3. Use the `api.video` member to get video metadata JSON using query parameters and POST data calculated, similar to the existing, from the video data URL and server time, which has the same format as the JSON expected from the old Anvato API.

For the SendtoNews extractor, the API returned JSON with media links in `configuration.sources.src` of a playlist item instead of `jwconfiguration`.

This PR implements the necessary changes to all three extractors.

For all extractors, tests had to be validated, replaced or fixed.

A small fix from the pending PR #29698 is pulled in to make some tests work under Python 2.

Resolves #27699.