### PR TITLE
[YoutubeDL] Prevent failure on non-audio-video formats

### DIFF
--- a/test/test_YoutubeDL.py
+++ b/test/test_YoutubeDL.py
@@ -454,6 +454,18 @@ class TestFormatSelection(unittest.TestCase):
         ydl.process_ie_result(info_dict.copy())
         self.assertEqual(ydl.downloaded_info_dicts[0]['format_id'], 'video+audio')
 
+    def test_format_selection_non_audio_video(self):
+        formats = [
+            {'format_id': 'audio', 'url': TEST_URL, 'ext': 'm4a', 'vcodec': 'none'},
+            {'format_id': 'chapter', 'ext': 'mhtml', 'acodec': 'none', 'vcodec': 'none', 'url': 'about:invalid'},
+            {'format_id': 'video', 'url': TEST_URL, 'ext': 'mp4', 'acodec': 'none'},
+        ]
+        info_dict = _make_result(formats)
+
+        ydl = YDL({'format': 'bestvideo+bestaudio'})
+        ydl.process_ie_result(info_dict.copy())
+        self.assertEqual(ydl.downloaded_info_dicts[0]['format_id'], 'video+audio')
+
     def test_invalid_format_specs(self):
         def assert_syntax_error(format_spec):
             ydl = YDL({'format': format_spec})

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1319,25 +1319,25 @@ class YoutubeDL(object):
                     elif format_spec == 'bestaudio':
                         audio_formats = [
                             f for f in formats
-                            if f.get('vcodec') == 'none']
+                            if f.get('vcodec') == 'none' and f.get('acodec') != 'none']
                         if audio_formats:
                             yield audio_formats[-1]
                     elif format_spec == 'worstaudio':
                         audio_formats = [
                             f for f in formats
-                            if f.get('vcodec') == 'none']
+                            if f.get('vcodec') == 'none' and f.get('acodec') != 'none']
                         if audio_formats:
                             yield audio_formats[0]
                     elif format_spec == 'bestvideo':
                         video_formats = [
                             f for f in formats
-                            if f.get('acodec') == 'none']
+                            if f.get('acodec') == 'none' and f.get('vcodec') != 'none']
                         if video_formats:
                             yield video_formats[-1]
                     elif format_spec == 'worstvideo':
                         video_formats = [
                             f for f in formats
-                            if f.get('acodec') == 'none']
+                            if f.get('acodec') == 'none' and f.get('vcodec') != 'none']
                         if video_formats:
                             yield video_formats[0]
                     else:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Backport https://github.com/yt-dlp/yt-dlp/commit/551f93885e25c208c581702494d758e58b608992 to ignore non-audio-video streams in selectors. Required for https://github.com/ytdl-org/youtube-dl/pull/31097
