### PR TITLE
[ORF] Extractor overhaul

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -5,9 +5,9 @@ import hashlib
 import json
 import os.path
 import re
-import types
 import ssl
 import sys
+import types
 import unittest
 
 import youtube_dl.extractor
@@ -181,18 +181,18 @@ def expect_value(self, got, expected, field):
             op, _, expected_num = expected.partition(':')
             expected_num = int(expected_num)
             if op == 'mincount':
-                assert_func = assertGreaterEqual
+                assert_func = self.assertGreaterEqual
                 msg_tmpl = 'Expected %d items in field %s, but only got %d'
             elif op == 'maxcount':
-                assert_func = assertLessEqual
+                assert_func = self.assertLessEqual
                 msg_tmpl = 'Expected maximum %d items in field %s, but got %d'
             elif op == 'count':
-                assert_func = assertEqual
+                assert_func = self.assertEqual
                 msg_tmpl = 'Expected exactly %d items in field %s, but got %d'
             else:
                 assert False
             assert_func(
-                self, len(got), expected_num,
+                len(got), expected_num,
                 msg_tmpl % (expected_num, field, len(got)))
             return
         self.assertEqual(
@@ -260,27 +260,6 @@ def assertRegexpMatches(self, text, regexp, msg=None):
             else:
                 msg = note + ', ' + msg
             self.assertTrue(m, msg)
-
-
-def assertGreaterEqual(self, got, expected, msg=None):
-    if not (got >= expected):
-        if msg is None:
-            msg = '%r not greater than or equal to %r' % (got, expected)
-        self.assertTrue(got >= expected, msg)
-
-
-def assertLessEqual(self, got, expected, msg=None):
-    if not (got <= expected):
-        if msg is None:
-            msg = '%r not less than or equal to %r' % (got, expected)
-        self.assertTrue(got <= expected, msg)
-
-
-def assertEqual(self, got, expected, msg=None):
-    if not (got == expected):
-        if msg is None:
-            msg = '%r not equal to %r' % (got, expected)
-        self.assertTrue(got == expected, msg)
 
 
 def expect_warnings(ydl, warnings_re):

--- a/test/test_download.py
+++ b/test/test_download.py
@@ -9,8 +9,6 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from test.helper import (
-    assertGreaterEqual,
-    assertLessEqual,
     expect_warnings,
     get_params,
     gettestcases,
@@ -36,11 +34,19 @@ from youtube_dl.utils import (
     ExtractorError,
     error_to_compat_str,
     format_bytes,
+    IDENTITY,
+    preferredencoding,
     UnavailableVideoError,
 )
 from youtube_dl.extractor import get_info_extractor
 
 RETRIES = 3
+
+# Some unittest APIs require actual str
+if not isinstance('TEST', str):
+    _encode_str = lambda s: s.encode(preferredencoding())
+else:
+    _encode_str = IDENTITY
 
 
 class YoutubeDL(youtube_dl.YoutubeDL):
@@ -102,7 +108,7 @@ def generator(test_case, tname):
 
         def print_skipping(reason):
             print('Skipping %s: %s' % (test_case['name'], reason))
-            self.skipTest(reason)
+            self.skipTest(_encode_str(reason))
 
         if not ie.working():
             print_skipping('IE marked as not _WORKING')
@@ -187,16 +193,14 @@ def generator(test_case, tname):
                 expect_info_dict(self, res_dict, test_case.get('info_dict', {}))
 
             if 'playlist_mincount' in test_case:
-                assertGreaterEqual(
-                    self,
+                self.assertGreaterEqual(
                     len(res_dict['entries']),
                     test_case['playlist_mincount'],
                     'Expected at least %d in playlist %s, but got only %d' % (
                         test_case['playlist_mincount'], test_case['url'],
                         len(res_dict['entries'])))
             if 'playlist_maxcount' in test_case:
-                assertLessEqual(
-                    self,
+                self.assertLessEqual(
                     len(res_dict['entries']),
                     test_case['playlist_maxcount'],
                     'Expected at most %d in playlist %s, but got %d' % (
@@ -243,8 +247,8 @@ def generator(test_case, tname):
                         if params.get('test'):
                             expected_minsize = max(expected_minsize, 10000)
                         got_fsize = os.path.getsize(tc_filename)
-                        assertGreaterEqual(
-                            self, got_fsize, expected_minsize,
+                        self.assertGreaterEqual(
+                            got_fsize, expected_minsize,
                             'Expected %s to be at least %s, but it\'s only %s ' %
                             (tc_filename, format_bytes(expected_minsize),
                                 format_bytes(got_fsize)))

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1039,8 +1039,8 @@ class YoutubeDL(object):
         elif result_type in ('playlist', 'multi_video'):
             # Protect from infinite recursion due to recursively nested playlists
             # (see https://github.com/ytdl-org/youtube-dl/issues/27833)
-            webpage_url = ie_result['webpage_url']
-            if webpage_url in self._playlist_urls:
+            webpage_url = ie_result.get('webpage_url')  # not all pl/mv have this
+            if webpage_url and webpage_url in self._playlist_urls:
                 self.to_screen(
                     '[download] Skipping already downloaded playlist: %s'
                     % ie_result.get('title') or ie_result.get('id'))
@@ -1048,6 +1048,10 @@ class YoutubeDL(object):
 
             self._playlist_level += 1
             self._playlist_urls.add(webpage_url)
+            new_result = dict((k, v) for k, v in extra_info.items() if k not in ie_result)
+            if new_result:
+                new_result.update(ie_result)
+                ie_result = new_result
             try:
                 return self.__process_playlist(ie_result, download)
             finally:

--- a/youtube_dl/YoutubeDL.py
+++ b/youtube_dl/YoutubeDL.py
@@ -1597,6 +1597,28 @@ class YoutubeDL(object):
         self.cookiejar.add_cookie_header(pr)
         return pr.get_header('Cookie')
 
+    def _fill_common_fields(self, info_dict, final=True):
+
+        for ts_key, date_key in (
+                ('timestamp', 'upload_date'),
+                ('release_timestamp', 'release_date'),
+        ):
+            if info_dict.get(date_key) is None and info_dict.get(ts_key) is not None:
+                # Working around out-of-range timestamp values (e.g. negative ones on Windows,
+                # see http://bugs.python.org/issue1646728)
+                try:
+                    upload_date = datetime.datetime.utcfromtimestamp(info_dict[ts_key])
+                    info_dict[date_key] = compat_str(upload_date.strftime('%Y%m%d'))
+                except (ValueError, OverflowError, OSError):
+                    pass
+
+        # Auto generate title fields corresponding to the *_number fields when missing
+        # in order to always have clean titles. This is very common for TV series.
+        if final:
+            for field in ('chapter', 'season', 'episode'):
+                if info_dict.get('%s_number' % field) is not None and not info_dict.get(field):
+                    info_dict[field] = '%s %d' % (field.capitalize(), info_dict['%s_number' % field])
+
     def process_video_result(self, info_dict, download=True):
         assert info_dict.get('_type', 'video') == 'video'
 
@@ -1664,24 +1686,7 @@ class YoutubeDL(object):
         if 'display_id' not in info_dict and 'id' in info_dict:
             info_dict['display_id'] = info_dict['id']
 
-        for ts_key, date_key in (
-                ('timestamp', 'upload_date'),
-                ('release_timestamp', 'release_date'),
-        ):
-            if info_dict.get(date_key) is None and info_dict.get(ts_key) is not None:
-                # Working around out-of-range timestamp values (e.g. negative ones on Windows,
-                # see http://bugs.python.org/issue1646728)
-                try:
-                    upload_date = datetime.datetime.utcfromtimestamp(info_dict[ts_key])
-                    info_dict[date_key] = compat_str(upload_date.strftime('%Y%m%d'))
-                except (ValueError, OverflowError, OSError):
-                    pass
-
-        # Auto generate title fields corresponding to the *_number fields when missing
-        # in order to always have clean titles. This is very common for TV series.
-        for field in ('chapter', 'season', 'episode'):
-            if info_dict.get('%s_number' % field) is not None and not info_dict.get(field):
-                info_dict[field] = '%s %d' % (field.capitalize(), info_dict['%s_number' % field])
+        self._fill_common_fields(info_dict)
 
         for cc_kind in ('subtitles', 'automatic_captions'):
             cc = info_dict.get(cc_kind)

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -898,7 +898,8 @@ from .ooyala import (
 )
 from .ora import OraTVIE
 from .orf import (
-    ORFTVthekIE,
+    ORFONIE,
+    ORFONLiveIE,
     ORFFM4IE,
     ORFFM4StoryIE,
     ORFOE1IE,

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -900,20 +900,11 @@ from .ora import OraTVIE
 from .orf import (
     ORFONIE,
     ORFONLiveIE,
-    ORFFM4IE,
     ORFFM4StoryIE,
-    ORFOE1IE,
-    ORFOE3IE,
-    ORFNOEIE,
-    ORFWIEIE,
-    ORFBGLIE,
-    ORFOOEIE,
-    ORFSTMIE,
-    ORFKTNIE,
-    ORFSBGIE,
-    ORFTIRIE,
-    ORFVBGIE,
     ORFIPTVIE,
+    ORFPodcastIE,
+    ORFRadioIE,
+    ORFRadioCollectionIE,
 )
 from .outsidetv import OutsideTVIE
 from .packtpub import (

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -135,7 +135,7 @@ class ORFRadioIE(ORFRadioBase):
                 'duration': 14413.0,
             }
         }],
-        # 'skip': 'Shows from ORF Sound are only available for 30 days.'
+        'skip': 'Shows from ORF Sound are only available for 30 days.'
     }, {
         'url': 'https://oe1.orf.at/player/20240531/758136',
         'md5': '2397717aaf3ae9c22a4f090ee3b8d374',
@@ -149,7 +149,7 @@ class ORFRadioIE(ORFRadioBase):
             'uploader': 'oe1',
             'duration': 1500,
         },
-        # 'skip': 'Shows from ORF Sound are only available for 30 days.'
+        'skip': 'Shows from ORF Sound are only available for 30 days.'
     }]
 
     def _real_extract(self, url):
@@ -199,8 +199,9 @@ class ORFRadioCollectionIE(ORFRadioBase):
                 'uploader': 'fm4',
             },
         }],
-        # 'skip': 'Shows from ORF Sound are only available for 30 days.'
+        'skip': 'Shows from ORF Sound are only available for 30 days.'
     }, {
+        # persistent playlist (FM4 Highlights)
         'url': 'https://sound.orf.at/collection/4/',
         'info_dict': {
             'id': '4',
@@ -285,7 +286,7 @@ class ORFPodcastIE(ORFRadioBase):
             'duration': 101,
             'series': 'Der Kräutertipp von Christine Lackner',
         },
-        # 'skip': 'ORF podcasts are only available for a limited time'
+        'skip': 'ORF podcasts are only available for a limited time'
     }]
 
     _ID_NAMES = ('slug', 'guid')
@@ -642,6 +643,7 @@ class ORFONIE(ORFONBase):
         'params': {
             'format': 'bestvideo',
         },
+        'skip': 'Available until 2024-08-12',
     }, {
         'url': 'https://on.orf.at/video/3220355',
         'md5': '925a93b2b9a37da5c9b979d7cf71aa2e',
@@ -683,6 +685,7 @@ class ORFONIE(ORFONBase):
             'noplaylist': True,
             'format': 'bestvideo',
         },
+        'skip': 'Available until 2024-06-14',
     }, {
         # Video with multiple segments and no combined version
         'url': 'https://on.orf.at/video/14227864/formel-1-grosser-preis-von-monaco-2024',

--- a/youtube_dl/extractor/orf.py
+++ b/youtube_dl/extractor/orf.py
@@ -6,6 +6,7 @@ import functools
 import re
 
 from .common import InfoExtractor
+from .youtube import YoutubeIE
 from ..utils import (
     clean_html,
     determine_ext,
@@ -14,10 +15,8 @@ from ..utils import (
     int_or_none,
     merge_dicts,
     mimetype2ext,
-    orderedSet,
     parse_age_limit,
     parse_iso8601,
-    remove_end,
     strip_jsonp,
     txt_or_none,
     unified_strdate,
@@ -305,11 +304,90 @@ class ORFPodcastIE(ORFRadioBase):
         }, self._extract_podcast_upload(data), rev=True)
 
 
-class ORFIPTVIE(InfoExtractor):
+class ORFIPTVBase(InfoExtractor):
+    _TITLE_STRIP_RE = ''
+
+    def _extract_video(self, video_id, webpage, fatal=False):
+
+        data = self._download_json(
+            'http://bits.orf.at/filehandler/static-api/json/current/data.json?file=%s' % video_id,
+            video_id)[0]
+
+        video = traverse_obj(data, (
+            'sources', ('default', 'q8c'),
+            T(lambda x: x if x['loadBalancerUrl'] else None),
+            any))
+
+        load_balancer_url = video['loadBalancerUrl']
+
+        try:
+            rendition = self._download_json(
+                load_balancer_url, video_id, transform_source=strip_jsonp)
+        except ExtractorError:
+            rendition = None
+
+        if not rendition:
+            rendition = {
+                'redirect': {
+                    'smil': re.sub(
+                        r'(/)jsonp(/.+\.)mp4$', r'\1dash\2smil/manifest.mpd',
+                        load_balancer_url),
+                },
+            }
+
+        f = traverse_obj(video, {
+            'abr': ('audioBitrate', T(int_or_none)),
+            'vbr': ('bitrate', T(int_or_none)),
+            'fps': ('videoFps', T(int_or_none)),
+            'width': ('videoWidth', T(int_or_none)),
+            'height': ('videoHeight', T(int_or_none)),
+        })
+
+        formats = []
+        for format_id, format_url in traverse_obj(rendition, (
+                'redirect', T(dict.items), Ellipsis)):
+            if format_id == 'rtmp':
+                ff = f.copy()
+                ff.update({
+                    'url': format_url,
+                    'format_id': format_id,
+                })
+                formats.append(ff)
+            elif determine_ext(format_url) == 'f4m':
+                formats.extend(self._extract_f4m_formats(
+                    format_url, video_id, f4m_id=format_id))
+            elif determine_ext(format_url) == 'm3u8':
+                formats.extend(self._extract_m3u8_formats(
+                    format_url, video_id, 'mp4', m3u8_id=format_id,
+                    entry_protocol='m3u8_native'))
+            elif determine_ext(format_url) == 'mpd':
+                formats.extend(self._extract_mpd_formats(
+                    format_url, video_id, mpd_id=format_id))
+
+        if formats or fatal:
+            self._sort_formats(formats)
+        else:
+            return
+
+        return merge_dicts({
+            'id': video_id,
+            'title': re.sub(self._TITLE_STRIP_RE, '', self._og_search_title(webpage)),
+            'description': self._og_search_description(webpage),
+            'upload_date': unified_strdate(self._html_search_meta(
+                'dc.date', webpage, 'upload date', fatal=False)),
+            'formats': formats,
+        }, traverse_obj(data, {
+            'duration': ('duration', T(k_float_or_none)),
+            'thumbnail': ('sources', 'default', 'preview', T(url_or_none)),
+        }), rev=True)
+
+
+class ORFIPTVIE(ORFIPTVBase):
     IE_NAME = 'orf:iptv'
     IE_DESC = 'iptv.ORF.at'
     _WORKING = False  # URLs redirect to orf.at/
     _VALID_URL = r'https?://iptv\.orf\.at/(?:#/)?stories/(?P<id>\d+)'
+    _TITLE_STRIP_RE = r'\s+-\s+iptv\.ORF\.at\S*$'
 
     _TEST = {
         'url': 'http://iptv.orf.at/stories/2275236/',
@@ -334,74 +412,32 @@ class ORFIPTVIE(InfoExtractor):
         video_id = self._search_regex(
             r'data-video(?:id)?="(\d+)"', webpage, 'video id')
 
-        data = self._download_json(
-            'http://bits.orf.at/filehandler/static-api/json/current/data.json?file=%s' % video_id,
-            video_id)[0]
-
-        duration = float_or_none(data['duration'], 1000)
-
-        video = data['sources']['default']
-        load_balancer_url = video['loadBalancerUrl']
-        abr = int_or_none(video.get('audioBitrate'))
-        vbr = int_or_none(video.get('bitrate'))
-        fps = int_or_none(video.get('videoFps'))
-        width = int_or_none(video.get('videoWidth'))
-        height = int_or_none(video.get('videoHeight'))
-        thumbnail = video.get('preview')
-
-        rendition = self._download_json(
-            load_balancer_url, video_id, transform_source=strip_jsonp)
-
-        f = {
-            'abr': abr,
-            'vbr': vbr,
-            'fps': fps,
-            'width': width,
-            'height': height,
-        }
-
-        formats = []
-        for format_id, format_url in rendition['redirect'].items():
-            if format_id == 'rtmp':
-                ff = f.copy()
-                ff.update({
-                    'url': format_url,
-                    'format_id': format_id,
-                })
-                formats.append(ff)
-            elif determine_ext(format_url) == 'f4m':
-                formats.extend(self._extract_f4m_formats(
-                    format_url, video_id, f4m_id=format_id))
-            elif determine_ext(format_url) == 'm3u8':
-                formats.extend(self._extract_m3u8_formats(
-                    format_url, video_id, 'mp4', m3u8_id=format_id))
-            else:
-                continue
-        self._sort_formats(formats)
-
-        title = remove_end(self._og_search_title(webpage), ' - iptv.ORF.at')
-        description = self._og_search_description(webpage)
-        upload_date = unified_strdate(self._html_search_meta(
-            'dc.date', webpage, 'upload date'))
-
-        return {
-            'id': video_id,
-            'title': title,
-            'description': description,
-            'duration': duration,
-            'thumbnail': thumbnail,
-            'upload_date': upload_date,
-            'formats': formats,
-        }
+        return self._extract_video(video_id, webpage)
 
 
-class ORFFM4StoryIE(InfoExtractor):
+class ORFFM4StoryIE(ORFIPTVBase):
     IE_NAME = 'orf:fm4:story'
     IE_DESC = 'fm4.orf.at stories'
     _VALID_URL = r'https?://fm4\.orf\.at/stories/(?P<id>\d+)'
+    _TITLE_STRIP_RE = r'\s+-\s+fm4\.ORF\.at\s*$'
 
-    _TEST = {
+    _TESTS = [{
+        'url': 'https://fm4.orf.at/stories/3041554/',
+        'add_ie': ['Youtube'],
+        'info_dict': {
+            'id': '3041554',
+            'title': 'Is The EU Green Deal In Mortal Danger?',
+        },
+        'playlist_count': 4,
+        'params': {
+            'format': 'bestvideo',
+        },
+    }, {
         'url': 'http://fm4.orf.at/stories/2865738/',
+        'info_dict': {
+            'id': '2865738',
+            'title': 'Manu Delago und Inner Tongue live',
+        },
         'playlist': [{
             'md5': 'e1c2c706c45c7b34cf478bbf409907ca',
             'info_dict': {
@@ -418,86 +454,49 @@ class ORFFM4StoryIE(InfoExtractor):
             'info_dict': {
                 'id': '547798',
                 'ext': 'flv',
-                'title': 'Manu Delago und Inner Tongue live (2)',
+                'title': 'Manu Delago und Inner Tongue https://vod-ww.mdn.ors.at/cms-worldwide_episodes_nas/_definst_/nas/cms-worldwide_episodes/online/14228823_0005.smil/chunklist_b992000_vo.m3u8live (2)',
                 'duration': 1504.08,
                 'thumbnail': r're:^https?://.*\.jpg$',
                 'upload_date': '20170913',
                 'description': 'Manu Delago und Inner Tongue haben bei der FM4 Soundpark Session live alles gegeben. Hier gibt es Fotos und die gesamte Session als Video.',
             },
         }],
-    }
+        'skip': 'Videos gone',
+    }]
 
     def _real_extract(self, url):
         story_id = self._match_id(url)
         webpage = self._download_webpage(url, story_id)
 
         entries = []
-        all_ids = orderedSet(re.findall(r'data-video(?:id)?="(\d+)"', webpage))
-        for idx, video_id in enumerate(all_ids):
-            data = self._download_json(
-                'http://bits.orf.at/filehandler/static-api/json/current/data.json?file=%s' % video_id,
-                video_id)[0]
+        seen_ids = set()
+        for idx, video_id in enumerate(re.findall(r'data-video(?:id)?="(\d+)"', webpage)):
+            if video_id in seen_ids:
+                continue
+            seen_ids.add(video_id)
+            entry = self._extract_video(video_id, webpage, fatal=False)
+            if not entry:
+                continue
 
-            duration = float_or_none(data['duration'], 1000)
-
-            video = data['sources']['q8c']
-            load_balancer_url = video['loadBalancerUrl']
-            abr = int_or_none(video.get('audioBitrate'))
-            vbr = int_or_none(video.get('bitrate'))
-            fps = int_or_none(video.get('videoFps'))
-            width = int_or_none(video.get('videoWidth'))
-            height = int_or_none(video.get('videoHeight'))
-            thumbnail = video.get('preview')
-
-            rendition = self._download_json(
-                load_balancer_url, video_id, transform_source=strip_jsonp)
-
-            f = {
-                'abr': abr,
-                'vbr': vbr,
-                'fps': fps,
-                'width': width,
-                'height': height,
-            }
-
-            formats = []
-            for format_id, format_url in rendition['redirect'].items():
-                if format_id == 'rtmp':
-                    ff = f.copy()
-                    ff.update({
-                        'url': format_url,
-                        'format_id': format_id,
-                    })
-                    formats.append(ff)
-                elif determine_ext(format_url) == 'f4m':
-                    formats.extend(self._extract_f4m_formats(
-                        format_url, video_id, f4m_id=format_id))
-                elif determine_ext(format_url) == 'm3u8':
-                    formats.extend(self._extract_m3u8_formats(
-                        format_url, video_id, 'mp4', m3u8_id=format_id))
-                else:
-                    continue
-            self._sort_formats(formats)
-
-            title = remove_end(self._og_search_title(webpage), ' - fm4.ORF.at')
             if idx >= 1:
                 # Titles are duplicates, make them unique
-                title += ' (' + str(idx + 1) + ')'
-            description = self._og_search_description(webpage)
-            upload_date = unified_strdate(self._html_search_meta(
-                'dc.date', webpage, 'upload date'))
+                entry['title'] = '%s (%d)' % (entry['title'], idx)
 
-            entries.append({
-                'id': video_id,
-                'title': title,
-                'description': description,
-                'duration': duration,
-                'thumbnail': thumbnail,
-                'upload_date': upload_date,
-                'formats': formats,
-            })
+            entries.append(entry)
 
-        return self.playlist_result(entries)
+        seen_ids = set()
+        for yt_id in re.findall(
+                r'data-id\s*=\s*["\']([\w-]+)[^>]+\bclass\s*=\s*["\']youtube\b',
+                webpage):
+            if yt_id in seen_ids:
+                continue
+            seen_ids.add(yt_id)
+            if YoutubeIE.suitable(yt_id):
+                entries.append(self.url_result(yt_id, ie='Youtube', video_id=yt_id))
+
+        return self.playlist_result(
+            entries, story_id,
+            re.sub(self._TITLE_STRIP_RE, '', self._og_search_title(webpage, default='') or None))
 
 
 class ORFONBase(InfoExtractor):


### PR DESCRIPTION
<details><summary>Boilerplate: own/yt-dlp code, fix/new extractor</summary>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except for code from yt-dlp for which this or the below has been asserted.
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [x] New extractor
- [ ] New feature

---
</details>

### Description of your *pull request* and other information

This PR overhauls and brings up-to-date the ORF extractor module.

TV is now handled by the on.orf.at single-page-app, replacing the former TVthek. The PR back-ports the `ORFONIE` recently added to yt-dlp to replace the broken `ORFTVthekIE`: thx @HobbyistDev, @TuxCoder, @seproDev. Resolves #32798.

Some shows (former extended live events?) may be returned as `multi_video` playlists: yt-dl has no support for automatic concatenation of `multi_video` playlists (yet), but if the same format is selected for all items (segments) it should be possible to concatenate the A-V streams without re-encoding using _ffmpeg_.

Livestream support (not widely tested) has been added. See also https://github.com/yt-dlp/yt-dlp/issues/10052.

Similarly radio and audio clips are now handled through sound.orf.at. The `ORFRadioIE` extractor has been updated and made public to support this as well as residual xx.orf.at/player/... URLs. The previous per-station IEs are removed. Resolves #29394. See also https://github.com/yt-dlp/yt-dlp/issues/5265, https://github.com/yt-dlp/yt-dlp/issues/9581.

`ORFRadioCollectionIE` is added to support playlists in ORF Sound.

The PR also back-ports and re-works `ORFPodcastIE` from yt-dlp: thx @Esokrates.

`ORFFM4StoryIE` is fixed and also now gets any in-page YT media: see https://github.com/yt-dlp/yt-dlp/issues/2477.

Core `YoutubeDL` processing is tweaked to support some not previously encountered playlist structures.   
