### PR TITLE
[DoodStream] Add extractor from yt-dlp back-port

### DIFF
--- a/youtube_dl/extractor/doodstream.py
+++ b/youtube_dl/extractor/doodstream.py
@@ -61,7 +61,7 @@ class DoodStreamIE(InfoExtractor):
             'duration': 12.0,
         },
     }, {
-        'url': 'http://dood.ws /d/h7ecgw5oqn8k',
+        'url': 'http://dood.ws/d/h7ecgw5oqn8k',
         'only_matching': True,
     }, {
         'url': 'https://dood.li/d/wlihoael8uog',
@@ -94,7 +94,7 @@ class DoodStreamIE(InfoExtractor):
                 'Referer': url,
             }, note='Downloading authpage URL')
         final_url += ''.join((random_choice(ascii_letters + digits)
-                                        for _ in range(10)))
+                              for _ in range(10)))
         final_url = update_url_query(final_url, {
             'token': token,
             'expiry': int(time_time() * 1000),

--- a/youtube_dl/extractor/doodstream.py
+++ b/youtube_dl/extractor/doodstream.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+import random
+import string
+import time
+
+from ..compat import compat_filter as filter
+from ..utils import (
+    clean_html,
+    ExtractorError,
+    get_element_by_class,
+    parse_duration,
+    parse_filesize,
+    update_url_query,
+    unified_strdate,
+    url_or_none,
+)
+
+from .common import InfoExtractor
+
+
+class DoodStreamIE(InfoExtractor):
+    _VALID_URL = r'https?://(?:www\.)?dood\.(?:to|watch)/[ed]/(?P<id>[a-z0-9]+)'
+    _TESTS = [{
+        'url': 'http://dood.to/e/5s1wmbdacezb',
+        'md5': '4568b83b31e13242b3f1ff96c55f0595',
+        'info_dict': {
+            'id': '5s1wmbdacezb',
+            'ext': 'mp4',
+            'title': 'Kat Wonders - Monthly May 2020',
+            'description': 'Kat Wonders - Monthly May 2020 | DoodStream.com',
+            'thumbnail': 'https://img.doodcdn.com/snaps/flyus84qgl2fsk4g.jpg',
+        },
+        'skip': 'Video not found',
+    }, {
+        'url': 'http://dood.watch/d/5s1wmbdacezb',
+        'md5': '4568b83b31e13242b3f1ff96c55f0595',
+        'info_dict': {
+            'id': '5s1wmbdacezb',
+            'ext': 'mp4',
+            'title': 'Kat Wonders - Monthly May 2020',
+            'description': 'Kat Wonders - Monthly May 2020 | DoodStream.com',
+            'thumbnail': 'https://img.doodcdn.com/snaps/flyus84qgl2fsk4g.jpg',
+        },
+        'skip': 'Video not found',
+    }, {
+        'url': 'https://dood.to/d/jzrxn12t2s7n',
+        'md5': '3207e199426eca7c2aa23c2872e6728a',
+        'info_dict': {
+            'id': 'jzrxn12t2s7n',
+            'ext': 'mp4',
+            'title': 'Stacy Cruz Cute ALLWAYSWELL',
+            'description': 'Stacy Cruz Cute ALLWAYSWELL | DoodStream.com',
+            'thumbnail': 'https://img.doodcdn.com/snaps/8edqd5nppkac3x8u.jpg',
+        },
+        'skip': 'Video not found',
+    }, {
+        'url': 'https://dood.to/d/is34uy8wvaet',
+        'md5': '04740d3ba93bcd638aa7a097d9226710',
+        'info_dict': {
+            'id': 'is34uy8wvaet',
+            'ext': 'mp4',
+            'title': 'Akhanda (2021) Telugu DVDScr MP3 700MB - DoodStream',
+            'upload_date': '20211202',
+            'filesize_approx': int,
+            'duration': 9886,
+        }
+    }]
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        url = 'https://dood.to/e/' + video_id
+        headers = {
+            'User-Agent': 'Mozilla/5.0',  # (Windows NT 6.1; WOW64; rv:53.0) Gecko/20100101 Firefox/66.0',
+        }
+        webpage = self._download_webpage(url, video_id, headers=headers)
+
+        title = self._html_search_meta(('og:title', 'twitter:title'), webpage, default=None)
+        if not title:
+            title = self._html_search_regex(r'<title\b[^>]*>([^<]+?)(?:\|\s+DoodStream\s*)?</title', webpage, 'title')
+            if title == 'Video not found':
+                raise ExtractorError(title, expected=True)
+        token = self._html_search_regex(r'''[?&]token=([a-z0-9]+)[&']''', webpage, 'token')
+
+        headers.update({
+            # 'User-Agent': 'Mozilla/5.0',  # (Windows NT 6.1; WOW64; rv:53.0) Gecko/20100101 Firefox/66.0',
+            'referer': url
+        })
+
+        pass_md5 = self._html_search_regex(r'(/pass_md5.*?)\'', webpage, 'pass_md5')
+        final_url = (
+            self._download_webpage('https://dood.to' + pass_md5, video_id, headers=headers, note='Downloading final URL')
+            + ''.join((random.choice(string.ascii_letters + string.digits) for _ in range(10)))
+        )
+        final_url = update_url_query(final_url, {'token': token, 'expiry': int(time.time() * 1000), })
+
+        thumb = next(filter(None, (url_or_none(self._html_search_meta(x, webpage, default=None))
+                                   for x in ('og:image', 'twitter:image'))), None)
+        description = self._html_search_meta(
+            ('og:description', 'description', 'twitter:description'), webpage, default=None)
+
+        webpage = self._download_webpage('https://dood.to/d/' + video_id, video_id, headers=headers, fatal=False)
+
+        def get_class_text(x):
+            return clean_html(get_element_by_class(x, webpage))
+
+        return {
+            'id': video_id,
+            'title': title,
+            'url': final_url,
+            'http_headers': headers,
+            'ext': 'mp4',
+            'upload_date': unified_strdate(get_class_text('uploadate')),
+            'duration': parse_duration(get_class_text('length')),
+            'filesize_approx': parse_filesize(get_class_text('size')),
+            'description': description,
+            'thumbnail': thumb,
+        }

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -299,6 +299,7 @@ from .democracynow import DemocracynowIE
 from .dfb import DFBIE
 from .dhm import DHMIE
 from .digg import DiggIE
+from .doodstream import DoodStreamIE
 from .dotsub import DotsubIE
 from .douyutv import (
     DouyuShowIE,


### PR DESCRIPTION
<details>
<summary>Boilerplate: mixed code, new extractor</summary>
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except where:
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (`yt-dlp/yt_dlp/extractor/doodstream.py`)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

</details>

---

### Description of your *pull request* and other information

This PR adds the DoodStreamIE extractor as originally proposed in #28008 and subsequently included in yt-dlc and yt-dlp.

The code is taken from the current yt-dlp extractor, adapted for the yt-dl platform, with these further fixes and improvements:

* enforce vanilla UA `Mozilla/5.0` to bypass CloudFlare blockage
* extract from both embed (`/e/`) and player (`/d/`) pages to get additional metadata (duration, size, upload date)
* raise error for `Video not found` title in the embed page
* also recognise TLDs .so, .la, .pm, .sh, .ws, .one.

Other candidate TLDs are .com, .cx, or indeed `[a-z0-9-]*`.

Closes #28903.
Closes #28008.
Resolves #28883.
With suitable changes to the Generic extractor (eg, https://github.com/ytdl-org/youtube-dl/pull/28903/commits/7496a0401cc1f398bd6d72a566025de178e7871d in reverse), would handle #29628.
Incorporates, closes #32979, thx @mp3butcher.