### PR TITLE
Check for oreilly login with new url

### DIFF
--- a/youtube_dl/extractor/safari.py
+++ b/youtube_dl/extractor/safari.py
@@ -38,7 +38,8 @@ class SafariBaseIE(InfoExtractor):
             'Downloading login page')
 
         def is_logged(urlh):
-            return 'learning.oreilly.com/home/' in urlh.geturl()
+            return ('https://learning.oreilly.com/member/login/' == urlh.geturl()
+                    or 'learning.oreilly.com/home/' in urlh.geturl())
 
         if is_logged(urlh):
             self.LOGGED_IN = True


### PR DESCRIPTION
Resolves #30884

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request resolves the issue seen in #30884.  With this change, the following types of URLs should function again:

 * URLs to specific videos that start with "/api/", e.g., https://learning.oreilly.com/api/v1/book/9781491935828/chapter/video226616.html
 * URLs to the video class so that the whole playlist can be downloaded, e.g., https://learning.oreilly.com/videos/design-patterns-in/9781491935828/

This was tested with oreilly account credentials passed via `--username` and `--password`.
