### PR TITLE
[YandexMusic] Save track version in the title field

### DIFF
--- a/youtube_dl/extractor/palcomp3.py
+++ b/youtube_dl/extractor/palcomp3.py
@@ -8,7 +8,7 @@ from ..compat import compat_str
 from ..utils import (
     int_or_none,
     str_or_none,
-    try_get,
+    traverse_obj,
 )
 
 
@@ -109,7 +109,7 @@ class PalcoMP3ArtistIE(PalcoMP3BaseIE):
     }
     name'''
 
-    @ classmethod
+    @classmethod
     def suitable(cls, url):
         return False if re.match(PalcoMP3IE._VALID_URL, url) else super(PalcoMP3ArtistIE, cls).suitable(url)
 
@@ -118,7 +118,8 @@ class PalcoMP3ArtistIE(PalcoMP3BaseIE):
         artist = self._call_api(artist_slug, self._ARTIST_FIELDS_TMPL)['artist']
 
         def entries():
-            for music in (try_get(artist, lambda x: x['musics']['nodes'], list) or []):
+            for music in traverse_obj(artist, (
+                    'musics', 'nodes', lambda _, m: m['musicID'])):
                 yield self._parse_music(music)
 
         return self.playlist_result(
@@ -137,7 +138,7 @@ class PalcoMP3VideoIE(PalcoMP3BaseIE):
             'title': 'Maiara e Maraisa - Você Faz Falta Aqui - DVD Ao Vivo Em Campo Grande',
             'description': 'md5:7043342c09a224598e93546e98e49282',
             'upload_date': '20161107',
-            'uploader_id': 'maiaramaraisaoficial',
+            'uploader_id': '@maiaramaraisaoficial',
             'uploader': 'Maiara e Maraisa',
         }
     }]

--- a/youtube_dl/extractor/yandexmusic.py
+++ b/youtube_dl/extractor/yandexmusic.py
@@ -106,6 +106,25 @@ class YandexMusicTrackIE(YandexMusicBaseIE):
     }, {
         'url': 'http://music.yandex.com/album/540508/track/4878838',
         'only_matching': True,
+    }, {
+        'url': 'https://music.yandex.ru/album/16302456/track/85430762',
+        'md5': '11b8d50ab03b57738deeaadf661a0a48',
+        'info_dict': {
+            'id': '85430762',
+            'ext': 'mp3',
+            'abr': 128,
+            'title': 'Haddadi Von Engst, Phonic Youth, Super Flu - Til The End (Super Flu Remix)',
+            'filesize': int,
+            'duration': 431.14,
+            'track': 'Til The End (Super Flu Remix)',
+            'album': 'Til The End',
+            'album_artist': 'Haddadi Von Engst, Phonic Youth',
+            'artist': 'Haddadi Von Engst, Phonic Youth, Super Flu',
+            'release_year': 2021,
+            'genre': 'house',
+            'disc_number': 1,
+            'track_number': 2,
+        }
     }]
 
     def _real_extract(self, url):
@@ -116,6 +135,9 @@ class YandexMusicTrackIE(YandexMusicBaseIE):
             'track', tld, url, track_id, 'Downloading track JSON',
             {'track': '%s:%s' % (track_id, album_id)})['track']
         track_title = track['title']
+        track_version = track.get('version')
+        if track_version:
+            track_title = '%s (%s)' % (track_title, track_version)
 
         download_data = self._download_json(
             'https://music.yandex.ru/api/v2.1/handlers/track/%s:%s/web-album_track-track-track-main/download/m' % (track_id, album_id),


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

YandexMusic stores the track title and its version in sepatate fields.
<img width="640" alt="image" src="https://github.com/ytdl-org/youtube-dl/assets/1153031/073b047b-c8fb-46e1-b235-8fa9aefe83a8">
For example, both of this tracks will be downloaded with the same title "Til The End".
I want to concatenate title and version in a single field and save it as "Til The End (Super Flu Remix)"

Also I would like to merge #31159 here.