### PR TITLE
Fixed groups() call on potentially empty regex search object

### DIFF
--- a/youtube_dl/extractor/myspass.py
+++ b/youtube_dl/extractor/myspass.py
@@ -36,13 +36,12 @@ class MySpassIE(InfoExtractor):
         video_url = xpath_text(metadata, 'url_flv', 'download url', True)
         video_id_int = int(video_id)
 
-        regex_check = re.search(r'/myspass2009/\d+/(\d+)/(\d+)/(\d+)/', video_url)
-        if regex_check:
-            for group in regex_check.groups():
-                group_int = int(group)
-                if group_int > video_id_int:
-                    video_url = video_url.replace(
-                        group, compat_str(group_int // video_id_int))
+        grps = re.search(r'/myspass2009/\d+/(\d+)/(\d+)/(\d+)/', video_url)
+        for group in grps.groups() if grps else []:
+            group_int = int(group)
+            if group_int > video_id_int:
+                video_url = video_url.replace(
+                    group, compat_str(group_int // video_id_int))
 
         return {
             'id': video_id,

--- a/youtube_dl/extractor/myspass.py
+++ b/youtube_dl/extractor/myspass.py
@@ -35,11 +35,14 @@ class MySpassIE(InfoExtractor):
         title = xpath_text(metadata, 'title', fatal=True)
         video_url = xpath_text(metadata, 'url_flv', 'download url', True)
         video_id_int = int(video_id)
-        for group in re.search(r'/myspass2009/\d+/(\d+)/(\d+)/(\d+)/', video_url).groups():
-            group_int = int(group)
-            if group_int > video_id_int:
-                video_url = video_url.replace(
-                    group, compat_str(group_int // video_id_int))
+
+        regex_check = re.search(r'/myspass2009/\d+/(\d+)/(\d+)/(\d+)/', video_url)
+        if regex_check:
+            for group in regex_check.groups():
+                group_int = int(group)
+                if group_int > video_id_int:
+                    video_url = video_url.replace(
+                        group, compat_str(group_int // video_id_int))
 
         return {
             'id': video_id,


### PR DESCRIPTION
- https://github.com/ytdl-org/youtube-dl/issues/30521

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Within the myspass site extractor, there is a short regex for checking for certain substrings in the video url.
```groups()``` was called on ```re.search()``` without first ensuring there were any results to return a regex object. I've added a simple check for this.

Resolves #30521
Closes #30522