### PR TITLE
[TubiTv] Extractor overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 *.pyc
 *.pyo
 *.class
@@ -5,6 +6,7 @@
 *.DS_Store
 wine-py2exe/
 py2exe.log
+.pytest_cache/
 *.kate-swp
 build/
 dist/

--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -1328,7 +1328,10 @@ from .trovo import (
 from .trunews import TruNewsIE
 from .trutv import TruTVIE
 from .tube8 import Tube8IE
-from .tubitv import TubiTvIE
+from .tubitv import (
+    TubiTvIE,
+    TubiTvShowIE,
+)
 from .tumblr import TumblrIE
 from .tunein import (
     TuneInClipIE,

--- a/youtube_dl/extractor/tubitv.py
+++ b/youtube_dl/extractor/tubitv.py
@@ -1,23 +1,61 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import re
-
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    get_element_by_id,
     int_or_none,
+    js_to_json,
+    merge_dicts,
+    parse_age_limit,
     sanitized_Request,
+    strip_or_none,
+    T,
+    traverse_obj,
+    url_or_none,
     urlencode_postdata,
 )
 
 
 class TubiTvIE(InfoExtractor):
-    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/(?:video|movies|tv-shows)/(?P<id>[0-9]+)'
+    IE_NAME = 'tubitv'
+    _VALID_URL = r'https?://(?:www\.)?tubitv\.com/(?P<type>video|movies|tv-shows)/(?P<id>\d+)'
     _LOGIN_URL = 'http://tubitv.com/login'
     _NETRC_MACHINE = 'tubitv'
-    _GEO_COUNTRIES = ['US']
     _TESTS = [{
+        'url': 'https://tubitv.com/movies/100004539/the-39-steps',
+        'info_dict': {
+            'id': '100004539',
+            'ext': 'mp4',
+            'title': 'The 39 Steps',
+            'description': 'md5:bb2f2dd337f0dc58c06cb509943f54c8',
+            'uploader_id': 'abc2558d54505d4f0f32be94f2e7108c',
+            'release_year': 1935,
+            'thumbnail': r're:^https?://.+\.(jpe?g|png)$',
+            'duration': 5187,
+        },
+        'params': {'skip_download': 'm3u8'},
+        'skip': 'This content is currently unavailable',
+    }, {
+        'url': 'https://tubitv.com/tv-shows/554628/s01-e01-rise-of-the-snakes',
+        'info_dict': {
+            'id': '554628',
+            'ext': 'mp4',
+            'title': 'S01:E01 - Rise of the Snakes',
+            'description': 'md5:ba136f586de53af0372811e783a3f57d',
+            'episode': 'Rise of the Snakes',
+            'episode_number': 1,
+            'season': 'Season 1',
+            'season_number': 1,
+            'uploader_id': '2a9273e728c510d22aa5c57d0646810b',
+            'release_year': 2011,
+            'thumbnail': r're:^https?://.+\.(jpe?g|png)$',
+            'duration': 1376,
+        },
+        'params': {'skip_download': 'm3u8'},
+        'skip': 'This content is currently unavailable',
+    }, {
         'url': 'http://tubitv.com/video/283829/the_comedian_at_the_friday',
         'md5': '43ac06be9326f41912dc64ccf7a80320',
         'info_dict': {
@@ -27,6 +65,7 @@ class TubiTvIE(InfoExtractor):
             'description': 'A stand up comedian is forced to look at the decisions in his life while on a one week trip to the west coast.',
             'uploader_id': 'bc168bee0d18dd1cb3b86c68706ab434',
         },
+        'skip': 'Content Unavailable',
     }, {
         'url': 'http://tubitv.com/tv-shows/321886/s01_e01_on_nom_stories',
         'only_matching': True,
@@ -34,24 +73,42 @@ class TubiTvIE(InfoExtractor):
         'url': 'http://tubitv.com/movies/383676/tracker',
         'only_matching': True,
     }, {
-        'url': 'https://tubitv.com/movies/560057/penitentiary?start=true',
+        'url': 'https://tubitv.com/tv-shows/200141623/s01-e01-episode-1',
         'info_dict': {
-            'id': '560057',
+            'id': '200141623',
             'ext': 'mp4',
-            'title': 'Penitentiary',
-            'description': 'md5:8d2fc793a93cc1575ff426fdcb8dd3f9',
-            'uploader_id': 'd8fed30d4f24fcb22ec294421b9defc2',
-            'release_year': 1979,
+            'title': 'Shameless S01:E01 - Episode 1',
+            'description': 'Having her handbag stolen proves to be a blessing in disguise for Fiona when handsome stranger Steve comes to her rescue.',
+            'timestamp': 1725148800,
+            'upload_date': '20240901',
+            'uploader': 'all3-media',
+            'uploader_id': '9b8e3a8d789b1c843f4b680c025a1853',
+            'release_year': 2004,
+            'episode': 'Episode 1',
+            'episode_number': 1,
+            'season': 'Season 1',
+            'season_number': 1,
+            'series': 'Shameless',
+            'cast': list,
+            'age_limit': 17,
         },
         'params': {
-            'skip_download': True,
+            'format': 'best/bestvideo',
+            'skip_download': 'm3u8'
         },
     }]
+
+    # DRM formats are included only to raise appropriate error
+    _UNPLAYABLE_FORMATS = ('hlsv6_widevine', 'hlsv6_widevine_nonclearlead', 'hlsv6_playready_psshv0',
+                           'hlsv6_fairplay', 'dash_widevine', 'dash_widevine_nonclearlead')
 
     def _login(self):
         username, password = self._get_login_info()
         if username is None:
             return
+        self._perform_login(username, password)
+
+    def _perform_login(self, username, password):
         self.report_login()
         form_data = {
             'username': username,
@@ -62,7 +119,7 @@ class TubiTvIE(InfoExtractor):
         request.add_header('Content-Type', 'application/x-www-form-urlencoded')
         login_page = self._download_webpage(
             request, None, False, 'Wrong login info')
-        if not re.search(r'id="tubi-logout"', login_page):
+        if get_element_by_id('tubi-logout', login_page) is None:
             raise ExtractorError(
                 'Login failed (invalid username/password)', expected=True)
 
@@ -70,41 +127,69 @@ class TubiTvIE(InfoExtractor):
         self._login()
 
     def _real_extract(self, url):
-        video_id = self._match_id(url)
-        video_data = self._download_json(
-            'http://tubitv.com/oz/videos/%s/content' % video_id, video_id)
-        title = video_data['title']
+        video_id, video_type = self._match_valid_url(url).group('id', 'type')
+        webpage = self._download_webpage('https://tubitv.com/{0}/{1}/'.format(video_type, video_id), video_id)
+        data = self._search_json(
+            r'window\.__data\s*=', webpage, 'data', video_id,
+            transform_source=js_to_json)['video']['byId']
+        video_data = data[video_id]
+        info = self._search_json_ld(webpage, video_id, expected_type='VideoObject', default={})
+        title = strip_or_none(info.get('title'))
+        info['title'] = title or strip_or_none(video_data['title'])
 
-        formats = self._extract_m3u8_formats(
-            self._proto_relative_url(video_data['url']),
-            video_id, 'mp4', 'm3u8_native')
+        formats = []
+        drm_formats = 0
+
+        for resource in traverse_obj(video_data, ('video_resources', lambda _, v: v['type'] and v['manifest']['url'])):
+            manifest_url = url_or_none(resource['manifest']['url'])
+            if not manifest_url:
+                continue
+            resource_type = resource['type']
+            if resource_type == 'dash':
+                formats.extend(self._extract_mpd_formats(manifest_url, video_id, mpd_id=resource_type, fatal=False))
+            elif resource_type in ('hlsv3', 'hlsv6'):
+                formats.extend(self._extract_m3u8_formats(manifest_url, video_id, 'mp4', m3u8_id=resource_type, fatal=False))
+            elif resource_type in self._UNPLAYABLE_FORMATS:
+                drm_formats += 1
+            else:
+                self.report_warning('Skipping unknown resource type "{0}"'.format(resource_type))
+
+        if not formats and drm_formats > 0:
+            self.report_drm(video_id)
+        elif not formats and not video_data.get('policy_match'):  # policy_match is False if content was removed
+            raise ExtractorError('This content is currently unavailable', expected=True)
         self._sort_formats(formats)
 
-        thumbnails = []
-        for thumbnail_url in video_data.get('thumbnails', []):
-            if not thumbnail_url:
-                continue
-            thumbnails.append({
-                'url': self._proto_relative_url(thumbnail_url),
-            })
-
         subtitles = {}
-        for sub in video_data.get('subtitles', []):
-            sub_url = sub.get('url')
+        for sub in traverse_obj(video_data, ('subtitles', lambda _, v: v['url'])):
+            sub_url = self._proto_relative_url(sub['url'])
             if not sub_url:
                 continue
             subtitles.setdefault(sub.get('lang', 'English'), []).append({
-                'url': self._proto_relative_url(sub_url),
+                'url': sub_url,
             })
 
-        return {
+        season_number, episode_number, episode_title = self._search_regex(
+            r'\bS(\d+):E(\d+) - (.+)', info['title'], 'episode info', fatal=False, group=(1, 2, 3), default=(None, None, None))
+
+        return merge_dicts({
             'id': video_id,
-            'title': title,
             'formats': formats,
             'subtitles': subtitles,
-            'thumbnails': thumbnails,
-            'description': video_data.get('description'),
-            'duration': int_or_none(video_data.get('duration')),
-            'uploader_id': video_data.get('publisher_id'),
-            'release_year': int_or_none(video_data.get('year')),
-        }
+            'season_number': int_or_none(season_number),
+            'episode_number': int_or_none(episode_number),
+            'episode': episode_title
+        }, traverse_obj(video_data, {
+            'description': ('description', T(strip_or_none)),
+            'duration': ('duration', T(int_or_none)),
+            'uploader': ('import_id', T(strip_or_none)),
+            'uploader_id': ('publisher_id', T(strip_or_none)),
+            'release_year': ('year', T(int_or_none)),
+            'thumbnails': ('thumbnails', Ellipsis, T(self._proto_relative_url), {'url': T(url_or_none)}),
+            'cast': ('actors', Ellipsis, T(strip_or_none)),
+            'categories': ('tags', Ellipsis, T(strip_or_none)),
+            'age_limit': ('ratings', 0, 'value', T(parse_age_limit)),
+        }), traverse_obj(data, (lambda _, v: v['type'] == 's', {
+            'series': ('title', T(strip_or_none)),
+            # 'series_id': ('id', T(compat_str)),
+        }), get_all=False), info)


### PR DESCRIPTION
<details><summary>Boilerplate: own/yt-dlp code, bug fix/improvement</summary>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except for code from yt-dlp for which this or the below has already been asserted.
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---
</details>

### Description of your *pull request* and other information

This PR updates the extractor for tubitv.com and adds a series/season  extractor.

The PR includes these features back-ported from _yt-dlp_:
* update `TubiTvIE`: thx @shirt-dev, @chilinux, @bashonly
* add `TubiTvShowIE`: thx @Ashish0804, @sqrtNOT, @bashonly

Breaking change: `TubiTvIE` no longer recognises the URL scheme `tubitv:{id}`; instead, use `https://tubitv.com/tv-shows/{id}/`.

Rationale for modifying `TubiTvShowIE` extraction tactic is [here](https://github.com/yt-dlp/yt-dlp/issues/11170#issuecomment-2399918777).  

