### PR TITLE
[pornhub] Download archive improvement

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -518,9 +518,9 @@ class PornHubPlaylistBaseIE(PornHubBaseIE):
         return [
             self.url_result(
                 'http://www.%s/%s' % (host, video_url),
-                PornHubIE.ie_key(), video_title=title)
-            for video_url, title in orderedSet(re.findall(
-                r'href="/?(view_video\.php\?.*\bviewkey=[\da-z]+[^"]*)"[^>]*\s+title="([^"]+)"',
+                PornHubIE.ie_key(), video_title=title, video_id=id)
+            for video_url, id, title in orderedSet(re.findall(
+                r'href="/?(view_video\.php\?.*\bviewkey=([\da-z]+)[^"]*)"[^>]*\s+title="([^"]+)"',
                 container))
         ]
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

PornHub video metadata is downloaded while downloading playlist even though video id is present in archive file.
This happens because PornoHub playlist extractor doesn't extract video id and video id is needed to check presence in archive. With video id exported downloading new videos from playlists happens faster.

Example (before):
First attempt downloads metadata and video. Second attempt downloads only metadata.

> python -m youtube_dl -v --download-archive archive.txt --playlist-items 1 https://rt.pornhub.com/model/luxury-girl/videos
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'--download-archive', u'archive.txt', u'--playlist-items', u'1', u'https://rt.pornhub.com/model/luxury-girl/videos']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Git HEAD: 195f22f67
[debug] Python version 2.7.18 (CPython) - Linux-5.15.0-56-generic-x86_64-with-Ubuntu-20.04-focal
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7
[debug] Proxy map: {}
[download] Downloading playlist: model/luxury-girl/videos
[PornHubPagedVideoList] model/luxury-girl/videos: Downloading page 1
[PornHubPagedVideoList] playlist model/luxury-girl/videos: Downloading 1 videos
[download] Downloading video 1 of 1
[PornHub] ph638e30ea5325d: Downloading pc webpage
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading JSON metadata
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
WARNING: unable to extract view count; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
[debug] Default format spec: bestvideo+bestaudio/best
[debug] Invoking downloader on u'https://ev-h.phncdn.com/hls/videos/202212/05/420850311/,1080P_4000K,720P_4000K,480P_2000K,240P_1000K,_420850311.mp4.urlset/index-f1-v1-a1.m3u8?validfrom=1671460872&validto=1671468072&ipa=89.64.77.248&hdl=-1&hash=ugBHt9juTr4uTAHIvAUyTdyeDfw%3D'
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 301
[download] Destination: He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4
[download] 100% of 322.97MiB in 07:26
[debug] ffmpeg command line: ffprobe -show_streams 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4'
[ffmpeg] Fixing malformed AAC bitstream in "He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel 'repeat+info' -i 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4' -c copy -f mp4 '-bsf:a' aac_adtstoasc 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.temp.mp4'
[download] Finished downloading playlist: model/luxury-girl/videos

> python -m youtube_dl -v --download-archive archive.txt --playlist-items 1 https://rt.pornhub.com/model/luxury-girl/videos
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'--download-archive', u'archive.txt', u'--playlist-items', u'1', u'https://rt.pornhub.com/model/luxury-girl/videos']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Git HEAD: 195f22f67
[debug] Python version 2.7.18 (CPython) - Linux-5.15.0-56-generic-x86_64-with-Ubuntu-20.04-focal
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7
[debug] Proxy map: {}
[download] Downloading playlist: model/luxury-girl/videos
[PornHubPagedVideoList] model/luxury-girl/videos: Downloading page 1
[PornHubPagedVideoList] playlist model/luxury-girl/videos: Downloading 1 videos
[download] Downloading video 1 of 1
[PornHub] ph638e30ea5325d: Downloading pc webpage
[PornHub] ph638e30ea5325d: Downloading JSON metadata
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
WARNING: unable to extract view count; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
[debug] Default format spec: bestvideo+bestaudio/best
[download] He Fucked Me Right On The Sunbed While I Was Sunbathing has already been recorded in archive
[download] Finished downloading playlist: model/luxury-girl/videos


Example (after):

> python -m youtube_dl -v --download-archive archive.txt --playlist-items 1 https://rt.pornhub.com/model/luxury-girl/videos
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'--download-archive', u'archive.txt', u'--playlist-items', u'1', u'https://rt.pornhub.com/model/luxury-girl/videos']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Git HEAD: f9c466d2d
[debug] Python version 2.7.18 (CPython) - Linux-5.15.0-56-generic-x86_64-with-Ubuntu-20.04-focal
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7
[debug] Proxy map: {}
[download] Downloading playlist: model/luxury-girl/videos
[PornHubPagedVideoList] model/luxury-girl/videos: Downloading page 1
[PornHubPagedVideoList] playlist model/luxury-girl/videos: Downloading 1 videos
[download] Downloading video 1 of 1
[PornHub] ph638e30ea5325d: Downloading pc webpage
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading JSON metadata
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
[PornHub] ph638e30ea5325d: Downloading m3u8 information
WARNING: unable to extract view count; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
[debug] Default format spec: bestvideo+bestaudio/best
[debug] Invoking downloader on u'https://ev-h.phncdn.com/hls/videos/202212/05/420850311/,1080P_4000K,720P_4000K,480P_2000K,240P_1000K,_420850311.mp4.urlset/index-f1-v1-a1.m3u8?validfrom=1671459973&validto=1671467173&ipa=<ip>&hdl=-1&hash=h%2Fhdm9Fcirg8zw9gBnxgZtsgO48%3D'
[hlsnative] Downloading m3u8 manifest
[hlsnative] Total fragments: 301
[download] Destination: He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4
[download] 100% of 322.97MiB in 04:10
[debug] ffmpeg command line: ffprobe -show_streams 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4'
[ffmpeg] Fixing malformed AAC bitstream in "He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4"
[debug] ffmpeg command line: ffmpeg -y -loglevel 'repeat+info' -i 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.mp4' -c copy -f mp4 '-bsf:a' aac_adtstoasc 'file:He Fucked Me Right On The Sunbed While I Was Sunbathing-ph638e30ea5325d.temp.mp4'
[download] Finished downloading playlist: model/luxury-girl/videos

> python -m youtube_dl -v --download-archive archive.txt --playlist-items 1 https://rt.pornhub.com/model/luxury-girl/videos
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'--download-archive', u'archive.txt', u'--playlist-items', u'1', u'https://rt.pornhub.com/model/luxury-girl/videos']
[debug] Encodings: locale UTF-8, fs UTF-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Git HEAD: f9c466d2d
[debug] Python version 2.7.18 (CPython) - Linux-5.15.0-56-generic-x86_64-with-Ubuntu-20.04-focal
[debug] exe versions: ffmpeg 4.2.7, ffprobe 4.2.7
[debug] Proxy map: {}
[download] Downloading playlist: model/luxury-girl/videos
[PornHubPagedVideoList] model/luxury-girl/videos: Downloading page 1
[PornHubPagedVideoList] playlist model/luxury-girl/videos: Downloading 1 videos
[download] Downloading video 1 of 1
[download] He Fucked Me Right On The Sunbed While I Was Sunbathing has already been recorded in archive
[download] Finished downloading playlist: model/luxury-girl/videos
