### PR TITLE
[core] Add option --get-manifest-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          write anything to disk
     --skip-download                      Do not download the video
     -g, --get-url                        Simulate, quiet but print URL
+    --get-manifest-url                   Simulate, quiet but print manifest URL
     -e, --get-title                      Simulate, quiet but print title
     --get-id                             Simulate, quiet but print id
     --get-thumbnail                      Simulate, quiet but print thumbnail URL

--- a/test/parameters.json
+++ b/test/parameters.json
@@ -4,6 +4,7 @@
     "forcedescription": false, 
     "forcefilename": false, 
     "forceformat": false, 
+    "forcemanifesturl": false, 
     "forcethumbnail": false, 
     "forcetitle": false, 
     "forceurl": false, 

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -151,6 +151,7 @@ class YoutubeDL(object):
     quiet:             Do not print messages to stdout.
     no_warnings:       Do not print out anything for warnings.
     forceurl:          Force printing final URL.
+    forcemanifesturl:  Force printing manifest URL.
     forcetitle:        Force printing title.
     forceid:           Force printing ID.
     forcethumbnail:    Force printing thumbnail URL.
@@ -1763,6 +1764,12 @@ class YoutubeDL(object):
             else:
                 # For RTMP URLs, also include the playpath
                 self.to_stdout(info_dict['url'] + info_dict.get('play_path', ''))
+        if self.params.get('forcemanifesturl', False) and not incomplete:
+            if info_dict.get('requested_formats') is not None:
+                for f in info_dict['requested_formats']:
+                    self.to_stdout(f['manifest_url'])
+            else:
+                self.to_stdout(info_dict['manifest_url'])
         print_optional('thumbnail')
         print_optional('description')
         if self.params.get('forcefilename', False) and filename is not None:

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -243,7 +243,7 @@ def _real_main(argv=None):
                      ' file! Use "{0}.%(ext)s" instead of "{0}" as the output'
                      ' template'.format(outtmpl))
 
-    any_getting = opts.geturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat or opts.getduration or opts.dumpjson or opts.dump_single_json
+    any_getting = opts.geturl or opts.getmanifesturl or opts.gettitle or opts.getid or opts.getthumbnail or opts.getdescription or opts.getfilename or opts.getformat or opts.getduration or opts.dumpjson or opts.dump_single_json
     any_printing = opts.print_json
     download_archive_fn = expand_path(opts.download_archive) if opts.download_archive is not None else opts.download_archive
 
@@ -326,6 +326,7 @@ def _real_main(argv=None):
         'quiet': (opts.quiet or any_getting or any_printing),
         'no_warnings': opts.no_warnings,
         'forceurl': opts.geturl,
+        'forcemanifesturl': opts.getmanifesturl,
         'forcetitle': opts.gettitle,
         'forceid': opts.getid,
         'forcethumbnail': opts.getthumbnail,

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -595,6 +595,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='geturl', default=False,
         help='Simulate, quiet but print URL')
     verbosity.add_option(
+        '--get-manifest-url',
+        action='store_true', dest='getmanifesturl', default=False,
+        help='Simulate, quiet but print manifest URL')
+    verbosity.add_option(
         '-e', '--get-title',
         action='store_true', dest='gettitle', default=False,
         help='Simulate, quiet but print title')


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

For every item in the info dictionary, there is a respective `--get-*` option except for the `manifest_url`. This commit adds the new option `--get-manifest-url` simply in the same manner as for all the other `--get-*`options before. This new option can be used as you would use `--get-url` for instance but it would return the manifest URL instead of the video/audio URL.

Resolves #10976.