### PR TITLE
[SkylineWebcamsIE] Attempt to fix extractor, should investigate further

### DIFF
--- a/youtube_dl/extractor/skylinewebcams.py
+++ b/youtube_dl/extractor/skylinewebcams.py
@@ -26,8 +26,11 @@ class SkylineWebcamsIE(InfoExtractor):
         webpage = self._download_webpage(url, video_id)
 
         stream_url = self._search_regex(
-            r'(?:url|source)\s*:\s*(["\'])(?P<url>(?:https?:)?//.+?\.m3u8.*?)\1', webpage,
+            r'(?:url|source)\s*:\s*(["\'])(?P<url>(?:https?:)?(?://)?\S+?\.m3u8.*?)\1', webpage,
             'stream url', group='url')
+
+        if 'skylinewebcams.com' not in stream_url and 'livee.m3u8' in stream_url:
+            stream_url = stream_url.replace('livee.m3u8', 'https://hd-auth.skylinewebcams.com/live.m3u8')
 
         title = self._og_search_title(webpage)
         description = self._og_search_description(webpage)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

SkylineWebcams support is broken — I got the following output trying a random webcam:

```console
$ youtube-dl -vU 'https://www.skylinewebcams.com/it/webcam/espana/canarias/santa-cruz-de-tenerife/playa-los-cristianos.html'
[debug] System config: []
[debug] User config: []
[debug] Custom config: []
[debug] Command-line args: ['-vU', 'https://www.skylinewebcams.com/it/webcam/espana/canarias/santa-cruz-de-tenerife/playa-los-cristianos.html']
[debug] Encodings: locale UTF-8, fs utf-8, out utf-8, pref UTF-8
[debug] youtube-dl version 2021.12.17
[debug] Python version 3.11.3 (CPython) - Linux-6.2.10-1-clear-x86_64-with-glibc2.37
[debug] exe versions: ffmpeg 6.0, ffprobe 6.0
[debug] Proxy map: {}
It looks like you installed youtube-dl with a package manager, pip, setup.py or a tarball. Please use that to update.
[SkylineWebcams] playa-los-cristianos: Downloading webpage
ERROR: Unable to extract stream url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/youtube_dl/YoutubeDL.py", line 815, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/youtube_dl/YoutubeDL.py", line 836, in __extract_info
    ie_result = ie.extract(url)
                ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/youtube_dl/extractor/common.py", line 534, in extract
    ie_result = self._real_extract(url)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/youtube_dl/extractor/skylinewebcams.py", line 28, in _real_extract
    stream_url = self._search_regex(
                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/youtube_dl/extractor/common.py", line 1012, in _search_regex
    raise RegexNotFoundError('Unable to extract %s' % _name)
youtube_dl.utils.RegexNotFoundError: Unable to extract stream url; please report this issue on https://yt-dl.org/bug . Make sure you are using the latest version; see  https://yt-dl.org/update  on how to update. Be sure to call youtube-dl with the --verbose flag and include its complete output.
```

The raw stream url is now `source:'livee.m3u8?a=abcd1234...'` — I tried to fix the regex, then noticed the base domain did not appear in the stream url and fixed that too, but it doesn't suffice. Inspecting network requests there's no `livee.m3u8` but various ones to `https://hd-auth.skylinewebcams.com/live`, so also tried to do a simple replace and _it seems_ working now.

Needless to say it's a pretty hackish approach and it should be investigated further.