### PR TITLE
[Newgrounds] Fix newgrounds video error

### DIFF
--- a/youtube_dl/extractor/newgrounds.py
+++ b/youtube_dl/extractor/newgrounds.py
@@ -56,13 +56,13 @@ class NewgroundsIE(InfoExtractor):
         media_id = self._match_id(url)
 
         webpage = self._download_webpage(url, media_id)
-      
+
         paths = url.split('/')
         if paths[-3] == 'audio':
             isAudio = True
         else:
-            isAudio = False 
-        
+            isAudio = False
+
         if isAudio:
             media_url = self._parse_json(self._search_regex(
                 r'"url"\s*:\s*("[^"]+"),', webpage, ''), media_id)
@@ -71,7 +71,7 @@ class NewgroundsIE(InfoExtractor):
                 (r'(?s)<h4[^>]*>(.+?)</h4>.*?<em>\s*Author\s*</em>',
                  r'(?:Author|Writer)\s*<a[^>]+>([^<]+)'), webpage, 'uploader',
                 fatal=False)
-            
+
             formats = [{
                 'url': media_url,
                 'format_id': 'source',
@@ -92,9 +92,8 @@ class NewgroundsIE(InfoExtractor):
                     formats.append({
                         'url': sources[source][i]['src'],
                         'format_id': source,
-                        'height': int(source[:-2]) # 1080p -> 1080
+                        'height': int(source[:-2])  # 1080p -> 1080
                     })
-
 
         title = self._html_search_regex(
             r'<title>([^>]+)</title>', webpage, 'title')
@@ -116,7 +115,7 @@ class NewgroundsIE(InfoExtractor):
 
         self._check_formats(formats, media_id)
         self._sort_formats(formats)
-        
+
         return {
             'id': media_id,
             'title': title,

--- a/youtube_dl/extractor/newgrounds.py
+++ b/youtube_dl/extractor/newgrounds.py
@@ -27,6 +27,17 @@ class NewgroundsIE(InfoExtractor):
             'duration': 143,
         },
     }, {
+        'url': 'https://www.newgrounds.com/portal/view/850292',
+        'md5': 'bb7cacf45e1b4d648e2dac2d79284d67',
+        'info_dict': {
+            'id': '850292',
+            'ext': 'mp4',
+            'title': 'Timeless (2021)',
+            'uploader': 'Kevuhn',
+            'timestamp': 1657896960,
+            'upload_date': '20220715',
+        },
+    }, {
         # source format unavailable, additional mp4 formats
         'url': 'http://www.newgrounds.com/portal/view/689400',
         'info_dict': {
@@ -44,7 +55,7 @@ class NewgroundsIE(InfoExtractor):
 
     def _real_extract(self, url):
         media_id = self._match_id(url)
-
+        
         webpage = self._download_webpage(url, media_id)
 
         title = self._html_search_regex(
@@ -80,7 +91,6 @@ class NewgroundsIE(InfoExtractor):
             (r'(?s)<h4[^>]*>(.+?)</h4>.*?<em>\s*Author\s*</em>',
              r'(?:Author|Writer)\s*<a[^>]+>([^<]+)'), webpage, 'uploader',
             fatal=False)
-
         timestamp = unified_timestamp(self._html_search_regex(
             (r'<dt>\s*Uploaded\s*</dt>\s*<dd>([^<]+</dd>\s*<dd>[^<]+)',
              r'<dt>\s*Uploaded\s*</dt>\s*<dd>([^<]+)'), webpage, 'timestamp',

--- a/youtube_dl/extractor/newgrounds.py
+++ b/youtube_dl/extractor/newgrounds.py
@@ -79,7 +79,7 @@ class NewgroundsIE(InfoExtractor):
             }]
 
         else:
-            media_url = f'https://www.newgrounds.com/portal/video/{media_id}'
+            media_url = 'https://www.newgrounds.com/portal/video/' + media_id
             media = self._download_json(media_url, media_id, headers={'X-Requested-With': 'XMLHttpRequest'})
 
             uploader = media['author']

--- a/youtube_dl/extractor/newgrounds.py
+++ b/youtube_dl/extractor/newgrounds.py
@@ -44,7 +44,7 @@ class NewgroundsIE(InfoExtractor):
             'id': '689400',
             'ext': 'mp4',
             'title': 'ZTV News Episode 8',
-            'uploader': 'BennettTheSage',
+            'uploader': 'ZONE-SAMA',
             'timestamp': 1487965140,
             'upload_date': '20170224',
         },

--- a/youtube_dl/extractor/newgrounds.py
+++ b/youtube_dl/extractor/newgrounds.py
@@ -27,17 +27,6 @@ class NewgroundsIE(InfoExtractor):
             'duration': 143,
         },
     }, {
-        'url': 'https://www.newgrounds.com/portal/view/673111',
-        'md5': '3394735822aab2478c31b1004fe5e5bc',
-        'info_dict': {
-            'id': '673111',
-            'ext': 'mp4',
-            'title': 'Dancin',
-            'uploader': 'Squirrelman82',
-            'timestamp': 1460256780,
-            'upload_date': '20160410',
-        },
-    }, {
         # source format unavailable, additional mp4 formats
         'url': 'http://www.newgrounds.com/portal/view/689400',
         'info_dict': {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

This pull request attempts to fix #30575.

- One of the links contained no media (video was removed from the website); removed and added a new test
- One of the videos had an incorrect uploader; replaced with the correct one
- Separated extractor for audio and video; now both audio and video can be downloaded