### PR TITLE
Sanitize info dict before dumping JSON

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1804,7 +1804,7 @@ class YoutubeDL(object):
         info_dict['_filename'] = filename = self.prepare_filename(info_dict)
 
         # Forced printings
-        self.__forced_printings(info_dict, filename, incomplete=False)
+        self.__forced_printings(self.filter_requested_info(info_dict), filename, incomplete=False)
 
         # Do nothing else if in simulate mode
         if self.params.get('simulate', False):

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -2100,7 +2100,7 @@ class YoutubeDL(object):
                 [info_filename], mode='r',
                 openhook=fileinput.hook_encoded('utf-8'))) as f:
             # FileInput doesn't have a read method, we can't call json.load
-            #TODO: let's use io.open(), then
+            # TODO: let's use io.open(), then
             info = self.filter_requested_info(json.loads('\n'.join(f)))
         try:
             self.process_ie_result(info, download=True)

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1777,7 +1777,7 @@ class YoutubeDL(object):
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
         if self.params.get('forcejson', False):
-            self.to_stdout(json.dumps(info_dict))
+            self.to_stdout(json.dumps(self.sanitize_info(info_dict)))
 
     def process_info(self, info_dict):
         """Process a single resolved IE result."""
@@ -1804,7 +1804,7 @@ class YoutubeDL(object):
         info_dict['_filename'] = filename = self.prepare_filename(info_dict)
 
         # Forced printings
-        self.__forced_printings(self.filter_requested_info(info_dict), filename, incomplete=False)
+        self.__forced_printings(info_dict, filename, incomplete=False)
 
         # Do nothing else if in simulate mode
         if self.params.get('simulate', False):
@@ -2091,7 +2091,7 @@ class YoutubeDL(object):
                 raise
             else:
                 if self.params.get('dump_single_json', False):
-                    self.to_stdout(json.dumps(res))
+                    self.to_stdout(json.dumps(self.sanitize_info(res)))
 
         return self._download_retcode
 
@@ -2100,6 +2100,7 @@ class YoutubeDL(object):
                 [info_filename], mode='r',
                 openhook=fileinput.hook_encoded('utf-8'))) as f:
             # FileInput doesn't have a read method, we can't call json.load
+            #TODO: let's use io.open(), then
             info = self.filter_requested_info(json.loads('\n'.join(f)))
         try:
             self.process_ie_result(info, download=True)


### PR DESCRIPTION
### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

This is a follow up to fe7e130 I think which didn't fix everything.

Sample failing command:

```
> youtube-dl --print-json "https://www.youtube.com/watch?v=SrK1yv3g8dI"

Traceback (most recent call last):
  File "/home/gabi/.local/bin/youtube-dl", line 8, in <module>
    sys.exit(main())
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/__init__.py", line 475, in main
    _real_main(argv)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/__init__.py", line 465, in _real_main
    retcode = ydl.download(all_urls)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 2085, in download
    res = self.extract_info(
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 815, in extract_info
    return self.__extract_info(url, ie, download, extra_info, process)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 822, in wrapper
    return func(self, *args, **kwargs)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 854, in __extract_info
    return self.process_ie_result(ie_result, download, extra_info)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 888, in process_ie_result
    return self.process_video_result(ie_result, download=download)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 1698, in process_video_result
    self.process_info(new_info)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 1807, in process_info
    self.__forced_printings(info_dict, filename, incomplete=False)
  File "/home/gabi/.local/lib/python3.10/site-packages/youtube_dl/YoutubeDL.py", line 1780, in __forced_printings
    self.to_stdout(json.dumps(info_dict))
  File "/usr/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type LazyList is not JSON serializable
```