### PR TITLE
[postprocessors] Added progress hook calls at the end of postprocessing

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -234,11 +234,13 @@ class YoutubeDL(object):
                        postprocessor.
     progress_hooks:    A list of functions that get called on download
                        progress, with a dictionary with the entries
-                       * status: One of "downloading", "error", or "finished".
+                       * status: One of "downloading", "error", "finished",
+                                 or "postprocessed".
                                  Check this first and ignore unknown values.
 
-                       If status is one of "downloading", or "finished", the
-                       following properties may also be present:
+                       If status is one of "downloading", "finished", or
+                       "postprocessed", the following properties may also be
+                       present:
                        * filename: The final filename (always present)
                        * tmpfilename: The filename we're currently writing to
                        * downloaded_bytes: Bytes on disk
@@ -253,6 +255,9 @@ class YoutubeDL(object):
                                          downloaded video fragment.
                        * fragment_count: The number of fragments (= individual
                                          files that will be merged)
+                       * postprocessor: The specific postprocessor that ran.
+                                        See youtube_dl/postprocessor/__init__.py
+                                        for a list of possibilities.
 
                        Progress hooks are guaranteed to be called at least once
                        (with status "finished") if the download is successful.
@@ -2110,6 +2115,8 @@ class YoutubeDL(object):
             pps_chain.extend(ie_info['__postprocessors'])
         pps_chain.extend(self._pps)
         for pp in pps_chain:
+            for ph in self._progress_hooks:
+                pp.add_progress_hook(ph)
             files_to_delete = []
             try:
                 files_to_delete, info = pp.run(info)

--- a/youtube_dl/postprocessor/common.py
+++ b/youtube_dl/postprocessor/common.py
@@ -33,6 +33,7 @@ class PostProcessor(object):
 
     def __init__(self, downloader=None):
         self._downloader = downloader
+        self._progress_hooks = []
 
     def set_downloader(self, downloader):
         """Sets the downloader for this PP."""
@@ -63,6 +64,15 @@ class PostProcessor(object):
 
     def _configuration_args(self, default=[]):
         return cli_configuration_args(self._downloader.params, 'postprocessor_args', default)
+
+    def _hook_progress(self, status):
+        for ph in self._progress_hooks:
+            ph(status)
+
+    def add_progress_hook(self, ph):
+        # See YoutubeDl.py (search for progress_hooks) for a description of
+        # this interface
+        self._progress_hooks.append(ph)
 
 
 class AudioConversionError(PostProcessingError):

--- a/youtube_dl/postprocessor/embedthumbnail.py
+++ b/youtube_dl/postprocessor/embedthumbnail.py
@@ -127,4 +127,12 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
         else:
             raise EmbedThumbnailPPError('Only mp3 and m4a/mp4 are supported for thumbnail embedding for now.')
 
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
+
         return [], info

--- a/youtube_dl/postprocessor/execafterdownload.py
+++ b/youtube_dl/postprocessor/execafterdownload.py
@@ -27,5 +27,9 @@ class ExecAfterDownloadPP(PostProcessor):
         if retCode != 0:
             raise PostProcessingError(
                 'Command returned error code %d' % retCode)
+        self._hook_progress({
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return [], information

--- a/youtube_dl/postprocessor/ffmpeg.py
+++ b/youtube_dl/postprocessor/ffmpeg.py
@@ -349,6 +349,14 @@ class FFmpegExtractAudioPP(FFmpegPostProcessor):
                 new_path, time.time(), information['filetime'],
                 errnote='Cannot update utime of audio file')
 
+        fsize = os.path.getsize(new_path)
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': new_path,
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
+
         return [path], information
 
 
@@ -372,6 +380,13 @@ class FFmpegVideoConvertorPP(FFmpegPostProcessor):
         information['filepath'] = outpath
         information['format'] = self._preferedformat
         information['ext'] = self._preferedformat
+        fsize = os.path.getsize(outpath)
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': outpath,
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
         return [path], information
 
 
@@ -429,6 +444,13 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
         self.run_ffmpeg_multiple_files(input_files, temp_filename, opts)
         os.remove(encodeFilename(filename))
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return sub_filenames, information
 
@@ -514,6 +536,13 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
             os.remove(metadata_filename)
         os.remove(encodeFilename(filename))
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
         return [], info
 
 
@@ -525,6 +554,13 @@ class FFmpegMergerPP(FFmpegPostProcessor):
         self._downloader.to_screen('[ffmpeg] Merging formats into "%s"' % filename)
         self.run_ffmpeg_multiple_files(info['__files_to_merge'], temp_filename, args)
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
         return info['__files_to_merge'], info
 
     def can_merge(self):
@@ -560,6 +596,13 @@ class FFmpegFixupStretchedPP(FFmpegPostProcessor):
 
         os.remove(encodeFilename(filename))
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return [], info
 
@@ -578,6 +621,13 @@ class FFmpegFixupM4aPP(FFmpegPostProcessor):
 
         os.remove(encodeFilename(filename))
         os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+        fsize = os.path.getsize(encodeFilename(filename))
+        self._hook_progress({
+            'total_bytes': fsize,
+            'filename': encodeFilename(filename),
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return [], info
 
@@ -594,6 +644,14 @@ class FFmpegFixupM3u8PP(FFmpegPostProcessor):
 
             os.remove(encodeFilename(filename))
             os.rename(encodeFilename(temp_filename), encodeFilename(filename))
+
+            fsize = os.path.getsize(encodeFilename(filename))
+            self._hook_progress({
+                'total_bytes': fsize,
+                'filename': encodeFilename(filename),
+                'status': 'postprocessed',
+                'postprocessor': self.__class__.__name__
+            })
         return [], info
 
 
@@ -656,5 +714,10 @@ class FFmpegSubtitlesConvertorPP(FFmpegPostProcessor):
                     'ext': new_ext,
                     'data': f.read(),
                 }
+
+        self._hook_progress({
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return sub_filenames, info

--- a/youtube_dl/postprocessor/metadatafromtitle.py
+++ b/youtube_dl/postprocessor/metadatafromtitle.py
@@ -44,5 +44,9 @@ class MetadataFromTitlePP(PostProcessor):
             self._downloader.to_screen(
                 '[fromtitle] parsed %s: %s'
                 % (attribute, value if value is not None else 'NA'))
+        self._hook_progress({
+            'status': 'postprocessed',
+            'postprocessor': self.__class__.__name__
+        })
 
         return [], info

--- a/youtube_dl/postprocessor/xattrpp.py
+++ b/youtube_dl/postprocessor/xattrpp.py
@@ -55,6 +55,11 @@ class XAttrMetadataPP(PostProcessor):
                     write_xattr(filename, xattrname, byte_value)
                     num_written += 1
 
+            self._hook_progress({
+                'status': 'postprocessed',
+                'postprocessor': self.__class__.__name__
+            })
+
             return [], info
 
         except XAttrUnavailableError as e:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This adds progress hooks to the post processors in addition to where they are already called in the downloaders. The specific use case this resolves is getting the finalized filename and final file size after merging or other post processing occurs. A new status option was added to the progress hooks called `postprocessed`.
