### PR TITLE
Fix Crucial guide command leads into errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
 # DESCRIPTION
 **youtube-dl** is a command-line program to download videos from YouTube.com and a few more sites. It requires the Python interpreter, version 2.6, 2.7, or 3.2+, and it is not platform specific. It should work on your Unix box, on Windows or on macOS. It is released to the public domain, which means you can modify it, redistribute it or use it however you like.
 
-    youtube-dl [OPTIONS] URL [URL...]
+    youtube-dl [OPTIONS] [URL...]
 
 # OPTIONS
     -h, --help                           Print this help text and exit


### PR DESCRIPTION
At university, colleagues and I tried this tool, but all of us got the error at this point:

  youtube-dl [OPTIONS] URL [URL...]

  youtube-dl -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best' URL https://www.youtube.com/watch?v=Toon9VARRIU

![youtube-dl-miguelgargallo-contribution](https://user-images.githubusercontent.com/5947268/193855229-f3a8c3a0-410d-462d-9408-c7bf201408ec.png)

ERROR: You've asked youtube-dl to download the URL "URL". That doesn't make any sense. Simply remove the parameter in your command or configuration. Add -v to the command line to see what arguments and configuration youtube-dl got.

So, to avoid future devs into this error... we love the project and want to improve it!

By just removing the "URL" word.