### PR TITLE
[utils] Fix sanitize_url regression with search queries

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -65,6 +65,7 @@ from youtube_dl.utils import (
     sanitize_filename,
     sanitize_path,
     sanitize_url,
+    sanitized_Request,
     expand_path,
     prepend_extension,
     replace_extension,
@@ -236,6 +237,10 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_url('httpss://foo.bar'), 'https://foo.bar')
         self.assertEqual(sanitize_url('rmtps://foo.bar'), 'rtmps://foo.bar')
         self.assertEqual(sanitize_url('https://foo.bar'), 'https://foo.bar')
+        self.assertEqual(sanitize_url('ytsearch:search query'), 'ytsearch:search query')
+
+    def test_sanitized_Request(self):
+        self.assertEqual(sanitized_Request('https://foo.bar/foo bar').get_full_url(), 'https://foo.bar/foo%20bar')
 
     def test_expand_path(self):
         def env(var):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -240,6 +240,7 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(sanitize_url('ytsearch:search query'), 'ytsearch:search query')
 
     def test_sanitized_Request(self):
+        # issue 31008
         self.assertEqual(sanitized_Request('https://foo.bar/foo bar').get_full_url(), 'https://foo.bar/foo%20bar')
 
     def test_expand_path(self):

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2169,11 +2169,11 @@ def sanitize_url(url):
     for mistake, fixup in COMMON_TYPOS:
         if re.match(mistake, url):
             return re.sub(mistake, fixup, url)
-    return escape_url(url)
+    return url
 
 
 def sanitized_Request(url, *args, **kwargs):
-    return compat_urllib_request.Request(sanitize_url(url), *args, **kwargs)
+    return compat_urllib_request.Request(escape_url(sanitize_url(url)), *args, **kwargs)
 
 
 def expand_path(s):


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Commit 1baa0f5 introduced a regression which caused search queries such as
"ytsearch:search query" to be changed to "ytsearch:search%20query".
This arose when setting the default-search option to "ytsearch"
and when calling the YoutubeDL.extract_info method.

This occurred because sanitize_url, which doesn't always receive a URL,
performs a URL escape. Instead, this escape should be performed in
sanitized_Request, which always receives a URL.

Example:

```sh
❯ youtube-dl "search query" --default-search ytsearch
[download] Downloading playlist: search%20query
[youtube:search] query "search%20query": Downloading page 1
[youtube:search] playlist search%20query: Downloading 1 videos
...
```
