### PR TITLE
Clarify: playlist-start/end options are inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          CIDR notation
 
 ## Video Selection:
-    --playlist-start NUMBER              Playlist video to start at (default is
+    --playlist-start NUMBER              Playlist video to start at (inclusive) (default is
                                          1)
-    --playlist-end NUMBER                Playlist video to end at (default is
+    --playlist-end NUMBER                Playlist video to end at (inclusive) (default is
                                          last)
     --playlist-items ITEM_SPEC           Playlist video items to download.
                                          Specify indices of the videos in the

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -258,11 +258,11 @@ def parseOpts(overrideArguments=None):
     selection.add_option(
         '--playlist-start',
         dest='playliststart', metavar='NUMBER', default=1, type=int,
-        help='Playlist video to start at (default is %default)')
+        help='Playlist video to start at (inclusive) (default is %default)')
     selection.add_option(
         '--playlist-end',
         dest='playlistend', metavar='NUMBER', default=None, type=int,
-        help='Playlist video to end at (default is last)')
+        help='Playlist video to end at (inclusive) (default is last)')
     selection.add_option(
         '--playlist-items',
         dest='playlist_items', metavar='ITEM_SPEC', default=None,


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Edit the README.md and the help text to clarify that the number specified for the --playlist-start and --playlist-end options when downloading a playlist is inclusive