### PR TITLE
indent json with --pretty-json

### DIFF
--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1914,7 +1914,10 @@ class YoutubeDL(object):
             self.to_stdout(formatSeconds(info_dict['duration']))
         print_mandatory('format')
         if self.params.get('forcejson', False):
-            self.to_stdout(json.dumps(self.sanitize_info(info_dict)))
+            if self.params.get('indent_json', False):
+                self.to_stdout(json.dumps(self.sanitize_info(info_dict), indent=2))
+            else:
+                self.to_stdout(json.dumps(self.sanitize_info(info_dict)))
 
     def process_info(self, info_dict):
         """Process a single resolved IE result."""

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -435,6 +435,7 @@ def _real_main(argv=None):
         # just for deprecation check
         'autonumber': opts.autonumber if opts.autonumber is True else None,
         'usetitle': opts.usetitle if opts.usetitle is True else None,
+        'indent_json': opts.pretty_json,
     }
 
     with YoutubeDL(ydl_opts) as ydl:

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -675,6 +675,11 @@ def parseOpts(overrideArguments=None):
         '--no-call-home',
         dest='call_home', action='store_false', default=False,
         help='Do NOT contact the youtube-dl server for debugging')
+    verbosity.add_option(
+        '--pretty-json',
+        dest='pretty_json', action='store_true', default=False,
+        help='Print json with indentation. Only when --dump-json is provided'
+    )
 
     filesystem = optparse.OptionGroup(parser, 'Filesystem Options')
     filesystem.add_option(


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

---

### Description of your *pull request* and other information

This switch `--pretty-json` prints result of `--dump-json` in a more human readable format. Applicable in storing video's information. 

**Reason**: I am making a wrapper called [youtube-dl-java](https://github.com/knighthat/youtube-dl-java). Loading 1 line of JSON with hundreds of thousands of characters takes a significantly long time due to how much memory is allocated for 1 single line.

This also makes it easier for users to inspect the return json since it's nicely indented.
