### PR TITLE
[jsinterp] Support YT player 590f65a6

### DIFF
--- a/test/test_jsinterp.py
+++ b/test/test_jsinterp.py
@@ -577,9 +577,11 @@ class TestJSInterpreter(unittest.TestCase):
     def test_unary_operators(self):
         jsi = JSInterpreter('function f(){return 2  -  - - 2;}')
         self.assertEqual(jsi.call_function('f'), 0)
-        # fails
-        # jsi = JSInterpreter('function f(){return 2 + - + - - 2;}')
-        # self.assertEqual(jsi.call_function('f'), 0)
+        jsi = JSInterpreter('function f(){return 2 + - + - - 2;}')
+        self.assertEqual(jsi.call_function('f'), 0)
+        # https://github.com/ytdl-org/youtube-dl/issues/32815
+        jsi = JSInterpreter('function f(){return 0  - 7 * - 6;}')
+        self.assertEqual(jsi.call_function('f'), 42)
 
     """ # fails so far
     def test_packed(self):

--- a/test/test_youtube_signature.py
+++ b/test/test_youtube_signature.py
@@ -158,6 +158,10 @@ _NSIG_TESTS = [
         'https://www.youtube.com/s/player/b7910ca8/player_ias.vflset/en_US/base.js',
         '_hXMCwMt9qE310D', 'LoZMgkkofRMCZQ',
     ),
+    (
+        'https://www.youtube.com/s/player/590f65a6/player_ias.vflset/en_US/base.js',
+        '1tm7-g_A9zsI8_Lay_', 'xI4Vem4Put_rOg',
+    ),
 ]
 
 

--- a/youtube_dl/extractor/common.py
+++ b/youtube_dl/extractor/common.py
@@ -3033,7 +3033,6 @@ class InfoExtractor(object):
             transform_source=transform_source, default=None)
 
     def _extract_jwplayer_data(self, webpage, video_id, *args, **kwargs):
-
         # allow passing `transform_source` through to _find_jwplayer_data()
         transform_source = kwargs.pop('transform_source', None)
         kwfind = compat_kwargs({'transform_source': transform_source}) if transform_source else {}

--- a/youtube_dl/extractor/palcomp3.py
+++ b/youtube_dl/extractor/palcomp3.py
@@ -8,7 +8,7 @@ from ..compat import compat_str
 from ..utils import (
     int_or_none,
     str_or_none,
-    try_get,
+    traverse_obj,
 )
 
 
@@ -109,7 +109,7 @@ class PalcoMP3ArtistIE(PalcoMP3BaseIE):
     }
     name'''
 
-    @ classmethod
+    @classmethod
     def suitable(cls, url):
         return False if re.match(PalcoMP3IE._VALID_URL, url) else super(PalcoMP3ArtistIE, cls).suitable(url)
 
@@ -118,7 +118,8 @@ class PalcoMP3ArtistIE(PalcoMP3BaseIE):
         artist = self._call_api(artist_slug, self._ARTIST_FIELDS_TMPL)['artist']
 
         def entries():
-            for music in (try_get(artist, lambda x: x['musics']['nodes'], list) or []):
+            for music in traverse_obj(artist, (
+                    'musics', 'nodes', lambda _, m: m['musicID'])):
                 yield self._parse_music(music)
 
         return self.playlist_result(
@@ -137,7 +138,7 @@ class PalcoMP3VideoIE(PalcoMP3BaseIE):
             'title': 'Maiara e Maraisa - Você Faz Falta Aqui - DVD Ao Vivo Em Campo Grande',
             'description': 'md5:7043342c09a224598e93546e98e49282',
             'upload_date': '20161107',
-            'uploader_id': 'maiaramaraisaoficial',
+            'uploader_id': '@maiaramaraisaoficial',
             'uploader': 'Maiara e Maraisa',
         }
     }]

--- a/youtube_dl/utils.py
+++ b/youtube_dl/utils.py
@@ -2406,7 +2406,7 @@ class ExtractorError(YoutubeDLError):
         """ tb, if given, is the original traceback (so that it can be printed out).
         If expected is set, this is a normal error message and most likely not a bug in youtube-dl.
         """
-
+        self.orig_msg = msg
         if sys.exc_info()[0] in (compat_urllib_error.URLError, socket.timeout, UnavailableVideoError):
             expected = True
         if video_id is not None:


### PR DESCRIPTION
<details><summary>Boilerplate: own/yt-dlp code, fix/improvement</summary>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except for code from yt-dlp for which this or the below has been asserted.
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---
</details>

### Description of the *pull request*

YT player `590f65a6` revealed a [bug in arithmetic evaluation](https://github.com/ytdl-org/youtube-dl/issues/32815#issuecomment-2176720409) in the JSInterpreter module. The PR corrects this and also makes a previously failing proposed test work; resolves #32815.

The bug also revealed some incomplete or inadequate back-porting:
* following yt-dlp, `orig_msg` is now set in `ExtractorError`
* an invalid integer format in an error message was changed to `!r`

To assist in resolving the problem, yt-dlp's interpreter Debugger was back-ported.

There are some further JSInterpreter tweaks and a fix for a new linter rule in an unrelated extractor module.