### PR TITLE
[PornHub] Rename the age verification cookie

### DIFF
--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -60,6 +60,14 @@ class PornHubBaseIE(InfoExtractor):
     def _real_initialize(self):
         self._logged_in = False
 
+    def _set_age_cookies(self, host):
+        # The age verification cookie may have a different name based on the location.
+        # Setting multiple cookies doesn't seem to be big deal so we prefer that solution instead
+        # of guessing the right cookie out of an IP we don't currently have.
+        self._set_cookie(host, 'age_verified', '1')
+        self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
+        self._set_cookie('thumbzilla.com', 'accessAgeDisclaimerTZ', '1')
+
     def _login(self, host):
         if self._logged_in:
             return
@@ -264,16 +272,9 @@ class PornHubIE(PornHubBaseIE):
         video_id = mobj.group('id')
 
         self._login(host)
-
-        # The age verification cookie may have a different name based on the location.
-        # Setting multiple cookies doesn't seem to be big deal so we prefer that solution instead
-        # of guessing the right cookie out of an IP we don't currently have.
-        self._set_cookie(host, 'age_verified', '1')
-        self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
-        self._set_cookie('thumbzilla.com', 'accessAgeDisclaimerTZ', '1')
+        self._set_age_cookies(host)
 
         def dl_webpage(platform):
-            self._set_cookie(host, 'platform', platform)
             return self._download_webpage(
                 'https://www.%s/view_video.php?viewkey=%s' % (host, video_id),
                 video_id, 'Downloading %s webpage' % platform)
@@ -569,6 +570,7 @@ class PornHubUserIE(PornHubPlaylistBaseIE):
         mobj = re.match(self._VALID_URL, url)
         user_id = mobj.group('id')
         videos_url = '%s/videos' % mobj.group('url')
+        self._set_age_cookies(mobj.group('host'))
         page = self._extract_page(url)
         if page:
             videos_url = update_url_query(videos_url, {'page': page})
@@ -633,6 +635,7 @@ class PornHubPagedPlaylistBaseIE(PornHubPlaylistBaseIE):
         item_id = mobj.group('id')
 
         self._login(host)
+        self._set_age_cookies(host)
 
         return self.playlist_result(self._entries(url, host, item_id), item_id)
 

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -66,6 +66,7 @@ class PornHubBaseIE(InfoExtractor):
         # of guessing the right cookie out of an IP we don't currently have.
         self._set_cookie(host, 'age_verified', '1')
         self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
+        self._set_cookie(host, 'accessPH', '1')
 
     def _login(self, host):
         if self._logged_in:

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -269,11 +269,8 @@ class PornHubIE(PornHubBaseIE):
         # Setting multple cookies doesn't seem to be big deal so we prefere that solution instead
         # of guessing the right cookie out of an IP we don't currently have.
         self._set_cookie(host, 'age_verified', '1')
-
-        if 'thumbzilla.com' in host:
-            self._set_cookie(host, 'accessAgeDisclaimerTZ', '1')
-        else:
-            self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
+        self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
+        self._set_cookie('thumbzilla.com', 'accessAgeDisclaimerTZ', '1')
 
         def dl_webpage(platform):
             self._set_cookie(host, 'platform', platform)

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -66,7 +66,6 @@ class PornHubBaseIE(InfoExtractor):
         # of guessing the right cookie out of an IP we don't currently have.
         self._set_cookie(host, 'age_verified', '1')
         self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
-        self._set_cookie('thumbzilla.com', 'accessAgeDisclaimerTZ', '1')
 
     def _login(self, host):
         if self._logged_in:

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -265,6 +265,11 @@ class PornHubIE(PornHubBaseIE):
 
         self._login(host)
 
+        # The age verification cookie may have a different name based on the location.
+        # Setting multple cookies doesn't seem to be big deal so we prefere that solution instead
+        # of guessing the right cookie out of an IP we don't currently have.
+        self._set_cookie(host, 'age_verified', '1')
+
         if 'thumbzilla.com' in host:
             self._set_cookie(host, 'accessAgeDisclaimerTZ', '1')
         else:

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -265,7 +265,10 @@ class PornHubIE(PornHubBaseIE):
 
         self._login(host)
 
-        self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
+        if 'thumbzilla.com' in host:
+            self._set_cookie(host, 'accessAgeDisclaimerTZ', '1')
+        else:
+            self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
 
         def dl_webpage(platform):
             self._set_cookie(host, 'platform', platform)

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -266,7 +266,7 @@ class PornHubIE(PornHubBaseIE):
         self._login(host)
 
         # The age verification cookie may have a different name based on the location.
-        # Setting multple cookies doesn't seem to be big deal so we prefere that solution instead
+        # Setting multiple cookies doesn't seem to be big deal so we prefer that solution instead
         # of guessing the right cookie out of an IP we don't currently have.
         self._set_cookie(host, 'age_verified', '1')
         self._set_cookie(host, 'accessAgeDisclaimerPH', '1')

--- a/youtube_dl/extractor/pornhub.py
+++ b/youtube_dl/extractor/pornhub.py
@@ -265,7 +265,7 @@ class PornHubIE(PornHubBaseIE):
 
         self._login(host)
 
-        self._set_cookie(host, 'age_verified', '1')
+        self._set_cookie(host, 'accessAgeDisclaimerPH', '1')
 
         def dl_webpage(platform):
             self._set_cookie(host, 'platform', platform)


### PR DESCRIPTION

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [ ] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

It only rename the legal age verification cookie.