### PR TITLE
[infomaniak] Add VOD2 embed extractor

### DIFF
--- a/youtube_dl/extractor/extractors.py
+++ b/youtube_dl/extractor/extractors.py
@@ -526,6 +526,7 @@ from .imgur import (
 )
 from .ina import InaIE
 from .inc import IncIE
+from .infomaniak import InfomaniakVod2IE
 from .indavideo import IndavideoEmbedIE
 from .infoq import InfoQIE
 from .instagram import (

--- a/youtube_dl/extractor/infomaniak.py
+++ b/youtube_dl/extractor/infomaniak.py
@@ -78,7 +78,13 @@ class InfomaniakVod2IE(InfoExtractor):
                 'display_id': share_id,
             }, entries[0], rev=True)
 
+        missing_id = sum(1 for e in entries if not e.get('id'))
         entries = [e for e in entries if e.get('id')]
+        if missing_id:
+            self.report_warning(
+                'Share contains multiple media entries, but %d item(s) are missing an id and will be skipped. '
+                'If this looks incorrect, please report the URL.' % missing_id,
+                share_id, only_once=True)
         if not entries:
             # Keep the error message actionable for site support requests
             raise ExtractorError('Unable to find any media in share JSON', expected=True)

--- a/youtube_dl/extractor/infomaniak.py
+++ b/youtube_dl/extractor/infomaniak.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from .common import InfoExtractor
+from ..utils import (
+    ExtractorError,
+    parse_duration,
+)
+
+
+class InfomaniakVod2IE(InfoExtractor):
+    IE_NAME = 'infomaniak:vod2'
+    _VALID_URL = r'https?://player\.vod2\.infomaniak\.com/embed/(?P<id>[0-9a-z]+)'
+    _TEST = {
+        'url': 'https://player.vod2.infomaniak.com/embed/1jhvl2uqg6ywp',
+        'info_dict': {
+            'id': '1jhvl2uqg6xis',
+            'display_id': '1jhvl2uqg6ywp',
+            'ext': 'mp4',
+            'title': 'Conférence à Dyo, octobre 2022',
+            'thumbnail': r're:^https?://.*\.(?:jpe?g|png)$',
+        },
+        'params': {
+            'skip_download': True,
+        },
+    }
+
+    def _real_extract(self, url):
+        share_id = self._match_id(url)
+        share = self._download_json(
+            'https://api.infomaniak.com/2/vod/res/shares/%s.json' % share_id,
+            share_id)
+        data = (share or {}).get('data') or {}
+        media = data.get('media') or []
+
+        entries = []
+        for m in media:
+            if not isinstance(m, dict):
+                continue
+            media_id = m.get('id') or share_id
+            title = m.get('title') or share_id
+            duration = parse_duration(m.get('duration'))
+            thumbnails = m.get('thumbnails') or {}
+            thumbnail = thumbnails.get('poster') or thumbnails.get('image')
+
+            source = m.get('source') or {}
+            formats = []
+
+            hls_url = source.get('hls')
+            if hls_url:
+                formats.extend(self._extract_m3u8_formats(
+                    hls_url, media_id, 'mp4', entry_protocol='m3u8_native',
+                    m3u8_id='hls', fatal=False))
+
+            mpd_url = source.get('dash')
+            if mpd_url:
+                formats.extend(self._extract_mpd_formats(
+                    mpd_url, media_id, mpd_id='dash', fatal=False))
+
+            best_url = source.get('best')
+            if best_url:
+                formats.append({
+                    'url': best_url,
+                    'format_id': 'http',
+                })
+
+            self._sort_formats(formats)
+
+            entries.append({
+                'id': media_id,
+                'display_id': share_id,
+                'title': title,
+                'duration': duration,
+                'thumbnail': thumbnail,
+                'formats': formats,
+                'webpage_url': url,
+            })
+
+        if not entries:
+            # Keep the error message actionable for site support requests
+            raise ExtractorError('Unable to find any media in share JSON', expected=True)
+
+        if len(entries) == 1:
+            return entries[0]
+
+        return self.playlist_result(entries, playlist_id=share_id)
+
+

--- a/youtube_dl/extractor/infomaniak.py
+++ b/youtube_dl/extractor/infomaniak.py
@@ -1,10 +1,17 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+from ..compat import compat_str as str
+
 from .common import InfoExtractor
 from ..utils import (
     ExtractorError,
+    merge_dicts,
     parse_duration,
+    str_or_none,
+    T,
+    traverse_obj,
+    url_or_none,
 )
 
 
@@ -13,15 +20,16 @@ class InfomaniakVod2IE(InfoExtractor):
     _VALID_URL = r'https?://player\.vod2\.infomaniak\.com/embed/(?P<id>[0-9a-z]+)'
     _TEST = {
         'url': 'https://player.vod2.infomaniak.com/embed/1jhvl2uqg6ywp',
+        'md5': '08c3a89906b70a614fa0fdb057e8a22e',
         'info_dict': {
             'id': '1jhvl2uqg6xis',
             'display_id': '1jhvl2uqg6ywp',
             'ext': 'mp4',
             'title': 'Conférence à Dyo, octobre 2022',
-            'thumbnail': r're:^https?://.*\.(?:jpe?g|png)$',
+            'thumbnail': r're:https?://.+\.(?:jpe?g|png)$',
         },
         'params': {
-            'skip_download': True,
+            'format': 'http',
         },
     }
 
@@ -30,20 +38,11 @@ class InfomaniakVod2IE(InfoExtractor):
         share = self._download_json(
             'https://api.infomaniak.com/2/vod/res/shares/%s.json' % share_id,
             share_id)
-        data = (share or {}).get('data') or {}
-        media = data.get('media') or []
-
         entries = []
-        for m in media:
-            if not isinstance(m, dict):
-                continue
-            media_id = m.get('id') or share_id
-            title = m.get('title') or share_id
-            duration = parse_duration(m.get('duration'))
-            thumbnails = m.get('thumbnails') or {}
-            thumbnail = thumbnails.get('poster') or thumbnails.get('image')
-
-            source = m.get('source') or {}
+        for media in traverse_obj(share, (
+                'data', 'media', lambda _, v: v.get('source').get)):
+            media_id = media.get('id') or share_id
+            source = media['source']
             formats = []
 
             hls_url = source.get('hls')
@@ -62,26 +61,32 @@ class InfomaniakVod2IE(InfoExtractor):
                 formats.append({
                     'url': best_url,
                     'format_id': 'http',
+                    'preference': 10,
                 })
 
             self._sort_formats(formats)
 
-            entries.append({
-                'id': media_id,
-                'display_id': share_id,
-                'title': title,
-                'duration': duration,
-                'thumbnail': thumbnail,
-                'formats': formats,
-                'webpage_url': url,
-            })
+            entries.append(merge_dicts(
+                traverse_obj(media, {
+                    'id': ('id', T(str_or_none)),
+                    'title': ('title', T(str)),
+                    'duration': ('duration', T(parse_duration)),
+                    'thumbnail': ('thumbnails', ('poster', 'image'), T(url_or_none), any),
+                }), {
+                    'display_id': share_id,
+                    'formats': formats,
+                }))
 
+        if len(entries) == 1:
+            return merge_dicts({
+                'id': share_id,
+                'display_id': share_id,
+            }, entries[0], rev=True)
+
+        entries = [e for e in entries if e.get('id')]
         if not entries:
             # Keep the error message actionable for site support requests
             raise ExtractorError('Unable to find any media in share JSON', expected=True)
-
-        if len(entries) == 1:
-            return entries[0]
 
         return self.playlist_result(entries, playlist_id=share_id)
 

--- a/youtube_dl/extractor/infomaniak.py
+++ b/youtube_dl/extractor/infomaniak.py
@@ -1,9 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from ..compat import compat_str as str
-
 from .common import InfoExtractor
+from ..compat import compat_str as str
 from ..utils import (
     ExtractorError,
     merge_dicts,
@@ -27,9 +26,6 @@ class InfomaniakVod2IE(InfoExtractor):
             'ext': 'mp4',
             'title': 'Conférence à Dyo, octobre 2022',
             'thumbnail': r're:https?://.+\.(?:jpe?g|png)$',
-        },
-        'params': {
-            'format': 'http',
         },
     }
 
@@ -73,7 +69,6 @@ class InfomaniakVod2IE(InfoExtractor):
                     'duration': ('duration', T(parse_duration)),
                     'thumbnail': ('thumbnails', ('poster', 'image'), T(url_or_none), any),
                 }), {
-                    'display_id': share_id,
                     'formats': formats,
                 }))
 


### PR DESCRIPTION
Fixes #31329

Add support for Infomaniak VOD2 embed URLs (player.vod2.infomaniak.com/embed/<id>) by introducing a new InfomaniakVod2IE extractor that reads the public share JSON and extracts HLS + direct MP4 sources. Fixes #31329 (example: https://player.vod2.infomaniak.com/embed/1jhvl2uqg6ywp).


Tests
python -m youtube_dl -v --no-check-certificate --skip-download https://player.vod2.infomaniak.com/embed/1jhvl2uqg6ywp
python -m youtube_dl --no-check-certificate --skip-download -F https://player.vod2.infomaniak.com/embed/1jhvl2uqg6ywp
export SSL_CERT_FILE="$(python -c 'import certifi; print(certifi.where())')"
python test/test_download.py TestDownload.test_InfomaniakVod2

Supersedes, closes #31981.