### PR TITLE
Temp work around for uploader_id

### DIFF
--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -453,9 +453,15 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
         return urljoin('https://www.youtube.com', url_or_path)
 
     def _extract_uploader_id(self, uploader_url):
-        return self._search_regex(
-            r'/(?:(?:channel|user)/|(?=@))([^/?&#]+)', uploader_url or '',
-            'uploader id', default=None)
+        result = 'fail'
+        try:
+            result = self._search_regex(
+                r'/(?:(?:channel|user)/|(?=@))([^/?&#]+)', uploader_url or '',
+                'uploader id', default=None)
+            return result
+        except:
+            result = 'NotFound'
+        return result
 
 
 class YoutubeIE(YoutubeBaseInfoExtractor):


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

Ignores the uploader_id as a try-catch. YouTube probably changed something.
If we want the uploader_id from YouTube we will need to update this instead of just ignoring it.