### PR TITLE
[options] add an `add` flag for each `embed` flag

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -811,15 +811,15 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='nopostoverwrites', default=False,
         help='Do not overwrite post-processed files; the post-processed files are overwritten by default')
     postproc.add_option(
-        '--embed-subs',
+        '--embed-subs', '--add-subs',
         action='store_true', dest='embedsubtitles', default=False,
         help='Embed subtitles in the video (only for mp4, webm and mkv videos)')
     postproc.add_option(
-        '--embed-thumbnail',
+        '--embed-thumbnail', '--add-thumbnail',
         action='store_true', dest='embedthumbnail', default=False,
         help='Embed thumbnail in the audio as cover art')
     postproc.add_option(
-        '--add-metadata',
+        '--add-metadata', '--embed-metadata',
         action='store_true', dest='addmetadata', default=False,
         help='Write metadata to the video file')
     postproc.add_option(


### PR DESCRIPTION

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I sometimes download some songs with this program and, like with bash primitives, I forget which flag is `embed` and which is `add` for metadata and thumbnail. This PR just add an alias for `--embed-subs` and `--embed-thumbnail` replacing the `embed` word to `add` to solve this problem. Now if you want you can use all add instead of some add and some embed.