### PR TITLE
[youtube] add published_time for --flat_playlist JSON

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -330,6 +330,8 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             renderer,
             (lambda x: x['ownerText']['runs'][0]['text'],
              lambda x: x['shortBylineText']['runs'][0]['text']), compat_str)
+        published_time = try_get(
+            renderer, lambda x: x['publishedTimeText']['simpleText'], compat_str) or ''
         return {
             '_type': 'url',
             'ie_key': YoutubeIE.ie_key(),
@@ -340,6 +342,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             'duration': duration,
             'view_count': view_count,
             'uploader': uploader,
+            'published_time': published_time,
         }
 
     def _search_results(self, query, params):


### PR DESCRIPTION
When getting JSON using "--flat-playlist", it misses any information about video age. It is very desirable to have such information. 
This PR adds "published_time" to the JSON.

Example:
  youtube-dl --flat-playlist -j ytsearch10:"egg recipe"
