### PR TITLE
Add live stream support for TubiTv

### DIFF
--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -13,38 +13,29 @@ from ..utils import (
 
 
 class TubiTvIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/(?:video|movies|tv-shows)/(?P<id>[0-9]+)'
+    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/(?:video|movies|tv-shows|live)/(?P<id>[0-9]+)'
     _LOGIN_URL = 'http://tubitv.com/login'
     _NETRC_MACHINE = 'tubitv'
     _GEO_COUNTRIES = ['US']
     _TESTS = [{
-        'url': 'http://tubitv.com/video/283829/the_comedian_at_the_friday',
-        'md5': '43ac06be9326f41912dc64ccf7a80320',
+        'url': 'https://tubitv.com/movies/229877/carnival-of-souls',
+        'md5': '275a9f78428cfd6428520989408bcfe9',
         'info_dict': {
-            'id': '283829',
+            'id': '229877',
             'ext': 'mp4',
-            'title': 'The Comedian at The Friday',
-            'description': 'A stand up comedian is forced to look at the decisions in his life while on a one week trip to the west coast.',
-            'uploader_id': 'bc168bee0d18dd1cb3b86c68706ab434',
+            'title': 'Carnival of Souls',
+            'description': 'After a traumatic accident, a woman becomes drawn to a mysterious abandoned carnival.',
+            'uploader_id': 'da2522b1c94be4a578da6ba674925159',
         },
     }, {
-        'url': 'http://tubitv.com/tv-shows/321886/s01_e01_on_nom_stories',
-        'only_matching': True,
-    }, {
-        'url': 'http://tubitv.com/movies/383676/tracker',
-        'only_matching': True,
-    }, {
-        'url': 'https://tubitv.com/movies/560057/penitentiary?start=true',
+        'url': 'https://tubitv.com/live/715943/wb-tv-watchlist',
         'info_dict': {
-            'id': '560057',
+            'id': '715943',
             'ext': 'mp4',
-            'title': 'Penitentiary',
-            'description': 'md5:8d2fc793a93cc1575ff426fdcb8dd3f9',
-            'uploader_id': 'd8fed30d4f24fcb22ec294421b9defc2',
-            'release_year': 1979,
-        },
-        'params': {
-            'skip_download': True,
+            'title': 'WB TV Watchlist',
+            'description': 're:.*',
+            'uploader_id': 'a12923a141282c8b62e593bac425db99',
+            'is_live': True,
         },
     }]
 
@@ -76,7 +67,8 @@ class TubiTvIE(InfoExtractor):
         title = video_data['title']
 
         formats = self._extract_m3u8_formats(
-            self._proto_relative_url(video_data['url']),
+            self._proto_relative_url(video_data.get('url')
+                                     or video_data['video_resources'][0]['manifest']['url']),
             video_id, 'mp4', 'm3u8_native')
         self._sort_formats(formats)
 
@@ -97,6 +89,10 @@ class TubiTvIE(InfoExtractor):
                 'url': self._proto_relative_url(sub_url),
             })
 
+        is_live = None
+        if video_data.get('tags'):
+            is_live = 'live' in video_data.get('tags')
+
         return {
             'id': video_id,
             'title': title,
@@ -107,4 +103,5 @@ class TubiTvIE(InfoExtractor):
             'duration': int_or_none(video_data.get('duration')),
             'uploader_id': video_data.get('publisher_id'),
             'release_year': int_or_none(video_data.get('year')),
+            'is_live': is_live,
         }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The TubiTv extractor was modified to support TubiTv's live streams, specifically the "Live TV" feature at <https://tubitv.com/live>. The accepted URLs are the ones after you click on the video preview from that guide page.

In addition, the existing tests for the extractor didn't work because the videos referenced were no longer available, so I updated those to include a normal on-demand video, plus a live stream.