### PR TITLE
[pr0gramm] implement InfoExtractor, Resolves #31433

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1669,5 +1669,5 @@ from .zoom import ZoomIE
 from .zype import ZypeIE
 from .pr0gramm import (
     Pr0grammIE,
-    Pr0grammStaticIE
+    Pr0grammStaticIE,
 )

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1667,3 +1667,7 @@ from .zingmp3 import (
 )
 from .zoom import ZoomIE
 from .zype import ZypeIE
+from .pr0gramm import (
+    Pr0grammIE,
+    Pr0grammStaticIE
+)

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from __future__ import unicode_literals
 
 from .common import InfoExtractor

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -6,7 +6,7 @@ from .common import InfoExtractor
 from datetime import datetime
 import re
 from ..utils import (
-    merge_dicts
+    merge_dicts,
 )
 
 
@@ -24,7 +24,7 @@ class Pr0grammStaticIE(InfoExtractor):
             'upload_date': '20221221',
             'release_date': '20221221',
             'timestamp': 1671580800,
-            'release_timestamp': 1671580800
+            'release_timestamp': 1671580800,
         }
     }
 
@@ -92,7 +92,7 @@ class Pr0grammIE(InfoExtractor):
             'upload_date': '20221221',
             'release_date': '20221221',
             'timestamp': 1671580800,
-            'release_timestamp': 1671580800
+            'release_timestamp': 1671580800,
         }
     }
 

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -10,6 +10,7 @@ from ..utils import (
 
 
 class Pr0grammStaticIE(InfoExtractor):
+    # Possible urls:
     # https://pr0gramm.com/static/5466437
     _VALID_URL = r'https?://pr0gramm\.com/static/(?P<id>[0-9]+)'
     _TEST = {
@@ -18,7 +19,7 @@ class Pr0grammStaticIE(InfoExtractor):
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
-            'title': 'pr0gramm - 5466437',
+            'title': 'pr0gramm-5466437 by g11st',
             'uploader': 'g11st',
             'upload_date': '20221221',
         }
@@ -56,7 +57,7 @@ class Pr0grammStaticIE(InfoExtractor):
 
         return merge_dicts({
             'id': video_id,
-            'title': 'pr0gramm - %s' % video_id,
+            'title': 'pr0gramm-%s%s' % (video_id, (' by ' + uploader) if uploader else ''),
             'uploader': uploader,
             'upload_date': uploadTimestr
         }, media_info)
@@ -86,7 +87,7 @@ class Pr0grammIE(InfoExtractor):
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
-            'title': 'pr0gramm - 5466437',
+            'title': 'pr0gramm-5466437 by g11st',
             'uploader': 'g11st',
             'upload_date': '20221221',
         }

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -1,0 +1,105 @@
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+
+from datetime import datetime
+import re
+from ..utils import (
+    merge_dicts
+)
+
+
+class Pr0grammStaticIE(InfoExtractor):
+    # https://pr0gramm.com/static/5466437
+    _VALID_URL = r'https?://pr0gramm\.com/static/(?P<id>[0-9]+)'
+    _TEST = {
+        'url': 'https://pr0gramm.com/static/5466437',
+        'md5': '52fa540d70d3edc286846f8ca85938aa',
+        'info_dict': {
+            'id': '5466437',
+            'ext': 'mp4',
+            'title': 'pr0gramm',
+            'uploader': 'g11st',
+            'upload_date': '20221221',
+            'release_date': '20221221',
+            'timestamp': 1671580800,
+            'release_timestamp': 1671580800
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+        webpage = self._download_webpage(url, video_id)
+
+        # Fetch media sources
+        entries = self._parse_html5_media_entries(url, webpage, video_id)
+        media_info = entries[0]
+
+        # this raises if there are no formats
+        self._sort_formats(media_info.get('formats') or [])
+
+        # Fetch author
+        uploader = self._html_search_regex(r'by\W+([\w-]+)\W+', webpage, 'uploader')
+
+        # Fetch approx upload timestamp from filename
+        # Have None-defaults in case the extraction fails
+        uploadDay = None
+        uploadMon = None
+        uploadYear = None
+        uploadTimestamp = None
+        uploadTimestr = None
+        # (//img.pr0gramm.com/2022/12/21/62ae8aa5e2da0ebf.mp4)
+        m = re.search(r'.*//img\.pr0gramm\.com/(?P<year>[0-9]+)/(?P<mon>[0-9]+)/(?P<day>[0-9]+)/\w+\.\w{,4}.*', webpage)
+
+        if (m):
+            # Up to a day of accuracy should suffice...
+            uploadDay = m.groupdict().get('day')
+            uploadMon = m.groupdict().get('mon')
+            uploadYear = m.groupdict().get('year')
+            uploadDatetime = datetime(int(uploadYear), int(uploadMon), int(uploadDay))
+            epochDatetime = datetime(1970, 1, 1)
+            uploadTimestamp = (uploadDatetime - epochDatetime).total_seconds()
+            uploadTimestr = str(uploadYear) + str(uploadMon) + str(uploadDay)
+
+        return merge_dicts({
+            'id': video_id,
+            'title': 'pr0gramm',  # Posts don't have titles. The id seems to be postfixed by yt-dl automatically.
+            'uploader': uploader,
+            'timestamp': uploadTimestamp,
+            'release_date': uploadTimestr,
+            'release_timestamp': uploadTimestamp,
+            'upload_date': uploadTimestr
+        }, media_info)
+
+
+# This extractor is for the primary url (used for sharing, and appears in the
+# location bar) Since this page loads the DOM via JS, yt-dl can't find any
+# video information here. So let's redirect to a compatibility version of
+# the site, which does contain the <video>-element  by itself,  without requiring
+# js to be ran.
+class Pr0grammIE(InfoExtractor):
+    # https://pr0gramm.com/new/546637
+    # https://pr0gramm.com/new/video/546637
+    _VALID_URL = r'https?://pr0gramm\.com/(?:new|top)/([^/]+/)?(?P<id>[0-9]+)'
+    _TEST = {
+        'url': 'https://pr0gramm.com/new/video/5466437',
+        'info_dict': {
+            'id': '5466437',
+            'ext': 'mp4',
+            'title': 'pr0gramm',
+            'uploader': 'g11st',
+            'upload_date': '20221221',
+            'release_date': '20221221',
+            'timestamp': 1671580800,
+            'release_timestamp': 1671580800
+        }
+    }
+
+    def _real_extract(self, url):
+        video_id = self._match_id(url)
+
+        # Since t
+        return self.url_result(
+            'https://pr0gramm.com/static/' + video_id,
+            video_id=video_id,
+            ie=Pr0grammStaticIE.ie_key())

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from .common import InfoExtractor
 
-from datetime import datetime
 import re
 from ..utils import (
     merge_dicts,
@@ -22,9 +21,6 @@ class Pr0grammStaticIE(InfoExtractor):
             'title': 'pr0gramm',
             'uploader': 'g11st',
             'upload_date': '20221221',
-            'release_date': '20221221',
-            'timestamp': 1671580800,
-            'release_timestamp': 1671580800,
         }
     }
 
@@ -47,28 +43,21 @@ class Pr0grammStaticIE(InfoExtractor):
         uploadDay = None
         uploadMon = None
         uploadYear = None
-        uploadTimestamp = None
         uploadTimestr = None
         # (//img.pr0gramm.com/2022/12/21/62ae8aa5e2da0ebf.mp4)
-        m = re.search(r'.*//img\.pr0gramm\.com/(?P<year>[0-9]+)/(?P<mon>[0-9]+)/(?P<day>[0-9]+)/\w+\.\w{,4}.*', webpage)
+        m = re.search(r'//img\.pr0gramm\.com/(?P<year>[\d]+)/(?P<mon>[\d]+)/(?P<day>[\d]+)/\w+\.\w{,4}', webpage)
 
         if (m):
             # Up to a day of accuracy should suffice...
             uploadDay = m.groupdict().get('day')
             uploadMon = m.groupdict().get('mon')
             uploadYear = m.groupdict().get('year')
-            uploadDatetime = datetime(int(uploadYear), int(uploadMon), int(uploadDay))
-            epochDatetime = datetime(1970, 1, 1)
-            uploadTimestamp = (uploadDatetime - epochDatetime).total_seconds()
-            uploadTimestr = str(uploadYear) + str(uploadMon) + str(uploadDay)
+            uploadTimestr = uploadYear + uploadMon + uploadDay
 
         return merge_dicts({
             'id': video_id,
             'title': 'pr0gramm',  # Posts don't have titles. The id seems to be postfixed by yt-dl automatically.
             'uploader': uploader,
-            'timestamp': uploadTimestamp,
-            'release_date': uploadTimestr,
-            'release_timestamp': uploadTimestamp,
             'upload_date': uploadTimestr
         }, media_info)
 
@@ -90,9 +79,6 @@ class Pr0grammIE(InfoExtractor):
             'title': 'pr0gramm',
             'uploader': 'g11st',
             'upload_date': '20221221',
-            'release_date': '20221221',
-            'timestamp': 1671580800,
-            'release_timestamp': 1671580800,
         }
     }
 

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -68,9 +68,19 @@ class Pr0grammStaticIE(InfoExtractor):
 # the site, which does contain the <video>-element  by itself,  without requiring
 # js to be ran.
 class Pr0grammIE(InfoExtractor):
+    # Possible urls:
     # https://pr0gramm.com/new/546637
     # https://pr0gramm.com/new/video/546637
-    _VALID_URL = r'https?://pr0gramm\.com/(?:new|top)/(?:[^/]+/)?(?P<id>[0-9]+)'
+    # https://pr0gramm.com/top/546637
+    # https://pr0gramm.com/top/video/546637
+    # https://pr0gramm.com/user/g11st/uploads/5466437
+    # https://pr0gramm.com/user/froschler/dafur-ist-man-hier/5091290
+    # https://pr0gramm.com/user/froschler/reinziehen-1elf/5232030
+    # https://pr0gramm.com/user/froschler/1elf/5232030
+    # https://pr0gramm.com/new/5495710:comment62621020 <- this is not the id!
+    # https://pr0gramm.com/top/fruher war alles damals/5498175
+
+    _VALID_URL = r'https?:\/\/pr0gramm\.com\/.+?\/(?P<id>[\d]+)(:|$)'
     _TEST = {
         'url': 'https://pr0gramm.com/new/video/5466437',
         'info_dict': {

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -18,7 +18,7 @@ class Pr0grammStaticIE(InfoExtractor):
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
-            'title': 'pr0gramm',
+            'title': 'pr0gramm - 5466437',
             'uploader': 'g11st',
             'upload_date': '20221221',
         }
@@ -56,7 +56,7 @@ class Pr0grammStaticIE(InfoExtractor):
 
         return merge_dicts({
             'id': video_id,
-            'title': 'pr0gramm',  # Posts don't have titles. The id seems to be postfixed by yt-dl automatically.
+            'title': 'pr0gramm - %s' % video_id,
             'uploader': uploader,
             'upload_date': uploadTimestr
         }, media_info)
@@ -76,11 +76,14 @@ class Pr0grammIE(InfoExtractor):
         'info_dict': {
             'id': '5466437',
             'ext': 'mp4',
-            'title': 'pr0gramm',
+            'title': 'pr0gramm - 5466437',
             'uploader': 'g11st',
             'upload_date': '20221221',
         }
     }
+
+    def _generic_title():
+        return "oof"
 
     def _real_extract(self, url):
         video_id = self._match_id(url)

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -80,7 +80,7 @@ class Pr0grammStaticIE(InfoExtractor):
 class Pr0grammIE(InfoExtractor):
     # https://pr0gramm.com/new/546637
     # https://pr0gramm.com/new/video/546637
-    _VALID_URL = r'https?://pr0gramm\.com/(?:new|top)/([^/]+/)?(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://pr0gramm\.com/(?:new|top)/(?:[^/]+/)?(?P<id>[0-9]+)'
     _TEST = {
         'url': 'https://pr0gramm.com/new/video/5466437',
         'info_dict': {
@@ -98,7 +98,6 @@ class Pr0grammIE(InfoExtractor):
     def _real_extract(self, url):
         video_id = self._match_id(url)
 
-        # Since t
         return self.url_result(
             'https://pr0gramm.com/static/' + video_id,
             video_id=video_id,

--- a/youtube_dl/extractor/pr0gramm.py
+++ b/youtube_dl/extractor/pr0gramm.py
@@ -81,7 +81,7 @@ class Pr0grammIE(InfoExtractor):
     # https://pr0gramm.com/new/5495710:comment62621020 <- this is not the id!
     # https://pr0gramm.com/top/fruher war alles damals/5498175
 
-    _VALID_URL = r'https?:\/\/pr0gramm\.com\/.+?\/(?P<id>[\d]+)(:|$)'
+    _VALID_URL = r'https?:\/\/pr0gramm\.com\/(?!static/\d+).+?\/(?P<id>[\d]+)(:|$)'
     _TEST = {
         'url': 'https://pr0gramm.com/new/video/5466437',
         'info_dict': {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Implement extractor for Pr0gramm social media. Pr0gramm did not work with the generic IE fallback, because page content is loaded dynamically with JS. Basically: it "re-routes" regular urls, encountered by end users, to a compatibility-page served statically (provided by Pr0gramm), which does contain video information. From here, metadata and video information is extracted.

This is primarily meant for urls like `https://pr0gramm.com/new/video/5466437`, `https://pr0gramm.com/new/5466437`, but obviously also provides support for the static compatibility site (to where public urls are routed to): `https://pr0gramm.com/static/5466437`

Thanks to @dirkf for pointing me the right way on more than one occasion!

Output when running yt-dl with -v
```
➜  youtube-dl git:(pr0gramm-extractor) python -m youtube_dl -v https://pr0gramm.com/new/video/5466437
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: [u'-v', u'https://pr0gramm.com/new/video/5466437']
[debug] Encodings: locale UTF-8, fs utf-8, out UTF-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Git HEAD: d8b46090a
[debug] Python version 2.7.18 (CPython) - Darwin-21.6.0-x86_64-i386-64bit
[debug] exe versions: ffmpeg 5.1.2, ffprobe 5.1.2, rtmpdump 2.4
[debug] Proxy map: {}
[Pr0grammStatic] 5466437: Downloading webpage
[debug] Default format spec: bestvideo+bestaudio/best
[debug] Invoking downloader on u'http://img.pr0gramm.com/2022/12/21/62ae8aa5e2da0ebf.mp4'
[download] Destination: pr0gramm-5466437.mp4
[download]   0.0% of 13.70MiB at Unknown speed ETA Unk
[download]   0.0% of 13.70MiB at Unknown speed ETA Unk
[download] 100% of 13.70MiB in 00:0
```
