### PR TITLE
readme: make it more clear that regex ignores case

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          --playlist-items 1-3,7,10-13", it will
                                          download the videos at index 1, 2, 3,
                                          7, 10, 11, 12 and 13.
-    --match-title REGEX                  Download only matching titles (caseless 
-                                         regex or sub-string)
+    --match-title REGEX                  Download only matching titles (case-
+                                         insensitive regex or sub-string)
     --reject-title REGEX                 Skip download for matching titles
-                                         (caseless regex or sub-string)
+                                         (case-insensitive regex or sub-string)
     --max-downloads NUMBER               Abort after downloading NUMBER files
     --min-filesize SIZE                  Do not download any videos smaller than
                                          SIZE (e.g. 50k or 44.6m)

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          --playlist-items 1-3,7,10-13", it will
                                          download the videos at index 1, 2, 3,
                                          7, 10, 11, 12 and 13.
-    --match-title REGEX                  Download only matching titles (regex or
+    --match-title REGEX                  Download only matching titles (caseless regex or
                                          caseless sub-string)
     --reject-title REGEX                 Skip download for matching titles
-                                         (regex or caseless sub-string)
+                                         (caseless regex or caseless sub-string)
     --max-downloads NUMBER               Abort after downloading NUMBER files
     --min-filesize SIZE                  Do not download any videos smaller than
                                          SIZE (e.g. 50k or 44.6m)

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          --playlist-items 1-3,7,10-13", it will
                                          download the videos at index 1, 2, 3,
                                          7, 10, 11, 12 and 13.
-    --match-title REGEX                  Download only matching titles (caseless regex or
-                                         caseless sub-string)
+    --match-title REGEX                  Download only matching titles (caseless 
+                                         regex or sub-string)
     --reject-title REGEX                 Skip download for matching titles
-                                         (caseless regex or caseless sub-string)
+                                         (caseless regex or sub-string)
     --max-downloads NUMBER               Abort after downloading NUMBER files
     --min-filesize SIZE                  Do not download any videos smaller than
                                          SIZE (e.g. 50k or 44.6m)


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I was confused whether the regex needed to be special when using the `OR` regex operator to list multiple substrings `Like|This`. I had to dig into the code to know what was going on. By moving the adjective in the README to the front it should be clear that both regex and substrings are treated with re.IGNORECASE