### PR TITLE
[nbl] Add new extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -749,6 +749,7 @@ from .nbc import (
     NBCSportsStreamIE,
     NBCSportsVPlayerIE,
 )
+from .nbl import NBLIE
 from .ndr import (
     NDRIE,
     NJoyIE,

--- a/youtube_dl/extractor/nbl.py
+++ b/youtube_dl/extractor/nbl.py
@@ -1,0 +1,69 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import unified_strdate
+
+
+class NBLIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?nbl\.com\.au/tv/(?:game-replays|highlights|condensed-games)/(?P<id>[0-9]+)'  # /(?P<display_id>.+)'
+    _TESTS = [
+        {
+            'url': 'https://nbl.com.au/tv/highlights/1310086/Perth-Wildcats-vs.-Sydney-Kings---Game-Highlights',
+            'md5': '684a1126879371c3137850b8474ae3c8',
+            'info_dict': {
+                'id': '1310086',
+                'ext': 'mp4',
+                'title': 'Perth Wildcats vs. Sydney Kings - Game Highlights',
+                'description': 'Watch the Game Highlights from Perth Wildcats vs. Sydney Kings, 03/26/2022',
+                'upload_date': '20220326'
+            }
+        },
+        {
+            'url': 'https://nbl.com.au/tv/condensed-games/1310087/Perth-Wildcats-vs.-Sydney-Kings---Condensed-Game',
+            'md5': '1f9ac9ea04dc4024e50b27593860a782',
+            'info_dict': {
+                'id': '1310087',
+                'ext': 'mp4',
+                'title': 'Perth Wildcats vs. Sydney Kings - Condensed Game',
+                'description': 'Watch the Condensed Game from Perth Wildcats vs. Sydney Kings, 03/26/2022',
+                'upload_date': '20220326'
+            }
+        },
+        {
+            'url': 'https://nbl.com.au/tv/game-replays/1303323/NBL22-Round-17-Replay---Perth-Wildcats-vs-Sydney-Kings',
+            'md5': '8505f02156f756e865a1aa80050eb768',
+            'expected_warnings': ['unable to extract OpenGraph description.+'],
+            'info_dict': {
+                'id': '1303323',
+                'ext': 'mp4',
+                'title': 'NBL22 Round 17 Replay - Perth Wildcats vs Sydney Kings',
+                'upload_date': '20220326'
+            }
+        }
+    ]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        title = self._html_search_regex(r'<title>(.+?)</title>', webpage, 'title')
+        stream_url = self._download_json(
+            "https://ott.nbl.com.au/api/v2/content/" + video_id + "/access/hls",
+            video_id,
+            data=b"",
+            headers={
+                "Referer": "https://ott.nbl.com.au/en-int/embed/" + video_id,
+                "Origin": "https://ott.nbl.com.au",
+                "Content-Length": "0"
+            }
+        )["data"]["stream"]
+        formats = self._extract_m3u8_formats(stream_url, video_id, ext="mp4")
+
+        return {
+            'id': video_id,
+            'title': title,
+            'description': self._og_search_description(webpage, default=None),
+            'upload_date': unified_strdate(self._og_search_property('video:release_date', webpage, 'upload_date')),
+            'formats': formats
+        }

--- a/youtube_dl/extractor/nbl.py
+++ b/youtube_dl/extractor/nbl.py
@@ -6,7 +6,7 @@ from ..utils import unified_strdate
 
 
 class NBLIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?nbl\.com\.au/tv/(?:game-replays|highlights|condensed-games)/(?P<id>[0-9]+)'  # /(?P<display_id>.+)'
+    _VALID_URL = r'https?://(?:www\.)?nbl\.com\.au/tv/(?:game-replays|highlights|condensed-games)/(?P<id>[0-9]+)/(?P<display_id>.+)'
     _TESTS = [
         {
             'url': 'https://nbl.com.au/tv/highlights/1310086/Perth-Wildcats-vs.-Sydney-Kings---Game-Highlights',


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is an extractor for game VODs, condensed game VODs, and highlight clips from the website of the National Basketball League of Australia (https://nbl.com.au). At this point it supports video watch URLs at the path /tv/[category]/[id]/. All tests are passing on 2.7.18 and 3.9.11 (I wasn't able to run 2.6.* on my dev machine).

I had plans to include the latter part of the url as the display_id, but I must be misunderstanding the named capture groups in _VALID_URL, as this does not seem to be getting added to the info dict.

I'd like to support the embed url format as well, e.g https://ott.nbl.com.au/en-int/embed/1303323, as this is used in og:video tags and might be a simplification for the extractor, but I didn't want to add that functionality at this time with my limited knowledge of what's available in ytdl.