### PR TITLE
disable --mtime by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,10 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
                                          files (restart from beginning)
     --no-part                            Do not use .part files - write directly
                                          into output file
-    --no-mtime                           Do not use the Last-modified header to
+    --mtime                              Use the Last-modified header to
                                          set the file modification time
+    --no-mtime                           Do not use the Last-modified header to
+                                         set the file modification time (default)
     --write-description                  Write video description to a
                                          .description file
     --write-info-json                    Write video metadata to a .info.json
@@ -482,15 +484,12 @@ Alternatively, refer to the [developer instructions](#developer-instructions) fo
 
 You can configure youtube-dl by placing any supported command line option to a configuration file. On Linux and macOS, the system wide configuration file is located at `/etc/youtube-dl.conf` and the user wide configuration file at `~/.config/youtube-dl/config`. On Windows, the user wide configuration file locations are `%APPDATA%\youtube-dl\config.txt` or `C:\Users\<user name>\youtube-dl.conf`. Note that by default configuration file may not exist so you may need to create it yourself.
 
-For example, with the following configuration file youtube-dl will always extract the audio, not copy the mtime, use a proxy and save all videos under `Movies` directory in your home directory:
+For example, with the following configuration file youtube-dl will always extract the audio, use a proxy and save all videos under `Movies` directory in your home directory:
 ```
 # Lines starting with # are comments
 
 # Always extract audio
 -x
-
-# Do not copy the mtime
---no-mtime
 
 # Use this proxy
 --proxy 127.0.0.1:3128

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -734,9 +734,13 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='nopart', default=False,
         help='Do not use .part files - write directly into output file')
     filesystem.add_option(
+        '--mtime',
+        action='store_true', dest='updatetime', default=False,
+        help='Use the Last-modified header to set the file modification time')
+    filesystem.add_option(
         '--no-mtime',
-        action='store_false', dest='updatetime', default=True,
-        help='Do not use the Last-modified header to set the file modification time')
+        action='store_false', dest='updatetime',
+        help='Do not use the Last-modified header to set the file modification time (default)')
     filesystem.add_option(
         '--write-description',
         action='store_true', dest='writedescription', default=False,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [ ] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

the mtime of a file normally reflects the last modification time of the file on disk rather than what the contents of the file represent. youtube-dl goes against this convention by default, which can cause issues when users don't know about youtube-dl special mtime behavior, e.g. premature deletion of files by cleanup scripts or time-based file searches.

instead of behaving in this unconventional way by default, youtube-dl should not modify the mtime of its output files unless the user specifically asks for that.

fixes #1709

