### PR TITLE
docs: add link to supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://github.com/ytdl-org/youtube-dl/workflows/CI/badge.svg)](https://github.com/ytdl-org/youtube-dl/actions?query=workflow%3ACI)
 
 
-youtube-dl - download videos from youtube.com or other video platforms
+youtube-dl - download videos from youtube.com or [other video platforms](http://ytdl-org.github.io/youtube-dl/supportedsites.html)
 
 - [INSTALLATION](#installation)
 - [DESCRIPTION](#description)


### PR DESCRIPTION
### What is the purpose of your *pull request*?
- [x] Docs
---

### Description of your *pull request* and other information

I was searching for the supported platforms in the readme but couldn't find them. Eventually found the link to to docs. Would be nice to link to the list directly.