### PR TITLE
[Youtube] Parse horizontalListRenderer entries the same way as the gr…

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2594,8 +2594,8 @@ class YoutubeTabIE(YoutubeBaseInfoExtractor):
                 yield entry
         renderer = content.get('horizontalListRenderer')
         if renderer:
-            # TODO
-            pass
+            for entry in self._grid_entries(renderer):
+                yield entry
 
     def _shelf_entries(self, shelf_renderer, skip_channels=False):
         ep = try_get(


### PR DESCRIPTION
…idRenderer ones (horizontalListRenderer)

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I was getting the album from Sonata Arctica here
https://www.youtube.com/channel/UCyGTmzFc3YzefTe8mOQ-QgA/playlists and realized
it did only get the created playlists, not the albums and singles.

By debugging the code, I realized the album and single parts are in a
horizontalListRenderer. Parsing this renderer was not yet implemented.

By looking at the content, I realized that apart from being of type
horizontalListRenderer, the items were in the same format as the ones I found in
a gridRenderer.

So I just used the same code for a few lines above that deal with a
gridRenderer. I definitely don't know enough to ensure it will always be the
case, so I'm just starting this pull request to start the discussion.

Also, I wanted to copy the tests about the gridRenderer to make tests about the
horizontalListRenderer, but I could not find any. I don't have the skill to
write tests on my own, so I might need so help there.

Thank you for the awesome youtube-dl.
