### PR TITLE
[YouTube, misc] Back-ports from yt-dlp for broken YT player `2b83d2e0` and later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,12 @@ jobs:
         ytdl-test-set: ${{ fromJSON(needs.select.outputs.test-set) }}
         run-tests-ext: [sh]
         include:
-        - os: windows-2019
+        - os: windows-2022
           python-version: 3.4
           python-impl: cpython
           ytdl-test-set: ${{ contains(needs.select.outputs.test-set, 'core') && 'core' || 'nocore' }}
           run-tests-ext: bat
-        - os: windows-2019
+        - os: windows-2022
           python-version: 3.4
           python-impl: cpython
           ytdl-test-set: ${{ contains(needs.select.outputs.test-set, 'download') && 'download'  || 'nodownload' }}

--- a/youtube_dl/__init__.py
+++ b/youtube_dl/__init__.py
@@ -409,6 +409,8 @@ def _real_main(argv=None):
         'include_ads': opts.include_ads,
         'default_search': opts.default_search,
         'youtube_include_dash_manifest': opts.youtube_include_dash_manifest,
+        'youtube_player_js_version': opts.youtube_player_js_version,
+        'youtube_player_js_variant': opts.youtube_player_js_variant,
         'encoding': opts.encoding,
         'extract_flat': opts.extract_flat,
         'mark_watched': opts.mark_watched,

--- a/youtube_dl/downloader/common.py
+++ b/youtube_dl/downloader/common.py
@@ -11,6 +11,7 @@ from ..utils import (
     decodeArgument,
     encodeFilename,
     error_to_compat_str,
+    float_or_none,
     format_bytes,
     shell_quote,
     timeconvert,
@@ -367,14 +368,27 @@ class FileDownloader(object):
                 })
                 return True
 
-        min_sleep_interval = self.params.get('sleep_interval')
-        if min_sleep_interval:
-            max_sleep_interval = self.params.get('max_sleep_interval', min_sleep_interval)
-            sleep_interval = random.uniform(min_sleep_interval, max_sleep_interval)
+        min_sleep_interval, max_sleep_interval = (
+            float_or_none(self.params.get(interval), default=0)
+            for interval in ('sleep_interval', 'max_sleep_interval'))
+
+        sleep_note = ''
+        available_at = info_dict.get('available_at')
+        if available_at:
+            forced_sleep_interval = available_at - int(time.time())
+            if forced_sleep_interval > min_sleep_interval:
+                sleep_note = 'as required by the site'
+                min_sleep_interval = forced_sleep_interval
+            if forced_sleep_interval > max_sleep_interval:
+                max_sleep_interval = forced_sleep_interval
+
+        sleep_interval = random.uniform(
+            min_sleep_interval, max_sleep_interval or min_sleep_interval)
+
+        if sleep_interval > 0:
             self.to_screen(
-                '[download] Sleeping %s seconds...' % (
-                    int(sleep_interval) if sleep_interval.is_integer()
-                    else '%.2f' % sleep_interval))
+                '[download] Sleeping %.2f seconds %s...' % (
+                    sleep_interval, sleep_note))
             time.sleep(sleep_interval)
 
         return self.real_download(filename, info_dict)

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -711,7 +711,7 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         r'/(?P<id>[a-zA-Z0-9_-]{8,})/player(?:_ias(?:_tce)?\.vflset(?:/[a-zA-Z]{2,3}_[a-zA-Z]{2,3})?|-plasma-ias-(?:phone|tablet)-[a-z]{2}_[A-Z]{2}\.vflset)/base\.js$',
         r'\b(?P<id>vfl[a-zA-Z0-9_-]{6,})\b.*?\.js$',
     )
-    _SUBTITLE_FORMATS = ('json3', 'srv1', 'srv2', 'srv3', 'ttml', 'vtt')
+    _SUBTITLE_FORMATS = ('json3', 'srv1', 'srv2', 'srv3', 'ttml', 'srt', 'vtt')
 
     _GEO_BYPASS = False
 

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2540,6 +2540,10 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
             if f.get('source_preference') is None:
                 f['source_preference'] = -1
 
+            # Deprioritize since its pre-merged m3u8 formats may have lower quality audio streams
+            if client_name == 'web_safari' and proto == 'hls' and not is_live:
+                f['source_preference'] -= 1
+
             if itag in ('616', '235'):
                 f['format_note'] = join_nonempty(f.get('format_note'), 'Premium', delim=' ')
                 f['source_preference'] += 100

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -109,7 +109,7 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
             'INNERTUBE_CONTEXT': {
                 'client': {
                     'clientName': 'MWEB',
-                    'clientVersion': '2.20250311.03.00',
+                    'clientVersion': '2.2.20250925.01.00',
                     # mweb previously did not require PO Token with this UA
                     'userAgent': 'Mozilla/5.0 (iPad; CPU OS 16_7_10 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1,gzip(gfe)',
                 },
@@ -123,32 +123,35 @@ class YoutubeBaseInfoExtractor(InfoExtractor):
                 'client': {
                     'clientName': 'TVHTML5',
                     'clientVersion': '7.20250312.16.00',
-                    'userAgent': 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version',
+                    # See: https://github.com/youtube/cobalt/blob/main/cobalt/browser/user_agent/user_agent_platform_info.cc#L506
+                    'userAgent': 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/25.lts.30.1034943-gold (unlike Gecko), Unknown_TV_Unknown_0/Unknown (Unknown, Unknown)',
                 },
             },
             'INNERTUBE_CONTEXT_CLIENT_NAME': 7,
             'SUPPORTS_COOKIES': True,
         },
-        'tv_simply': {
-            'INNERTUBE_CONTEXT': {
-                'client': {
-                    'clientName': 'TVHTML5_SIMPLY',
-                    'clientVersion': '1.0',
-                },
-            },
-            'INNERTUBE_CONTEXT_CLIENT_NAME': 75,
-        },
+
         'web': {
             'INNERTUBE_CONTEXT': {
                 'client': {
                     'clientName': 'WEB',
-                    'clientVersion': '2.20250312.04.00',
+                    'clientVersion': '2.20250925.01.00',
+                    'userAgent': 'Mozilla/5.0',
                 },
             },
             'INNERTUBE_CONTEXT_CLIENT_NAME': 1,
             'REQUIRE_PO_TOKEN': True,
             'SUPPORTS_COOKIES': True,
-            'PLAYER_PARAMS': '8AEB',
+        },
+        # Safari UA returns pre-merged video+audio 144p/240p/360p/720p/1080p HLS formats
+        'web_safari': {
+            'INNERTUBE_CONTEXT': {
+                'client': {
+                    'clientName': 'WEB',
+                    'clientVersion': '2.20250925.01.00',
+                    'userAgent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)',
+                },
+            },
         },
     }
 

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2668,7 +2668,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                     self.raise_geo_restricted(
                         subreason, countries)
                 reason += '\n' + subreason
+
             if reason:
+                if 'sign in' in reason.lower():
+                    self.raise_login_required(remove_end(reason, 'This helps protect our community. Learn more'))
+                elif traverse_obj(playability_status, ('errorScreen', 'playerCaptchaViewModel', T(dict))):
+                    reason += '. YouTube is requiring a captcha challenge before playback'
                 raise ExtractorError(reason, expected=True)
 
         self._sort_formats(formats)
@@ -2771,6 +2776,9 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
                 for fmt in self._SUBTITLE_FORMATS:
                     query.update({
                         'fmt': fmt,
+                        # xosf=1 causes undesirable text position data for vtt, json3 & srv* subtitles
+                        # See: https://github.com/yt-dlp/yt-dlp/issues/13654
+                        'xosf': []
                     })
                     lang_subs.append({
                         'ext': fmt,

--- a/youtube_dl/extractor/youtube.py
+++ b/youtube_dl/extractor/youtube.py
@@ -2183,8 +2183,12 @@ class YoutubeIE(YoutubeBaseInfoExtractor):
         video_id = self._match_id(url)
         base_url = self.http_scheme() + '//www.youtube.com/'
         webpage_url = base_url + 'watch?v=' + video_id
+        ua = traverse_obj(self._INNERTUBE_CLIENTS, (
+            'web', 'INNERTUBE_CONTEXT', 'client', 'userAgent'))
+        headers = {'User-Agent': ua} if ua else None
         webpage = self._download_webpage(
-            webpage_url + '&bpctr=9999999999&has_verified=1', video_id, fatal=False)
+            webpage_url + '&bpctr=9999999999&has_verified=1', video_id,
+            headers=headers, fatal=False)
 
         player_response = None
         player_url = None

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -405,6 +405,10 @@ def parseOpts(overrideArguments=None):
         action='store_true', dest='listformats',
         help='List all available formats of requested videos')
     video_format.add_option(
+        '--no-list-formats',
+        action='store_false', dest='listformats',
+        help='Do not list available formats of requested videos (default)')
+    video_format.add_option(
         '--youtube-include-dash-manifest',
         action='store_true', dest='youtube_include_dash_manifest', default=True,
         help=optparse.SUPPRESS_HELP)

--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -413,6 +413,17 @@ def parseOpts(overrideArguments=None):
         action='store_false', dest='youtube_include_dash_manifest',
         help='Do not download the DASH manifests and related data on YouTube videos')
     video_format.add_option(
+        '--youtube-player-js-variant',
+        action='store', dest='youtube_player_js_variant',
+        help='For YouTube, the player javascript variant to use for n/sig deciphering; `actual` to follow the site; default `%default`.',
+        choices=('actual', 'main', 'tcc', 'tce', 'es5', 'es6', 'tv', 'tv_es6', 'phone', 'tablet'),
+        default='main', metavar='VARIANT')
+    video_format.add_option(
+        '--youtube-player-js-version',
+        action='store', dest='youtube_player_js_version',
+        help='For YouTube, the player javascript version to use for n/sig deciphering, specified as `signature_timestamp@hash`, or `actual` to follow the site; default `%default`',
+        default='20348@0004de42', metavar='STS@HASH')
+    video_format.add_option(
         '--merge-output-format',
         action='store', dest='merge_output_format', metavar='FORMAT', default=None,
         help=(


### PR DESCRIPTION
## Please follow the guide below
<details>
<summary>Boilerplate: yt-dlp+own code, bug fix+new features</summary>
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Read [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site)
- [x] Read [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) and adjusted the code to meet them
- [x] Covered the code with tests (note that PRs without tests will be REJECTED)
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/), except for:
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence): code from yt-dlp under Unlicense

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New extractor
- [x] New feature

</details>

---

### Description of your *pull request* and other information

This PR primarily addresses the problem of #33186. It includes a version of the interim fix from yt-dlp/yt-dlp#14398: thx @seproDev.

The PR also includes these changes:
* updates relevant YT player data: thx yt-dlp devs severally
* some code YT extractor code clean-ups prompted by linting
* define a WEB user agent and force its use for video page downloads: fixes #33142
* add downloader support for the `available_at` (timestamp) format key and use it to implement the now required preroll waiting period for YT, as in yt-dlp/yt-dlp#14081: thx @bashonly
* fix YT subtitles extraction per yt-dlp/yt-dlp#13659: thx @bashonly
* extract srt subtitles for YT from yt-dlp/yt-dlp#13411: thx @gamer191
* extract fallback title and description from YT initial data, per yt-dlp/yt-dlp#14078: thx @bashonly
* support extracting LOCKUP_CONTENT_TYPE_VIDEO from YT subscriptions feed, per yt-dlp/yt-dlp#13665: thx @bashonly
* support the missing option --no-list-formats, as requested in yt-dlp/yt-dlp#14378
* and now we have to run the Windows stuff in Windows Server 2022, which apparently still supports our Py3.4 build.


