### PR TITLE
Add support for shows.acast.com

### DIFF
--- a/youtube_dl/extractor/acast.py
+++ b/youtube_dl/extractor/acast.py
@@ -107,6 +107,7 @@ class ACastChannelIE(ACastBaseIE):
             'id': '4efc5294-5385-4847-98bd-519799ce5786',
             'title': 'Today in Focus',
             'description': 'md5:c09ce28c91002ce4ffce71d6504abaae',
+            'skip': 'Error 404'
         },
         'playlist_mincount': 200,
     }, {
@@ -115,6 +116,13 @@ class ACastChannelIE(ACastBaseIE):
     }, {
         'url': 'https://shows.acast.com/611233d8767fdf0012f22cb6',
         'only_matching': True,
+    }, {
+        'url': 'https://play.acast.com/s/getthebeltpod',
+        'info_dict': {
+            'id': '4caac858-3cda-44e6-b684-50d88b909c18',
+            'title': 'Get The Belt'
+        },
+        'playlist_mincount': 138,
     }]
 
     @classmethod

--- a/youtube_dl/extractor/acast.py
+++ b/youtube_dl/extractor/acast.py
@@ -48,9 +48,9 @@ class ACastIE(ACastBaseIE):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
-                            (?:(?:embed|www|shows)\.)?acast\.com/|
-                            play\.acast\.com/s/
-                        )
+                            (?:(?:(?P<embed>embed)|www|shows)\.)?acast\.com|
+                            play\.acast\.com/s
+                        )/(?(embed)(?:$/)?)
                         (?P<channel>[^/]+)/(?P<id>[^/#?]+)
                     '''
     _TESTS = [{
@@ -96,7 +96,7 @@ class ACastChannelIE(ACastBaseIE):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
-                            (?:www|shows\.)?acast\.com/|
+                            (?:(?:www|shows)\.)?acast\.com/|
                             play\.acast\.com/s/
                         )
                         (?P<id>[^/#?]+)

--- a/youtube_dl/extractor/acast.py
+++ b/youtube_dl/extractor/acast.py
@@ -48,7 +48,7 @@ class ACastIE(ACastBaseIE):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
-                            (?:(?:embed|www)\.)?acast\.com/|
+                            (?:(?:embed|www|shows)\.)?acast\.com/|
                             play\.acast\.com/s/
                         )
                         (?P<channel>[^/]+)/(?P<id>[^/#?]+)
@@ -77,6 +77,9 @@ class ACastIE(ACastBaseIE):
     }, {
         'url': 'https://play.acast.com/s/sparpodcast/2a92b283-1a75-4ad8-8396-499c641de0d9',
         'only_matching': True,
+    }, {
+        'url': 'https://shows.acast.com/611233d8767fdf0012f22cb6/episodes/611233e4988b6a001394b5cf',
+        'only_matching': True,
     }]
 
     def _real_extract(self, url):
@@ -93,7 +96,7 @@ class ACastChannelIE(ACastBaseIE):
     _VALID_URL = r'''(?x)
                     https?://
                         (?:
-                            (?:www\.)?acast\.com/|
+                            (?:www|shows\.)?acast\.com/|
                             play\.acast\.com/s/
                         )
                         (?P<id>[^/#?]+)
@@ -108,6 +111,9 @@ class ACastChannelIE(ACastBaseIE):
         'playlist_mincount': 200,
     }, {
         'url': 'http://play.acast.com/s/ft-banking-weekly',
+        'only_matching': True,
+    }, {
+        'url': 'https://shows.acast.com/611233d8767fdf0012f22cb6',
         'only_matching': True,
     }]
 


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

I tried to add support for Acast's url `shows.acast.com`. It's my first PR and I wasn't able to check my regex properly so I hope someone more experienced can review it properly. That being said, I tested with the new URLs and it works 🙂.

While testing with the old URLs to ensure no regression, I noticed that some of them are not active anymore: [https://www.acast.com/todayinfocus](https://www.acast.com/todayinfocus) returns a 404.

I didn't remove it as I wasn't sure I should but I'm happy to do a bit of cleaning if someones greenlights it.

I also saw that they are using a new format with a dollar sign for embeds URL but (not being a regex expert) I failed to add it. Here's an example: `https://embed.acast.com/$/611233d8767fdf0012f22cb6/611233e4988b6a001394b5cf?feed=true`